### PR TITLE
Update java base image to jdk 14.0.2

### DIFF
--- a/Dockerfile.model
+++ b/Dockerfile.model
@@ -15,7 +15,7 @@ COPY . .
 
 RUN mvn -s maven_settings.xml --projects web -am -DskipTests=true package
 
-FROM openjdk:8-jdk
+FROM openjdk:14.0.2-jdk
 
 RUN mkdir -p /data
 


### PR DESCRIPTION
Updates base java version to the latest stable release (march 2020, 14.0.2). Should not affect router behavior, just opens up a lot of new options for us.