### PR TITLE
Increase contraction hierarchy preparation threads

### DIFF
--- a/default_gh_config.yaml
+++ b/default_gh_config.yaml
@@ -8,6 +8,7 @@ graphhopper:
   routing.ch.disabling_allowed: true
   routing.max_visited_nodes: 1500000
   graph.flag_encoders: car,bike,foot,truck
+  prepare.ch.threads: 16
 
   # Uncomment this if the export was done with turn-restriction-aware contraction hierarchies
   # prepare.ch.edge_based: edge_and_node


### PR DESCRIPTION
Bumps number of CH preparation threads to 16. Our current gcloud build machines have 32 vcores, but I believe that each separate vehicle profile only uses a single thread for computation (and we only have 5 or 6 profiles), so 16 should be more than enough. The default value was 1 thread.

Tested this on an Illinois graph build and it took the build time from [42:03](https://console.cloud.google.com/cloud-build/builds/21b749d5-43ee-4810-9dd3-ba48aa6b4247?project=model-159019) to [33:06](https://console.cloud.google.com/cloud-build/builds/68e1baf0-c156-4055-9fe8-1b2dce3056e3?project=model-159019).