### PR TITLE
Integrate recent bug fixes; move idls to exact model repo commit

### DIFF
--- a/grpc/src/main/java/RouterServer.java
+++ b/grpc/src/main/java/RouterServer.java
@@ -76,15 +76,17 @@ public class RouterServer {
         // Create matrix API instance
         MatrixAPI matrixAPI = new GHMatrixAPI(graphHopper, graphHopperConfiguration);
 
-        // Load GTFS link mapping and GTFS route info maps for use in building responses
+        // Load GTFS link mapping and GTFS info maps for use in building responses
         Map<String, String> gtfsLinkMappings = null;
         Map<String, List<String>> gtfsRouteInfo = null;
+        Map<String, String> gtfsFeedIdMapping = null;
 
         File linkMappingsDbFile = new File("transit_data/gtfs_link_mappings.db");
         if (linkMappingsDbFile.exists()) {
             DB db = DBMaker.newFileDB(linkMappingsDbFile).make();
             gtfsLinkMappings = db.getHashMap("gtfsLinkMappings");
             gtfsRouteInfo = db.getHashMap("gtfsRouteInfo");
+            gtfsFeedIdMapping = db.getHashMap("gtfsFeedIdMap");
             logger.info("Done loading GTFS link mappings and route info. Total number of mappings: " + gtfsLinkMappings.size());
         } else {
             logger.info("No GTFS link mapping mapdb file found! Skipped loading GTFS link mappings.");
@@ -102,7 +104,7 @@ public class RouterServer {
 
         // Start server
         server = NettyServerBuilder.forPort(50051)
-                .addService(new RouterImpl(graphHopper, ptRouter, matrixAPI, gtfsLinkMappings, gtfsRouteInfo))
+                .addService(new RouterImpl(graphHopper, ptRouter, matrixAPI, gtfsLinkMappings, gtfsRouteInfo, gtfsFeedIdMapping))
                 .addService(ProtoReflectionService.newInstance())
                 .maxConnectionAge(10, TimeUnit.SECONDS)
                 .maxConnectionAgeGrace(10, TimeUnit.SECONDS)

--- a/web-bundle/src/main/java/com/graphhopper/replica/GtfsLinkMapper.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/GtfsLinkMapper.java
@@ -80,7 +80,7 @@ public class GtfsLinkMapper {
             Map<String, List<String>> routeInfoMap = feed.routes.keySet().stream()
                     .map(routeId -> feed.routes.get(routeId))
                     .collect(Collectors.toMap(
-                            route -> route.route_id,
+                            route -> feedId + ":" + route.route_id,
                             route -> getRouteInfo(route, feed.agency.get(route.agency_id).agency_name)
                     ));
             gtfsRouteInfo.putAll(routeInfoMap);

--- a/web-bundle/src/main/java/com/graphhopper/resources/PtRouteResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/PtRouteResource.java
@@ -197,11 +197,11 @@ public class PtRouteResource {
         stableEdgeIdsList.addAll(stableEdgeIdsWithoutDuplicates);
 
         // Ordered list of GTFS route info, containing agency_name, route_short_name, route_long_name, route_type
-        List<String> routeInfo = gtfsRouteInfo.containsKey(leg.route_id)
-                ? gtfsRouteInfo.get(leg.route_id)
+        List<String> routeInfo = gtfsRouteInfo.containsKey(gtfsRouteInfoKey(leg))
+                ? gtfsRouteInfo.get(gtfsRouteInfoKey(leg))
                 : Lists.newArrayList("", "", "", "");
 
-        if (!gtfsRouteInfo.containsKey(leg.route_id)) {
+        if (!gtfsRouteInfo.containsKey(gtfsRouteInfoKey(leg))) {
             logger.info("Failed to find route info for route " + leg.route_id + " for PT trip leg " + leg.toString());
         }
 
@@ -216,5 +216,9 @@ public class PtRouteResource {
 
         return new CustomPtLeg(leg, stableEdgeIdsList, updatedStops,
                 routeInfo.get(0), routeInfo.get(1), routeInfo.get(2), routeInfo.get(3));
+    }
+
+    private static String gtfsRouteInfoKey(Trip.PtLeg leg) {
+        return leg.feed_id + ":" + leg.route_id;
     }
 }


### PR DESCRIPTION
As title states, our GH master branch (`original-direction`) has gotten a little out of sync with the base image we're using in the model repo. This gets GH master synced up with that base image. The main changes:
- switch idls back to the exact commit currently used in model repo. The current GH base image we use is on commit `95c8eba`; model repo is on `8e5403b`. The only difference between the two is that `95c8eba` has the polyline string removed from street routing responses, and `8e5403b` still includes it, but this change doesn't matter, because 1) the server isn't populating this field anyway, and 2) the client never makes use of this field (hence why we're using a GH image on `95c8eba` without issue)
- adds in recent "hotfixes" made recently that 1) add the GTFS feed ID to stop names returned in PT requests, and 2) fixes a bug discovered Friday that caused certain agency name/route long/short names/etc to be stored improperly (messing up info in certain PT responses). 

The reason the base image hasn't been synced w/ GH master recently is that the original GRPC base image we used was from commit `55d13ed` in the big [GRPC PR](https://github.com/replicahq/graphhopper/pull/26), but a few minor tweaks (none of which change behavior at all, just refactoring) were committed there after `55d13ed` before the PR was merged. Therefore, I've been adding the hotfixes mentioned above directly off of commit `55d13ed` (see last few commits on [this](https://github.com/replicahq/graphhopper/compare/master...replicahq:mega_router_v2.2_hotfix) branch, which includes these hotfixes; commit `b9fdab7` is the current most up-to-date base image we're using, `mega_router_v2.2_pt_fix`). All that this current PR does is take those new commits, and pastes them on top of our GH master branch. 