### PR TITLE
Fix storage of GTFS route info (remove string parsing bug)

### DIFF
--- a/web-bundle/src/main/java/com/graphhopper/replica/GtfsLinkMapper.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/GtfsLinkMapper.java
@@ -213,7 +213,7 @@ public class GtfsLinkMapper {
         return odStopsForTrip;
     }
 
-    // Returns comma-separated string of agency_name,route_short_name,route_long_name,route_type
+    // Ordered list of strings: agency_name,route_short_name,route_long_name,route_type
     private static List<String> getRouteInfo(Route route, String agencyName) {
         return Lists.newArrayList(agencyName, route.route_short_name, route.route_long_name, "" + route.route_type);
     }

--- a/web-bundle/src/main/java/com/graphhopper/replica/GtfsLinkMapper.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/GtfsLinkMapper.java
@@ -12,18 +12,12 @@ import com.graphhopper.gtfs.GraphHopperGtfs;
 import com.graphhopper.gtfs.GtfsStorage;
 import com.graphhopper.util.details.PathDetail;
 import org.apache.commons.lang3.tuple.Pair;
-import org.mapdb.DB;
-import org.mapdb.DBMaker;
-import org.mapdb.HTreeMap;
-import org.mapdb.Serializer;
+import org.mapdb.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.*;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class GtfsLinkMapper {
@@ -54,10 +48,10 @@ public class GtfsLinkMapper {
                 .valueSerializer(Serializer.STRING)
                 .make();
 
-        HTreeMap<String, String> gtfsRouteInfo = db
+        HTreeMap<String, List<String>> gtfsRouteInfo = db
                 .createHashMap("gtfsRouteInfo")
                 .keySerializer(Serializer.STRING)
-                .valueSerializer(Serializer.STRING)
+                .valueSerializer(Serializer.JAVA)
                 .make();
 
         HTreeMap<String, String> gtfsFeedIdMap = db
@@ -83,11 +77,11 @@ public class GtfsLinkMapper {
             gtfsFeedIdMap.put(feedId, feed.feedId);
 
             // Store route information in db for _every_ route type
-            Map<String, String> routeInfoMap = feed.routes.keySet().stream()
+            Map<String, List<String>> routeInfoMap = feed.routes.keySet().stream()
                     .map(routeId -> feed.routes.get(routeId))
                     .collect(Collectors.toMap(
                             route -> route.route_id,
-                            route -> getRouteInfoString(route, feed.agency.get(route.agency_id).agency_name)
+                            route -> getRouteInfo(route, feed.agency.get(route.agency_id).agency_name)
                     ));
             gtfsRouteInfo.putAll(routeInfoMap);
 
@@ -220,8 +214,8 @@ public class GtfsLinkMapper {
     }
 
     // Returns comma-separated string of agency_name,route_short_name,route_long_name,route_type
-    private static String getRouteInfoString(Route route, String agencyName) {
-        return agencyName + "," + route.route_short_name + "," + route.route_long_name + "," + route.route_type;
+    private static List<String> getRouteInfo(Route route, String agencyName) {
+        return Lists.newArrayList(agencyName, route.route_short_name, route.route_long_name, "" + route.route_type);
     }
 
     // returns all CSV rows (as a list of Strings) derived from a single GTFS feed's data

--- a/web-bundle/src/main/java/com/graphhopper/resources/PtRouteResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/PtRouteResource.java
@@ -37,7 +37,7 @@ public class PtRouteResource {
     private static final Logger logger = LoggerFactory.getLogger(PtRouteResource.class);
     private final PtRouter ptRouter;
     private static Map<String, String> gtfsLinkMappings;
-    private static Map<String, String> gtfsRouteInfo;
+    private static Map<String, List<String>> gtfsRouteInfo;
     private static Map<String, String> gtfsFeedIdMapping;
 
     // Statically load GTFS link mapping and GTFS route info maps for use in building responses
@@ -196,10 +196,10 @@ public class PtRouteResource {
         stableEdgeIdsList.clear();
         stableEdgeIdsList.addAll(stableEdgeIdsWithoutDuplicates);
 
-        // Split comma-separated GTFS route info string of agency_name,route_short_name,route_long_name,route_type
-        String[] routeInfo = gtfsRouteInfo.containsKey(leg.route_id)
-                ? gtfsRouteInfo.get(leg.route_id).split(",")
-                : new String[]{"", "", "", ""};
+        // Ordered list of GTFS route info, containing agency_name, route_short_name, route_long_name, route_type
+        List<String> routeInfo = gtfsRouteInfo.containsKey(leg.route_id)
+                ? gtfsRouteInfo.get(leg.route_id)
+                : Lists.newArrayList("", "", "", "");
 
         if (!gtfsRouteInfo.containsKey(leg.route_id)) {
             logger.info("Failed to find route info for route " + leg.route_id + " for PT trip leg " + leg.toString());
@@ -214,6 +214,7 @@ public class PtRouteResource {
                     stop.plannedDepartureTime, stop.predictedDepartureTime, stop.departureCancelled));
         }
 
-        return new CustomPtLeg(leg, stableEdgeIdsList, updatedStops, routeInfo[0], routeInfo[1], routeInfo[2], routeInfo[3]);
+        return new CustomPtLeg(leg, stableEdgeIdsList, updatedStops,
+                routeInfo.get(0), routeInfo.get(1), routeInfo.get(2), routeInfo.get(3));
     }
 }


### PR DESCRIPTION
Thanks to @michaz , we realized the source of the parsing issue Brett was hitting with a Sacramento GTFS feed, info [here](https://replicahq.slack.com/archives/CK358RL0Z/p1607624380053000). This should fix it (this just modifies the HTTP server, but once merged I'll update the necessary code in the GRPC PR we have up as well).