### PR TITLE
Add DD increment metric to HTTP route resource classes

### DIFF
--- a/web-bundle/pom.xml
+++ b/web-bundle/pom.xml
@@ -28,6 +28,12 @@
             <artifactId>jaxws-api</artifactId>
             <version>2.3.1</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.datadoghq</groupId>
+            <artifactId>java-dogstatsd-client</artifactId>
+            <version>2.10.3</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/web-bundle/src/main/java/com/graphhopper/http/GraphHopperBundle.java
+++ b/web-bundle/src/main/java/com/graphhopper/http/GraphHopperBundle.java
@@ -263,7 +263,7 @@ public class GraphHopperBundle implements ConfiguredBundle<GraphHopperBundleConf
         // Initialize Datadog client
         StatsDClient statsDClient = new NonBlockingStatsDClientBuilder()
                 .prefix("statsd")
-                .hostname("localhost")
+                .hostname(System.getenv("DD_AGENT_HOST"))
                 .port(8125)
                 .build();
 


### PR DESCRIPTION
For load balancing testing/comparisons against GRPC graphhopper. Adds datadog increment counters to HTTP service endpoints so we can observe how load is spread across pods during a run.