### PR TITLE
Set Maven to build JAR with Java 14

### DIFF
--- a/Dockerfile.model
+++ b/Dockerfile.model
@@ -1,13 +1,13 @@
-FROM maven:3.6.3-jdk-8 as build
+FROM maven:3.6.3-adoptopenjdk-14 as build
 
 ARG GRAPHHOPPER_TOKEN
 ARG GIT_USER_ID
 ARG GIT_PERSONAL_ACCESS
 
 ENV JETTY_PORT 11111
-ENV JAVA_OPTS "-server -Xconcurrentio -Xmx1g -Xms1g -XX:+UseG1GC -XX:MetaspaceSize=100M"
+ENV JAVA_OPTS "-server -Xmx1g -Xms1g -XX:+UseG1GC -XX:MetaspaceSize=100M"
 
-RUN apt-get install -y wget
+RUN apt-get update && apt-get install -y wget
 
 WORKDIR /graphhopper
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.target>14</maven.compiler.target>
     </properties>
 
     <modules>
@@ -29,8 +29,8 @@
                     <compilerArgument>-Xlint:deprecation</compilerArgument>
                     -->
                     <fork>true</fork>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>14</source>
+                    <target>14</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Changes maven base image to one with Java 14 available, and sets Java version for Maven build to 14, so we're not only running the JAR we generate with the newest Java, we're also building it with the same Java version.