### PR TITLE
Rename r5_edge_id path detail and return stable IDs by default

### DIFF
--- a/replica-common/src/main/java/com/graphhopper/stableid/PathDetailsBuilderFactoryWithStableId.java
+++ b/replica-common/src/main/java/com/graphhopper/stableid/PathDetailsBuilderFactoryWithStableId.java
@@ -69,9 +69,8 @@ public class PathDetailsBuilderFactoryWithStableId extends PathDetailsBuilderFac
             builders.add(new EdgeKeyDetails());
         }
 
-        if (requestedPathDetails.contains("stable_edge_ids")) {
-            builders.add(new StableIdPathDetailsBuilder(evl));
-        }
+        // Always add stable ID details builder, so stable IDs are always returned
+        builders.add(new StableIdPathDetailsBuilder(evl));
 
         for (Map.Entry entry : Arrays.asList(new MapEntry<>(RoadClass.KEY, RoadClass.class),
                 new MapEntry<>(RoadEnvironment.KEY, RoadEnvironment.class), new MapEntry<>(Surface.KEY, Surface.class),

--- a/replica-common/src/main/java/com/graphhopper/stableid/PathDetailsBuilderFactoryWithStableId.java
+++ b/replica-common/src/main/java/com/graphhopper/stableid/PathDetailsBuilderFactoryWithStableId.java
@@ -69,7 +69,7 @@ public class PathDetailsBuilderFactoryWithStableId extends PathDetailsBuilderFac
             builders.add(new EdgeKeyDetails());
         }
 
-        if (requestedPathDetails.contains("stable_edge_id")) {
+        if (requestedPathDetails.contains("stable_edge_ids")) {
             builders.add(new StableIdPathDetailsBuilder(evl));
         }
 

--- a/replica-common/src/main/java/com/graphhopper/stableid/PathDetailsBuilderFactoryWithStableId.java
+++ b/replica-common/src/main/java/com/graphhopper/stableid/PathDetailsBuilderFactoryWithStableId.java
@@ -69,7 +69,7 @@ public class PathDetailsBuilderFactoryWithStableId extends PathDetailsBuilderFac
             builders.add(new EdgeKeyDetails());
         }
 
-        if (requestedPathDetails.contains("r5_edge_id")) {
+        if (requestedPathDetails.contains("stable_edge_id")) {
             builders.add(new StableIdPathDetailsBuilder(evl));
         }
 

--- a/replica-common/src/main/java/com/graphhopper/stableid/PathDetailsBuilderFactoryWithStableId.java
+++ b/replica-common/src/main/java/com/graphhopper/stableid/PathDetailsBuilderFactoryWithStableId.java
@@ -69,8 +69,9 @@ public class PathDetailsBuilderFactoryWithStableId extends PathDetailsBuilderFac
             builders.add(new EdgeKeyDetails());
         }
 
-        // Always add stable ID details builder, so stable IDs are always returned
-        builders.add(new StableIdPathDetailsBuilder(evl));
+        if (requestedPathDetails.contains("stable_edge_ids")) {
+            builders.add(new StableIdPathDetailsBuilder(evl));
+        }
 
         for (Map.Entry entry : Arrays.asList(new MapEntry<>(RoadClass.KEY, RoadClass.class),
                 new MapEntry<>(RoadEnvironment.KEY, RoadEnvironment.class), new MapEntry<>(Surface.KEY, Surface.class),

--- a/replica-common/src/main/java/com/graphhopper/stableid/StableIdPathDetailsBuilder.java
+++ b/replica-common/src/main/java/com/graphhopper/stableid/StableIdPathDetailsBuilder.java
@@ -28,7 +28,7 @@ public class StableIdPathDetailsBuilder extends AbstractPathDetailsBuilder {
     private String edgeId;
 
     public StableIdPathDetailsBuilder(EncodedValueLookup originalDirectionFlagEncoder) {
-        super("r5_edge_id");
+        super("stable_edge_id");
         this.originalDirectionFlagEncoder = StableIdEncodedValues.fromEncodingManager((EncodingManager) originalDirectionFlagEncoder);
         edgeId = "";
     }

--- a/replica-common/src/main/java/com/graphhopper/stableid/StableIdPathDetailsBuilder.java
+++ b/replica-common/src/main/java/com/graphhopper/stableid/StableIdPathDetailsBuilder.java
@@ -28,7 +28,7 @@ public class StableIdPathDetailsBuilder extends AbstractPathDetailsBuilder {
     private String edgeId;
 
     public StableIdPathDetailsBuilder(EncodedValueLookup originalDirectionFlagEncoder) {
-        super("stable_edge_id");
+        super("stable_edge_ids");
         this.originalDirectionFlagEncoder = StableIdEncodedValues.fromEncodingManager((EncodingManager) originalDirectionFlagEncoder);
         edgeId = "";
     }

--- a/web-bundle/src/main/java/com/graphhopper/replica/GtfsLinkMapper.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/GtfsLinkMapper.java
@@ -144,7 +144,6 @@ public class GtfsLinkMapper {
                             odStopPair.getRight().stop_lat, odStopPair.getRight().stop_lon
                     );
                     odRequest.setProfile("car");
-                    odRequest.setPathDetails(Lists.newArrayList("stable_edge_ids"));
                     GHResponse response = graphHopper.route(odRequest);
 
                     // If stop->stop path couldn't be found by GH, don't store anything

--- a/web-bundle/src/main/java/com/graphhopper/replica/GtfsLinkMapper.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/GtfsLinkMapper.java
@@ -144,7 +144,7 @@ public class GtfsLinkMapper {
                             odStopPair.getRight().stop_lat, odStopPair.getRight().stop_lon
                     );
                     odRequest.setProfile("car");
-                    odRequest.setPathDetails(Lists.newArrayList("r5_edge_id"));
+                    odRequest.setPathDetails(Lists.newArrayList("stable_edge_id"));
                     GHResponse response = graphHopper.route(odRequest);
 
                     // If stop->stop path couldn't be found by GH, don't store anything
@@ -154,7 +154,8 @@ public class GtfsLinkMapper {
                     }
 
                     // Parse stable IDs for each edge from response
-                    List<PathDetail> responsePathEdgeIdDetails = response.getAll().get(0).getPathDetails().get("r5_edge_id");
+                    List<PathDetail> responsePathEdgeIdDetails = response.getAll().get(0)
+                            .getPathDetails().get("stable_edge_id");
                     List<String> pathEdgeIds = responsePathEdgeIdDetails.stream()
                             .map(pathDetail -> (String) pathDetail.getValue())
                             .collect(Collectors.toList());

--- a/web-bundle/src/main/java/com/graphhopper/replica/GtfsLinkMapper.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/GtfsLinkMapper.java
@@ -13,6 +13,7 @@ import com.graphhopper.GHResponse;
 import com.graphhopper.GraphHopper;
 import com.graphhopper.gtfs.GraphHopperGtfs;
 import com.graphhopper.gtfs.GtfsStorage;
+import com.graphhopper.stableid.PathDetailsBuilderFactoryWithStableId;
 import com.graphhopper.util.details.PathDetail;
 import org.apache.commons.lang3.tuple.Pair;
 import org.mapdb.DB;
@@ -145,6 +146,7 @@ public class GtfsLinkMapper {
                             odStopPair.getRight().stop_lat, odStopPair.getRight().stop_lon
                     );
                     odRequest.setProfile("car");
+                    odRequest.setPathDetails(Lists.newArrayList("stable_edge_ids"));
                     GHResponse response = graphHopper.route(odRequest);
 
                     // If stop->stop path couldn't be found by GH, don't store anything

--- a/web-bundle/src/main/java/com/graphhopper/replica/GtfsLinkMapper.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/GtfsLinkMapper.java
@@ -144,7 +144,7 @@ public class GtfsLinkMapper {
                             odStopPair.getRight().stop_lat, odStopPair.getRight().stop_lon
                     );
                     odRequest.setProfile("car");
-                    odRequest.setPathDetails(Lists.newArrayList("stable_edge_id"));
+                    odRequest.setPathDetails(Lists.newArrayList("stable_edge_ids"));
                     GHResponse response = graphHopper.route(odRequest);
 
                     // If stop->stop path couldn't be found by GH, don't store anything
@@ -155,7 +155,7 @@ public class GtfsLinkMapper {
 
                     // Parse stable IDs for each edge from response
                     List<PathDetail> responsePathEdgeIdDetails = response.getAll().get(0)
-                            .getPathDetails().get("stable_edge_id");
+                            .getPathDetails().get("stable_edge_ids");
                     List<String> pathEdgeIds = responsePathEdgeIdDetails.stream()
                             .map(pathDetail -> (String) pathDetail.getValue())
                             .collect(Collectors.toList());

--- a/web-bundle/src/main/java/com/graphhopper/resources/PtRouteResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/PtRouteResource.java
@@ -68,7 +68,6 @@ public class PtRouteResource {
         List<GHLocation> points = requestPoints.stream().map(AbstractParam::get).collect(Collectors.toList());
         Instant departureTime = departureTimeParam.get();
         Request request = new Request(points, departureTime);
-
         request.setArriveBy(arriveBy);
         Optional.ofNullable(profileQuery).ifPresent(request::setProfileQuery);
         Optional.ofNullable(profileDuration.get()).ifPresent(request::setMaxProfileDuration);

--- a/web-bundle/src/main/java/com/graphhopper/resources/PtRouteResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/PtRouteResource.java
@@ -68,6 +68,10 @@ public class PtRouteResource {
         List<GHLocation> points = requestPoints.stream().map(AbstractParam::get).collect(Collectors.toList());
         Instant departureTime = departureTimeParam.get();
         Request request = new Request(points, departureTime);
+
+        // Always return stable edge IDs, even if they aren't requested
+        if (!pathDetails.contains("stable_edge_ids")) pathDetails.add("stable_edge_ids");
+
         request.setArriveBy(arriveBy);
         Optional.ofNullable(profileQuery).ifPresent(request::setProfileQuery);
         Optional.ofNullable(profileDuration.get()).ifPresent(request::setMaxProfileDuration);

--- a/web-bundle/src/main/java/com/graphhopper/resources/PtRouteResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/PtRouteResource.java
@@ -68,6 +68,10 @@ public class PtRouteResource {
         List<GHLocation> points = requestPoints.stream().map(AbstractParam::get).collect(Collectors.toList());
         Instant departureTime = departureTimeParam.get();
         Request request = new Request(points, departureTime);
+
+        // Always return stable edge IDs, even if they aren't requested
+        if (!pathDetails.contains("stable_edge_id")) pathDetails.add("stable_edge_id");
+
         request.setArriveBy(arriveBy);
         Optional.ofNullable(profileQuery).ifPresent(request::setProfileQuery);
         Optional.ofNullable(profileDuration.get()).ifPresent(request::setMaxProfileDuration);
@@ -100,14 +104,14 @@ public class PtRouteResource {
             Trip.WalkLeg firstLeg = (Trip.WalkLeg) walkLegs.get(0);
             Trip.WalkLeg lastLeg = (Trip.WalkLeg) walkLegs.get(1);
 
-            List<String> lastLegStableIds = lastLeg.details.get("r5_edge_id").stream()
+            List<String> lastLegStableIds = lastLeg.details.get("stable_edge_id").stream()
                     .map(idPathDetail -> (String) idPathDetail.getValue())
                     .filter(id -> id.length() == 20)
                     .collect(toList());
 
             // The first leg contains stable IDs for both walking legs for some reason,
             // so we remove the IDs from the last leg
-            List<String> firstLegStableIds = firstLeg.details.get("r5_edge_id").stream()
+            List<String> firstLegStableIds = firstLeg.details.get("stable_edge_id").stream()
                     .map(idPathDetail -> (String) idPathDetail.getValue())
                     .filter(id -> id.length() == 20)
                     .collect(toList());

--- a/web-bundle/src/main/java/com/graphhopper/resources/PtRouteResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/PtRouteResource.java
@@ -70,7 +70,7 @@ public class PtRouteResource {
         Request request = new Request(points, departureTime);
 
         // Always return stable edge IDs, even if they aren't requested
-        if (!pathDetails.contains("stable_edge_id")) pathDetails.add("stable_edge_id");
+        if (!pathDetails.contains("stable_edge_ids")) pathDetails.add("stable_edge_ids");
 
         request.setArriveBy(arriveBy);
         Optional.ofNullable(profileQuery).ifPresent(request::setProfileQuery);
@@ -104,14 +104,14 @@ public class PtRouteResource {
             Trip.WalkLeg firstLeg = (Trip.WalkLeg) walkLegs.get(0);
             Trip.WalkLeg lastLeg = (Trip.WalkLeg) walkLegs.get(1);
 
-            List<String> lastLegStableIds = lastLeg.details.get("stable_edge_id").stream()
+            List<String> lastLegStableIds = lastLeg.details.get("stable_edge_ids").stream()
                     .map(idPathDetail -> (String) idPathDetail.getValue())
                     .filter(id -> id.length() == 20)
                     .collect(toList());
 
             // The first leg contains stable IDs for both walking legs for some reason,
             // so we remove the IDs from the last leg
-            List<String> firstLegStableIds = firstLeg.details.get("stable_edge_id").stream()
+            List<String> firstLegStableIds = firstLeg.details.get("stable_edge_ids").stream()
                     .map(idPathDetail -> (String) idPathDetail.getValue())
                     .filter(id -> id.length() == 20)
                     .collect(toList());

--- a/web-bundle/src/main/java/com/graphhopper/resources/PtRouteResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/PtRouteResource.java
@@ -69,9 +69,6 @@ public class PtRouteResource {
         Instant departureTime = departureTimeParam.get();
         Request request = new Request(points, departureTime);
 
-        // Always return stable edge IDs, even if they aren't requested
-        if (!pathDetails.contains("stable_edge_ids")) pathDetails.add("stable_edge_ids");
-
         request.setArriveBy(arriveBy);
         Optional.ofNullable(profileQuery).ifPresent(request::setProfileQuery);
         Optional.ofNullable(profileDuration.get()).ifPresent(request::setMaxProfileDuration);

--- a/web-bundle/src/main/java/com/graphhopper/resources/RouteResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/RouteResource.java
@@ -116,6 +116,10 @@ public class RouteResource {
             removeLegacyParameters(request.getHints());
         }
         errorIfLegacyParameters(request.getHints());
+
+        // Always return stable edge IDs, even if they aren't requested
+        if (!pathDetails.contains("stable_edge_id")) pathDetails.add("stable_edge_id");
+
         request.setPoints(points).
                 setProfile(profileName).
                 setAlgorithm(algoStr).

--- a/web-bundle/src/main/java/com/graphhopper/resources/RouteResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/RouteResource.java
@@ -118,7 +118,7 @@ public class RouteResource {
         errorIfLegacyParameters(request.getHints());
 
         // Always return stable edge IDs, even if they aren't requested
-        if (!pathDetails.contains("stable_edge_id")) pathDetails.add("stable_edge_id");
+        if (!pathDetails.contains("stable_edge_ids")) pathDetails.add("stable_edge_ids");
 
         request.setPoints(points).
                 setProfile(profileName).

--- a/web-bundle/src/main/java/com/graphhopper/resources/RouteResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/RouteResource.java
@@ -117,9 +117,6 @@ public class RouteResource {
         }
         errorIfLegacyParameters(request.getHints());
 
-        // Always return stable edge IDs, even if they aren't requested
-        if (!pathDetails.contains("stable_edge_ids")) pathDetails.add("stable_edge_ids");
-
         request.setPoints(points).
                 setProfile(profileName).
                 setAlgorithm(algoStr).

--- a/web-bundle/src/main/java/com/graphhopper/resources/RouteResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/RouteResource.java
@@ -116,6 +116,10 @@ public class RouteResource {
             removeLegacyParameters(request.getHints());
         }
         errorIfLegacyParameters(request.getHints());
+
+        // Always return stable edge IDs, even if they aren't requested
+        if (!pathDetails.contains("stable_edge_ids")) pathDetails.add("stable_edge_ids");
+
         request.setPoints(points).
                 setProfile(profileName).
                 setAlgorithm(algoStr).

--- a/web-bundle/src/main/java/com/graphhopper/resources/RouteResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/RouteResource.java
@@ -116,7 +116,6 @@ public class RouteResource {
             removeLegacyParameters(request.getHints());
         }
         errorIfLegacyParameters(request.getHints());
-
         request.setPoints(points).
                 setProfile(profileName).
                 setAlgorithm(algoStr).


### PR DESCRIPTION
Removes any traces of the old path detail string we were adding to request URLs in order to get stable edge IDs returned, from `r5_edge_id` to `stable_edge_ids`.

Also, this change makes it default behavior to return stable edge IDs, so code calling the server will no longer need to add `&details=r5_edge_id` to query params. This holds for both PT and non-PT routers, and was tested by building Sac locally + querying routes in the UI.