### PR TITLE
Don't fail fast

### DIFF
--- a/web-bundle/pom.xml
+++ b/web-bundle/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>com.graphhopper</groupId>
             <artifactId>graphhopper-matrix</artifactId>
-            <version>0.13.0-tardur3</version>
+            <version>0.13.0-tardur5</version>
         </dependency>
 
         <!-- required for JDK9 -->


### PR DESCRIPTION
With this version, add a query parameter or JSON request field, respectively, to the matrix API call:

`fail_fast=false`

In this case, O/D pairs for which no route is found will not let the entire matrix request fail. Rather, a matrix will be returned, and error messages for all failed cells will be appended, in the same format as they would be in the error message before (or without this parameter).

This does not yet work for points that couldn't be snapped to the graph. Those will still fail the request. Working on this.