### PR TITLE
RAD-694: Move OSM tag parsing to import step; store/load info w/ mapdb DB

### DIFF
--- a/replica-common/src/main/java/com/graphhopper/export/CustomGraphHopperGtfs.java
+++ b/replica-common/src/main/java/com/graphhopper/export/CustomGraphHopperGtfs.java
@@ -1,11 +1,13 @@
 package com.graphhopper.export;
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.graphhopper.GraphHopperConfig;
+import com.graphhopper.gtfs.GraphHopperGtfs;
 import com.graphhopper.reader.DataReader;
 import com.graphhopper.reader.ReaderElement;
 import com.graphhopper.reader.ReaderWay;
-import com.graphhopper.reader.osm.GraphHopperOSM;
 import com.graphhopper.reader.osm.OSMInput;
 import com.graphhopper.reader.osm.OSMReader;
 import com.graphhopper.routing.util.EncodingManager;
@@ -29,8 +31,8 @@ import java.util.Set;
  * data about a particular region's GH street network.
  */
 
-public class CustomGraphHopperOSM extends GraphHopperOSM {
-    private static final Logger LOG = LoggerFactory.getLogger(CustomGraphHopperOSM.class);
+public class CustomGraphHopperGtfs extends GraphHopperGtfs {
+    private static final Logger LOG = LoggerFactory.getLogger(CustomGraphHopperGtfs.class);
 
     // Tags considered by R5 when calculating the value of the `lanes` column
     private static final Set<String> LANE_TAGS = Sets.newHashSet("lanes", "lanes:forward", "lanes:backward");
@@ -40,13 +42,13 @@ public class CustomGraphHopperOSM extends GraphHopperOSM {
     private Map<Long, Map<String, String>> osmIdToLaneTags;
     // Map of GH edge ID to OSM way ID
     private Map<Integer, Long> ghIdToOsmId;
-    // Map of OSM way ID to String[] of access flags (from set {ALLOWS_CAR, ALLOWS_BIKE, ALLOWS_PEDESTRIAN}) for each
-    // edge direction, in order [forward, backward]
-    private Map<Long, String[]> osmIdToAccessFlags;
+    // Map of OSM way ID to access flags for each edge direction (each created from set
+    // {ALLOWS_CAR, ALLOWS_BIKE, ALLOWS_PEDESTRIAN}), stored in list in order [forward, backward]
+    private Map<Long, List<String>> osmIdToAccessFlags;
 
-    public CustomGraphHopperOSM(String osmPath) {
-        super();
-        this.osmPath = osmPath;
+    public CustomGraphHopperGtfs(GraphHopperConfig ghConfig) {
+        super(ghConfig);
+        this.osmPath = ghConfig.getString("datareader.file", "");
         this.osmIdToLaneTags = Maps.newHashMap();
         this.ghIdToOsmId = Maps.newHashMap();
         this.osmIdToAccessFlags = Maps.newHashMap();
@@ -54,6 +56,7 @@ public class CustomGraphHopperOSM extends GraphHopperOSM {
 
     @Override
     protected void registerCustomEncodedValues(EncodingManager.Builder emBuilder) {
+        super.registerCustomEncodedValues(emBuilder);
         StableIdEncodedValues.createAndAddEncodedValues(emBuilder);
     }
 
@@ -111,7 +114,7 @@ public class CustomGraphHopperOSM extends GraphHopperOSM {
                             // Compute accessibility flags for edge in both directions
                             Way way = new Way(wayTagsToConsider);
                             List<EnumSet<TraversalPermissionLabeler.EdgeFlag>> flags = flagLabeler.getPermissions(way);
-                            String[] flagStrings = {flags.get(0).toString(), flags.get(1).toString()};
+                            List<String> flagStrings = Lists.newArrayList(flags.get(0).toString(), flags.get(1).toString());
                             osmIdToAccessFlags.put(ghReaderWay.getId(), flagStrings);
                         }
                     }
@@ -131,17 +134,15 @@ public class CustomGraphHopperOSM extends GraphHopperOSM {
         return initDataReader(reader);
     }
 
-    public Map<String, String> getLanesTag(long osmId) {
-        return osmIdToLaneTags.containsKey(osmId) ? osmIdToLaneTags.get(osmId) : null;
+    public Map<Long, Map<String, String>> getOsmIdToLaneTags() {
+        return osmIdToLaneTags;
     }
 
-    public long getOsmIdForGhEdge(int ghEdgeId) {
-        return ghIdToOsmId.get(ghEdgeId);
+    public Map<Integer, Long> getGhIdToOsmId() {
+        return ghIdToOsmId;
     }
 
-    // Sets of flags are returned for each edge direction, stored in a String[] ordered [forward, backward]
-    public String getFlagsForGhEdge(int ghEdgeId, boolean reverse) {
-        int flagIndex = reverse ? 1 : 0;
-        return osmIdToAccessFlags.get(getOsmIdForGhEdge(ghEdgeId))[flagIndex];
+    public Map<Long, List<String>> getOsmIdToAccessFlags() {
+        return osmIdToAccessFlags;
     }
 }

--- a/web-bundle/src/main/java/com/graphhopper/http/GraphHopperManaged.java
+++ b/web-bundle/src/main/java/com/graphhopper/http/GraphHopperManaged.java
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.graphhopper.GraphHopper;
 import com.graphhopper.GraphHopperConfig;
 import com.graphhopper.config.Profile;
-import com.graphhopper.gtfs.GraphHopperGtfs;
+import com.graphhopper.export.CustomGraphHopperGtfs;
 import com.graphhopper.jackson.Jackson;
 import com.graphhopper.json.geo.JsonFeatureCollection;
 import com.graphhopper.reader.osm.GraphHopperOSM;
@@ -74,13 +74,7 @@ public class GraphHopperManaged implements Managed {
             landmarkSplittingFeatureCollection = null;
         }
         if (configuration.has("gtfs.file")) {
-            graphHopper = new GraphHopperGtfs(configuration) {
-                @Override
-                protected void registerCustomEncodedValues(EncodingManager.Builder emBuilder) {
-                    super.registerCustomEncodedValues(emBuilder);
-                    StableIdEncodedValues.createAndAddEncodedValues(emBuilder);
-                }
-            };
+            graphHopper = new CustomGraphHopperGtfs(configuration);
         } else {
             graphHopper = new GraphHopperOSM(landmarkSplittingFeatureCollection) {
                 @Override

--- a/web-bundle/src/main/java/com/graphhopper/replica/OsmHelper.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/OsmHelper.java
@@ -1,0 +1,63 @@
+package com.graphhopper.replica;
+
+import com.graphhopper.export.CustomGraphHopperGtfs;
+import org.mapdb.DB;
+import org.mapdb.DBMaker;
+import org.mapdb.HTreeMap;
+import org.mapdb.Serializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+
+public class OsmHelper {
+    private static final Logger logger = LoggerFactory.getLogger(OsmHelper.class);
+
+    public static void writeOsmInfoToMapDb(CustomGraphHopperGtfs graphHopperGtfs) {
+        logger.info("Initializing new MapDB database files to store OSM info.");
+        DB db = DBMaker.newFileDB(new File("transit_data/osm_info.db")).make();
+
+        HTreeMap<Long, Map<String, String>> osmIdToLaneTags = db
+                .createHashMap("osmIdToLaneTags")
+                .keySerializer(Serializer.LONG)
+                .valueSerializer(Serializer.JAVA)
+                .make();
+
+        HTreeMap<Integer, Long> ghIdToOsmId = db
+                .createHashMap("ghIdToOsmId")
+                .keySerializer(Serializer.INTEGER)
+                .valueSerializer(Serializer.LONG)
+                .make();
+
+        HTreeMap<Long, List<String>> osmIdToAccessFlags = db
+                .createHashMap("osmIdToAccessFlags")
+                .keySerializer(Serializer.LONG)
+                .valueSerializer(Serializer.JAVA)
+                .make();
+
+        osmIdToLaneTags.putAll(graphHopperGtfs.getOsmIdToLaneTags());
+        ghIdToOsmId.putAll(graphHopperGtfs.getGhIdToOsmId());
+        osmIdToAccessFlags.putAll(graphHopperGtfs.getOsmIdToAccessFlags());
+
+        db.commit();
+        db.close();
+        logger.info("Done writing OSM info to MapDB database files.");
+    }
+
+    public static Map<String, String> getLanesTag(long osmId, Map<Long, Map<String, String>> osmIdToLaneTags) {
+        return osmIdToLaneTags.getOrDefault(osmId, null);
+    }
+
+    public static long getOsmIdForGhEdge(int ghEdgeId, Map<Integer, Long> ghIdToOsmId) {
+        return ghIdToOsmId.getOrDefault(ghEdgeId, -1L);
+    }
+
+    // Sets of flags are returned for each edge direction, stored in a List<String> ordered [forward, backward]
+    public static String getFlagsForGhEdge(int ghEdgeId, boolean reverse, Map<Long, List<String>> osmIdToAccessFlags,
+                                           Map<Integer, Long> ghIdToOsmId) {
+        int flagIndex = reverse ? 1 : 0;
+        return osmIdToAccessFlags.get(getOsmIdForGhEdge(ghEdgeId, ghIdToOsmId)).get(flagIndex);
+    }
+}

--- a/web/src/main/java/com/graphhopper/http/cli/ExportCommand.java
+++ b/web/src/main/java/com/graphhopper/http/cli/ExportCommand.java
@@ -4,23 +4,24 @@ import com.google.common.collect.Lists;
 import com.graphhopper.GraphHopper;
 import com.graphhopper.http.GraphHopperManaged;
 import com.graphhopper.http.GraphHopperServerConfiguration;
+import com.graphhopper.replica.OsmHelper;
 import com.graphhopper.routing.ev.DecimalEncodedValue;
 import com.graphhopper.routing.ev.EnumEncodedValue;
 import com.graphhopper.routing.ev.RoadClass;
 import com.graphhopper.routing.util.AllEdgesIterator;
 import com.graphhopper.routing.util.CarFlagEncoder;
-import com.graphhopper.routing.util.DefaultFlagEncoderFactory;
 import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.stableid.StableIdEncodedValues;
 import com.graphhopper.storage.GraphHopperStorage;
 import com.graphhopper.storage.NodeAccess;
-import com.graphhopper.export.CustomGraphHopperOSM;
-import com.graphhopper.stableid.StableIdEncodedValues;
 import com.graphhopper.util.DistanceCalcEarth;
 import com.graphhopper.util.FetchMode;
 import com.graphhopper.util.PointList;
 import io.dropwizard.cli.ConfiguredCommand;
 import io.dropwizard.setup.Bootstrap;
 import net.sourceforge.argparse4j.inf.Namespace;
+import org.mapdb.DB;
+import org.mapdb.DBMaker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,9 +44,8 @@ import java.util.Map;
  */
 
 public class ExportCommand extends ConfiguredCommand<GraphHopperServerConfiguration> {
-    private static final Logger LOG = LoggerFactory.getLogger(ExportCommand.class);
+    private static final Logger logger = LoggerFactory.getLogger(ExportCommand.class);
 
-    private static final String FLAG_ENCODERS = "car,bike,foot";
     private static final List<String> HIGHWAY_FILTER_TAGS = Lists.newArrayList("bridleway", "steps");
     private static final String COLUMN_HEADERS = "\"stableEdgeId\",\"startVertex\",\"endVertex\"," +
             "\"startLat\",\"startLon\",\"endLat\",\"endLon\",\"geometry\",\"streetName\",\"distance\",\"osmid\"," +
@@ -67,25 +67,23 @@ public class ExportCommand extends ConfiguredCommand<GraphHopperServerConfigurat
                     configuredGraphHopper.getGraphHopperLocation());
         }
 
-        // Read and parse tag/ID info from OSM file specified in command line
-        EncodingManager encodingManager = EncodingManager.create(new DefaultFlagEncoderFactory(), FLAG_ENCODERS);
-        String osmWorkingDir = configuredGraphHopper.getGraphHopperLocation() + "/osm";
-        String osmFileLocation = configuredGraphHopper.getDataReaderFile();
-
-        CustomGraphHopperOSM osmTaggedGraphHopper = new CustomGraphHopperOSM(osmFileLocation);
-        osmTaggedGraphHopper.setGraphHopperLocation(osmWorkingDir);
-        osmTaggedGraphHopper.setEncodingManager(encodingManager);
-        osmTaggedGraphHopper.setInMemory();
-        osmTaggedGraphHopper.setDataReaderFile(osmFileLocation);
-        osmTaggedGraphHopper.importOrLoad();
-        osmTaggedGraphHopper.clean();
+        // Load OSM info needed for export from MapDB database file
+        DB db = DBMaker.newFileDB(new File("transit_data/osm_info.db")).make();
+        Map<Long, Map<String, String>> osmIdToLaneTags = db.getHashMap("osmIdToLaneTags");
+        Map<Integer, Long> ghIdToOsmId = db.getHashMap("ghIdToOsmId");
+        Map<Long, List<String>> osmIdToAccessFlags = db.getHashMap("osmIdToAccessFlags");
+        logger.info("Done loading OSM info needed for CSV export from MapDB file.");
 
         // Use loaded graph data to write street network out to CSV
-        writeStreetEdgesCsv(configuredGraphHopper, osmTaggedGraphHopper);
+        writeStreetEdgesCsv(configuredGraphHopper, osmIdToLaneTags, ghIdToOsmId, osmIdToAccessFlags);
+        db.close();
     }
 
     private static void writeStreetEdgesCsv(GraphHopper configuredGraphHopper,
-                                            CustomGraphHopperOSM osmTaggedGraphHopper) {
+                                            Map<Long, Map<String, String>> osmIdToLaneTags,
+                                            Map<Integer, Long> ghIdToOsmId,
+                                            Map<Long, List<String>> osmIdToAccessFlags) {
+
         // Grab edge/node iterators for graph loaded from pre-built GH files
         GraphHopperStorage graphHopperStorage = configuredGraphHopper.getGraphHopperStorage();
         AllEdgesIterator edgeIterator = graphHopperStorage.getAllEdges();
@@ -101,7 +99,7 @@ public class ExportCommand extends ConfiguredCommand<GraphHopperServerConfigurat
 
         File outputFile = new File(configuredGraphHopper.getGraphHopperLocation() + "/street_edges.csv");
 
-        LOG.info("Writing street edges...");
+        logger.info("Writing street edges...");
         OutputStream outputStream;
         try {
             outputStream = new BufferedOutputStream(new FileOutputStream(outputFile));
@@ -113,7 +111,10 @@ public class ExportCommand extends ConfiguredCommand<GraphHopperServerConfigurat
 
         // For each bidirectional edge in pre-built graph, calculate value of each CSV column
         // and export new line for each edge direction
+        int totalEdgeCount = 0;
+        int skippedEdgeCount = 0;
         while (edgeIterator.next()) {
+            totalEdgeCount++;
             // Fetch starting and ending vertices
             int ghEdgeId = edgeIterator.getEdge();
             int startVertex = edgeIterator.getBaseNode();
@@ -127,9 +128,9 @@ public class ExportCommand extends ConfiguredCommand<GraphHopperServerConfigurat
             PointList wayGeometry = edgeIterator.fetchWayGeometry(FetchMode.ALL);
             String geometryString = wayGeometry.toLineString(false).toString();
 
-            //todo: which distance calc to use?
-            // 1) edgeIterator.getDistance();
-            // 2) DistanceCalcEarth.DIST_EARTH.calcDist(startLat, startLon, endLat, endLon);
+            //todo : which distance calc to use?
+            // edgeIterator.getDistance();
+            // DistanceCalcEarth.DIST_EARTH.calcDist(startLat, startLon, endLat, endLon);
             long distanceMeters = Math.round(DistanceCalcEarth.DIST_EARTH.calcDist(startLat, startLon, endLat, endLon));
 
             // Parse OSM highway type and street name, and grab encoded stable IDs for both edge directions
@@ -144,16 +145,22 @@ public class ExportCommand extends ConfiguredCommand<GraphHopperServerConfigurat
             // Convert GH's distance in meters to millimeters to match R5's implementation
             long distanceMillimeters = distanceMeters * 1000;
 
-            // Fetch OSM ID and accessibility flags for each edge direction
+            // Fetch OSM ID, skipping edges from PT meta-graph that have no IDs set (getOsmIdForGhEdge returns -1)
+            long osmId = OsmHelper.getOsmIdForGhEdge(edgeIterator.getEdge(), ghIdToOsmId);
+            if (osmId == -1L) {
+                skippedEdgeCount++;
+                continue;
+            }
+
+            // Set accessibility flags for each edge direction
             // Returned flags are from the set {ALLOWS_CAR, ALLOWS_BIKE, ALLOWS_PEDESTRIAN}
-            long osmId = osmTaggedGraphHopper.getOsmIdForGhEdge(edgeIterator.getEdge());
-            String forwardFlags = osmTaggedGraphHopper.getFlagsForGhEdge(ghEdgeId, false);
-            String backwardFlags = osmTaggedGraphHopper.getFlagsForGhEdge(ghEdgeId, true);
+            String forwardFlags = OsmHelper.getFlagsForGhEdge(ghEdgeId, false, osmIdToAccessFlags, ghIdToOsmId);
+            String backwardFlags = OsmHelper.getFlagsForGhEdge(ghEdgeId, true, osmIdToAccessFlags, ghIdToOsmId);
 
             // Calculate number of lanes for edge, as done in R5, based on OSM tags + edge direction
-            int overallLanes = parseLanesTag(osmId, osmTaggedGraphHopper, "lanes");
-            int forwardLanes = parseLanesTag(osmId, osmTaggedGraphHopper, "lanes:forward");
-            int backwardLanes = parseLanesTag(osmId, osmTaggedGraphHopper, "lanes:backward");
+            int overallLanes = parseLanesTag(osmId, osmIdToLaneTags, "lanes");
+            int forwardLanes = parseLanesTag(osmId, osmIdToLaneTags, "lanes:forward");
+            int backwardLanes = parseLanesTag(osmId, osmIdToLaneTags, "lanes:backward");
 
             if (!backwardFlags.contains("ALLOWS_CAR")) {
                 backwardLanes = 0;
@@ -193,8 +200,11 @@ public class ExportCommand extends ConfiguredCommand<GraphHopperServerConfigurat
         }
 
         printStream.close();
-        LOG.info("Done writing street network to CSV");
-        assert(outputFile.exists());
+        logger.info("Done writing street network to CSV");
+        logger.info("A total of " + totalEdgeCount + " edges were considered; " + skippedEdgeCount + " edges were skipped");
+        if (!outputFile.exists()) {
+            logger.error("Output file can't be found! Export may not have completed successfully");
+        }
     }
 
     private static String toString(String stableEdgeId, int startVertex, int endVertex, double startLat,
@@ -207,15 +217,15 @@ public class ExportCommand extends ConfiguredCommand<GraphHopperServerConfigurat
     }
 
     // Taken from R5's lane parsing logic. See EdgeServiceServer.java in R5 repo
-    private static int parseLanesTag(long osmId, CustomGraphHopperOSM graphHopper, String laneTag) {
+    private static int parseLanesTag(long osmId, Map<Long, Map<String, String>> osmIdToLaneTags, String laneTag) {
         int result = -1;
-        Map<String, String> laneTagsOnEdge = graphHopper.getLanesTag(osmId);
+        Map<String, String> laneTagsOnEdge = OsmHelper.getLanesTag(osmId, osmIdToLaneTags);
         if (laneTagsOnEdge != null) {
             if (laneTagsOnEdge.containsKey(laneTag)) {
                 try {
                     return parseLanesTag(laneTagsOnEdge.get(laneTag));
                 } catch (NumberFormatException ex) {
-                    LOG.warn("way {}: Unable to parse lanes value as number {}", osmId, laneTag);
+                    logger.warn("way {}: Unable to parse lanes value as number {}", osmId, laneTag);
                 }
             }
         }

--- a/web/src/main/java/com/graphhopper/http/cli/ImportCommand.java
+++ b/web/src/main/java/com/graphhopper/http/cli/ImportCommand.java
@@ -19,8 +19,10 @@
 package com.graphhopper.http.cli;
 
 import com.graphhopper.GraphHopper;
+import com.graphhopper.export.CustomGraphHopperGtfs;
 import com.graphhopper.http.GraphHopperManaged;
 import com.graphhopper.http.GraphHopperServerConfiguration;
+import com.graphhopper.replica.OsmHelper;
 import com.graphhopper.replica.StableEdgeIdManager;
 import io.dropwizard.cli.ConfiguredCommand;
 import io.dropwizard.setup.Bootstrap;
@@ -37,6 +39,9 @@ public class ImportCommand extends ConfiguredCommand<GraphHopperServerConfigurat
         final GraphHopperManaged graphHopper = new GraphHopperManaged(configuration.getGraphHopperConfiguration(), bootstrap.getObjectMapper());
         GraphHopper gh = graphHopper.getGraphHopper();
         gh.importOrLoad();
+        if (gh instanceof CustomGraphHopperGtfs) {
+            OsmHelper.writeOsmInfoToMapDb((CustomGraphHopperGtfs) gh);
+        }
         StableEdgeIdManager stableEdgeIdManager = new StableEdgeIdManager(gh);
         stableEdgeIdManager.setStableEdgeIds();
         gh.close();

--- a/web/src/main/java/com/graphhopper/http/cli/ImportCommand.java
+++ b/web/src/main/java/com/graphhopper/http/cli/ImportCommand.java
@@ -40,6 +40,7 @@ public class ImportCommand extends ConfiguredCommand<GraphHopperServerConfigurat
         GraphHopper gh = graphHopper.getGraphHopper();
         gh.importOrLoad();
         if (gh instanceof CustomGraphHopperGtfs) {
+            ((CustomGraphHopperGtfs) gh).collectOsmInfo();
             OsmHelper.writeOsmInfoToMapDb((CustomGraphHopperGtfs) gh);
         }
         StableEdgeIdManager stableEdgeIdManager = new StableEdgeIdManager(gh);


### PR DESCRIPTION
Refactors the import and export commands to move the custom reading of OSM files (needed to grab OSM tag information used in export) from the export step to the import step, where the tag info is loaded into mapdb database files, and then loaded from disk at export-time. This eliminates the need for reading the OSM file twice, which is a good thing for both speed and cleanliness reasons.