### PR TITLE
Stable edge ids also for virtual edges

### DIFF
--- a/web-bundle/src/main/java/com/graphhopper/http/GraphHopperBundle.java
+++ b/web-bundle/src/main/java/com/graphhopper/http/GraphHopperBundle.java
@@ -18,14 +18,7 @@
 
 package com.graphhopper.http;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.BeanDescription;
 import com.fasterxml.jackson.databind.MapperFeature;
-import com.fasterxml.jackson.databind.SerializationConfig;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.module.SimpleModule;
-import com.fasterxml.jackson.databind.ser.BeanPropertyWriter;
-import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
 import com.fasterxml.jackson.databind.util.StdDateFormat;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.graphhopper.GraphHopper;
@@ -59,8 +52,6 @@ import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
-import java.util.List;
-import java.util.stream.Collectors;
 
 public class GraphHopperBundle implements ConfiguredBundle<GraphHopperBundleConfiguration> {
 
@@ -223,23 +214,6 @@ public class GraphHopperBundle implements ConfiguredBundle<GraphHopperBundleConf
         bootstrap.getObjectMapper().setDateFormat(new StdDateFormat());
         // See https://github.com/dropwizard/dropwizard/issues/1558
         bootstrap.getObjectMapper().enable(MapperFeature.ALLOW_EXPLICIT_PROPERTY_RENAMING);
-        // Because VirtualEdgeIteratorState has getters which throw Exceptions.
-        // http://stackoverflow.com/questions/35359430/how-to-make-jackson-ignore-properties-if-the-getters-throw-exceptions
-        bootstrap.getObjectMapper().registerModule(new SimpleModule().setSerializerModifier(new BeanSerializerModifier() {
-            @Override
-            public List<BeanPropertyWriter> changeProperties(SerializationConfig config, BeanDescription beanDesc, List<BeanPropertyWriter> beanProperties) {
-                return beanProperties.stream().map(bpw -> new BeanPropertyWriter(bpw) {
-                    @Override
-                    public void serializeAsField(Object bean, JsonGenerator gen, SerializerProvider prov) throws Exception {
-                        try {
-                            super.serializeAsField(bean, gen, prov);
-                        } catch (Exception e) {
-                            // Ignoring expected exception, see above.
-                        }
-                    }
-                }).collect(Collectors.toList());
-            }
-        }));
     }
 
     @Override

--- a/web-bundle/src/main/java/com/graphhopper/swl/PathDetailsBuilderFactoryWithEdgeKey.java
+++ b/web-bundle/src/main/java/com/graphhopper/swl/PathDetailsBuilderFactoryWithEdgeKey.java
@@ -70,7 +70,7 @@ public class PathDetailsBuilderFactoryWithEdgeKey extends PathDetailsBuilderFact
         }
 
         if (requestedPathDetails.contains("r5_edge_id")) {
-            builders.add(new R5EdgeIdPathDetailsBuilder(evl));
+            builders.add(new StableEdgeIdPathDetailsBuilder(evl));
         }
 
         for (Map.Entry entry : Arrays.asList(new MapEntry<>(RoadClass.KEY, RoadClass.class),

--- a/web-bundle/src/main/java/com/graphhopper/swl/R5EdgeIdPathDetailsBuilder.java
+++ b/web-bundle/src/main/java/com/graphhopper/swl/R5EdgeIdPathDetailsBuilder.java
@@ -19,10 +19,8 @@
 package com.graphhopper.swl;
 
 import com.graphhopper.routing.ev.EncodedValueLookup;
-import com.graphhopper.routing.querygraph.VirtualEdgeIteratorState;
 import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.util.EdgeIteratorState;
-import com.graphhopper.util.GHUtility;
 import com.graphhopper.util.details.AbstractPathDetailsBuilder;
 
 public class R5EdgeIdPathDetailsBuilder extends AbstractPathDetailsBuilder {
@@ -46,12 +44,8 @@ public class R5EdgeIdPathDetailsBuilder extends AbstractPathDetailsBuilder {
     }
 
     private String getR5EdgeId(EdgeIteratorState edge) {
-        if (edge instanceof VirtualEdgeIteratorState) {
-            return String.valueOf(GHUtility.getEdgeFromEdgeKey(((VirtualEdgeIteratorState) edge).getOriginalEdgeKey()));
-        } else {
-            boolean reverse = edge.get(EdgeIteratorState.REVERSE_STATE);
-            return originalDirectionFlagEncoder.getStableId(reverse, edge);
-        }
+        boolean reverse = edge.get(EdgeIteratorState.REVERSE_STATE);
+        return originalDirectionFlagEncoder.getStableId(reverse, edge);
     }
 
     @Override

--- a/web-bundle/src/main/java/com/graphhopper/swl/StableEdgeIdPathDetailsBuilder.java
+++ b/web-bundle/src/main/java/com/graphhopper/swl/StableEdgeIdPathDetailsBuilder.java
@@ -23,11 +23,11 @@ import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.util.EdgeIteratorState;
 import com.graphhopper.util.details.AbstractPathDetailsBuilder;
 
-public class R5EdgeIdPathDetailsBuilder extends AbstractPathDetailsBuilder {
+public class StableEdgeIdPathDetailsBuilder extends AbstractPathDetailsBuilder {
     private final StableIdEncodedValues originalDirectionFlagEncoder;
     private String edgeId;
 
-    public R5EdgeIdPathDetailsBuilder(EncodedValueLookup originalDirectionFlagEncoder) {
+    public StableEdgeIdPathDetailsBuilder(EncodedValueLookup originalDirectionFlagEncoder) {
         super("r5_edge_id");
         this.originalDirectionFlagEncoder = StableIdEncodedValues.fromEncodingManager((EncodingManager) originalDirectionFlagEncoder);
         edgeId = "";


### PR DESCRIPTION
The thing that returns stable edge ids was doing more than it should -- virtual edges don't seem to need special treatment at all. I think this happened when we started storing stable-edge-ids in the edge instead of deriving them from Graphhopper's edge numbers (where virtual edges would get a special one).