### PR TITLE
Add getter for count of unique turn cost entries in GH storage

### DIFF
--- a/core/src/main/java/com/graphhopper/storage/TurnCostExtension.java
+++ b/core/src/main/java/com/graphhopper/storage/TurnCostExtension.java
@@ -197,6 +197,13 @@ public class TurnCostExtension implements GraphExtension {
         return nextCostFlags(edgeFrom, nodeVia, edgeTo);
     }
 
+    /**
+     * @return the count of unique turn cost entries currently stored.
+     */
+    public int getTurnCostsCount() {
+        return turnCostsCount;
+    }
+
     public boolean isUTurn(int edgeFrom, int edgeTo) {
         return edgeFrom == edgeTo;
     }


### PR DESCRIPTION
@michaz does this seem reasonable to you? It would be great if I could fetch this value in the tests I'm writing to check that exporting turn restrictions works properly.