### PR TITLE
Add correct GTFS feed ID to stop names in PT responses

### DIFF
--- a/web-bundle/src/main/java/com/graphhopper/replica/GtfsLinkMapper.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/GtfsLinkMapper.java
@@ -62,6 +62,12 @@ public class GtfsLinkMapper {
                 .valueSerializer(Serializer.STRING)
                 .make();
 
+        HTreeMap<String, String> gtfsFeedIdMap = db
+                .createHashMap("gtfsFeedIdMap")
+                .keySerializer(Serializer.STRING)
+                .valueSerializer(Serializer.STRING)
+                .make();
+
         // For testing
         // Set<String> allStableIds = Sets.newHashSet();
 
@@ -69,7 +75,10 @@ public class GtfsLinkMapper {
         // and then for each trip, route via car between each stop pair in sequential order, storing the returned IDs
         for (String feedId : gtfsFeedMap.keySet()) {
             GTFSFeed feed = gtfsFeedMap.get(feedId);
-            logger.info("Processing GTFS feed " + feedId + " " + feed.feedId);
+            logger.info("Processing GTFS feed " + feed.feedId);
+
+            // Record mapping of internal GH feed ID -> GTFS feed ID
+            gtfsFeedIdMap.put(feedId, feed.feedId);
 
             // Store route information in db for _every_ route type
             Map<String, String> routeInfoMap = feed.routes.keySet().stream()
@@ -120,7 +129,7 @@ public class GtfsLinkMapper {
                 if (tripIdToStopsInTrip.keySet().size() > 10 &&
                         processedTripCount % (tripIdToStopsInTrip.keySet().size() / 10) == 0) {
                     logger.info(processedTripCount + "/" + tripIdToStopsInTrip.keySet().size() + " trips for feed "
-                            + feedId + " processed so far; " + nonUniqueODPairs + "/" + odStopCount
+                            + feed.feedId + " processed so far; " + nonUniqueODPairs + "/" + odStopCount
                             + " O/D stop pairs were non-unique, and were not routed between.");
                 }
                 
@@ -169,7 +178,7 @@ public class GtfsLinkMapper {
                 }
                 processedTripCount++;
             }
-            logger.info("Done processing GTFS feed " + feedId + "; " + tripIdToStopsInTrip.keySet().size() +
+            logger.info("Done processing GTFS feed " + feed.feedId + "; " + tripIdToStopsInTrip.keySet().size() +
                     " total trips processed; " + nonUniqueODPairs + "/" + odStopCount
                     + " O/D stop pairs were non-unique; routes for " + routeNotFoundCount + "/" + odStopCount
                     + " stop->stop pairs were not found");


### PR DESCRIPTION
Meant to fix the issue discussed [here](https://replicahq.slack.com/archives/CK358RL0Z/p1602761420071200). What this does:

- During GTFS link mapping process, stores a map of (internal GH "feed ID") --> (actual GTFS feed ID). For context, GH's internal IDs are sequentially numbered IDs of the form `gtfs_0`, `gtfs_1`, etc, whereas "actual GTFS feed ID" here refers to the feed ID provided in `feed_info.txt`, or, if not available, the filename of the GTFS feed
- In PT responses, reconstruct the stops that will be output by the server so they have stop IDs of the form `{actual feed ID}:{stop ID}`, which is in line with how R5 output stop IDs (and lines up with other DMs we have that run downstream)