### PR TITLE
Add max nodes config param

### DIFF
--- a/default_city.yml
+++ b/default_city.yml
@@ -1,6 +1,7 @@
 graphhopper:
   graph.location: transit_data/graphhopper
   routing.ch.disabling_allowed: true
+  routing.max_visited_nodes: 1500000
   r5.link_speed_file: transit_data/graphhopper/r5_predicted_tt.csv
 
 server:


### PR DESCRIPTION
Seeing timeouts on 2+ min queries in Dallas; copied this value from the hosted graphhopper.com version and it seems to help