### PR TITLE
Hotfix: divide by zero error in GTFS link mapper progress log message

### DIFF
--- a/web-bundle/src/main/java/com/graphhopper/replica/GtfsLinkMapper.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/GtfsLinkMapper.java
@@ -116,12 +116,14 @@ public class GtfsLinkMapper {
             // For each trip, route with auto between all O/D stop pairs,
             // and store returned stable edge IDs for each route in mapdb file
             for (String tripId : tripIdToStopsInTrip.keySet()) {
+                /*
                 if (processedTripCount % (tripIdToStopsInTrip.keySet().size() / 10) == 0) {
                     logger.info(processedTripCount + "/" + tripIdToStopsInTrip.keySet().size() + " trips for feed "
                             + feedId + " processed so far; " + nonUniqueODPairs + "/" + odStopCount
                             + " O/D stop pairs were non-unique, and were not routed between.");
                 }
-
+                */
+                
                 // Fetch all sequentially-ordered stop->stop pairs for this trip
                 List<Pair<Stop, Stop>> odStopsForTrip = getODStopsForTrip(tripIdToStopsInTrip.get(tripId), stopsForStreetBasedTrips);
 

--- a/web-bundle/src/main/java/com/graphhopper/replica/GtfsLinkMapper.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/GtfsLinkMapper.java
@@ -116,13 +116,12 @@ public class GtfsLinkMapper {
             // For each trip, route with auto between all O/D stop pairs,
             // and store returned stable edge IDs for each route in mapdb file
             for (String tripId : tripIdToStopsInTrip.keySet()) {
-                /*
-                if (processedTripCount % (tripIdToStopsInTrip.keySet().size() / 10) == 0) {
+                if (tripIdToStopsInTrip.keySet().size() > 10 &&
+                        processedTripCount % (tripIdToStopsInTrip.keySet().size() / 10) == 0) {
                     logger.info(processedTripCount + "/" + tripIdToStopsInTrip.keySet().size() + " trips for feed "
                             + feedId + " processed so far; " + nonUniqueODPairs + "/" + odStopCount
                             + " O/D stop pairs were non-unique, and were not routed between.");
                 }
-                */
                 
                 // Fetch all sequentially-ordered stop->stop pairs for this trip
                 List<Pair<Stop, Stop>> odStopsForTrip = getODStopsForTrip(tripIdToStopsInTrip.get(tripId), stopsForStreetBasedTrips);


### PR DESCRIPTION
Brett hit an issue where the line affected in this PR threw a `/ by zero` error. It turns out that there were < 10 trips in this feed, so `tripIdToStopsInTrip.keySet().size() / 10` returned `0`, and therefore, we were technically running `if(processedTripCount % 0 == 0)`, which rightfully threw an error.

The fix is to just ensure that we have >10 trips before running the main check, eliminating this possibility.