### PR TITLE
Lowercase stable ids

### DIFF
--- a/web-bundle/src/main/java/com/graphhopper/swl/CustomCarFlagEncoder.java
+++ b/web-bundle/src/main/java/com/graphhopper/swl/CustomCarFlagEncoder.java
@@ -49,7 +49,7 @@ public class CustomCarFlagEncoder extends CarFlagEncoder {
         for (int i=0; i<16; i++) {
             stableId[i] = (byte) edge.get(stableIdByte[i]);
         }
-        return DatatypeConverter.printHexBinary(stableId);
+        return DatatypeConverter.printHexBinary(stableId).toLowerCase();
     }
 
     final void setStableId(EdgeIteratorState edge, String stableId) {


### PR DESCRIPTION
our convention is to use lowercase hex strings for stable ids