### PR TITLE
Cleanup + GTFS link mapper hotfix to catch failed stop-stop routing

### DIFF
--- a/web-bundle/src/main/java/com/graphhopper/replica/GtfsLinkMapper.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/GtfsLinkMapper.java
@@ -114,7 +114,6 @@ public class GtfsLinkMapper {
             int odStopCount = 0;
             int nonUniqueODPairs = 0;
             int routeNotFoundCount = 0;
-            int singleEdgeReturnedCount = 0;
             // For each trip, route with auto between all O/D stop pairs,
             // and store returned stable edge IDs for each route in mapdb file
             for (String tripId : tripIdToStopsInTrip.keySet()) {
@@ -150,12 +149,12 @@ public class GtfsLinkMapper {
                     GHResponse response = graphHopper.route(odRequest);
 
                     // If stop->stop path couldn't be found by GH, don't store anything
-                    if (response.getAll().size() != 1) {
+                    if (response.getAll().size() == 0 || response.getAll().get(0).hasErrors()) {
                         routeNotFoundCount++;
                         continue;
                     }
 
-                    // Parse stable IDs and adjacent nodes for each edge from response
+                    // Parse stable IDs for each edge from response
                     List<PathDetail> responsePathEdgeIdDetails = response.getAll().get(0).getPathDetails().get("r5_edge_id");
                     List<String> pathEdgeIds = responsePathEdgeIdDetails.stream()
                             .map(pathDetail -> (String) pathDetail.getValue())
@@ -172,7 +171,6 @@ public class GtfsLinkMapper {
                     " total trips processed; " + nonUniqueODPairs + "/" + odStopCount
                     + " O/D stop pairs were non-unique; routes for " + routeNotFoundCount + "/" + odStopCount
                     + " stop->stop pairs were not found");
-            logger.info("number of returned paths that only had 1 virtual edge: " + singleEdgeReturnedCount);
         }
         db.commit();
         db.close();


### PR DESCRIPTION
Includes simple hotfix for [this](https://replicahq.slack.com/archives/CK358RL0Z/p1600553031022500) bug, plus a tiny bit of leftover clean-up.

Basic description of fix: there was one more tiny edge case in the GTFS link mapper where, when routing an auto from transit stop -> stop, a route wasn't found. Up to now, whenever this happened, the router just wouldn't return a response. In this case, we saw a situation where a response was returned, but the response included an error message. This fix combines these two cases into one check that ignores these un-found routes. 