### PR TITLE
RAD-1447: Fix street names and highway tags, use proper CSV lib in street export

### DIFF
--- a/replica-common/src/main/java/com/graphhopper/export/CustomGraphHopperGtfs.java
+++ b/replica-common/src/main/java/com/graphhopper/export/CustomGraphHopperGtfs.java
@@ -115,7 +115,7 @@ public class CustomGraphHopperGtfs extends GraphHopperGtfs {
                     }
 
                     // Parse highway tag from Way, if it's present
-                    String highway = getHighwayFromOsmElement(ghReaderWay);
+                    String highway = getHighwayFromOsmWay(ghReaderWay);
                     if (highway != null) {
                         osmIdToHighwayTag.put(osmId, highway);
                     }
@@ -173,14 +173,6 @@ public class CustomGraphHopperGtfs extends GraphHopperGtfs {
                                     osmIdToStreetName.put(member.getRef(), streetName);
                                 }
                             }
-                            // If we haven't recorded a highway tag for a Way in this Relation,
-                            // use the Relation's highway tag instead, if it exists
-                            if (!osmIdToHighwayTag.containsKey(member.getRef())) {
-                                String highway = getHighwayFromOsmElement(relation);
-                                if (highway != null) {
-                                    osmIdToHighwayTag.put(member.getRef(), highway);
-                                }
-                            }
                         }
                     }
                 }
@@ -191,9 +183,9 @@ public class CustomGraphHopperGtfs extends GraphHopperGtfs {
         }
     }
 
-    private static String getHighwayFromOsmElement(ReaderElement wayOrRelation) {
-        if (wayOrRelation.hasTag("highway")) {
-            return wayOrRelation.getTag("highway");
+    private static String getHighwayFromOsmWay(ReaderWay way) {
+        if (way.hasTag("highway")) {
+            return way.getTag("highway");
         } else {
             return null;
         }

--- a/replica-common/src/main/java/com/graphhopper/export/CustomGraphHopperGtfs.java
+++ b/replica-common/src/main/java/com/graphhopper/export/CustomGraphHopperGtfs.java
@@ -7,6 +7,7 @@ import com.graphhopper.GraphHopperConfig;
 import com.graphhopper.gtfs.GraphHopperGtfs;
 import com.graphhopper.reader.DataReader;
 import com.graphhopper.reader.ReaderElement;
+import com.graphhopper.reader.ReaderRelation;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.reader.osm.OSMInput;
 import com.graphhopper.reader.osm.OSMInputFile;
@@ -46,6 +47,10 @@ public class CustomGraphHopperGtfs extends GraphHopperGtfs {
     // Map of OSM way ID to access flags for each edge direction (each created from set
     // {ALLOWS_CAR, ALLOWS_BIKE, ALLOWS_PEDESTRIAN}), stored in list in order [forward, backward]
     private Map<Long, List<String>> osmIdToAccessFlags;
+    // Map of OSM way ID to street name. Name is parsed directly from Way, unless name field isn't present,
+    // in which case the name is taken from the Relation containing the Way, if one exists
+    private Map<Long, String> osmIdToStreetName;
+
 
     public CustomGraphHopperGtfs(GraphHopperConfig ghConfig) {
         super(ghConfig);
@@ -53,6 +58,7 @@ public class CustomGraphHopperGtfs extends GraphHopperGtfs {
         this.osmIdToLaneTags = Maps.newHashMap();
         this.ghIdToOsmId = Maps.newHashMap();
         this.osmIdToAccessFlags = Maps.newHashMap();
+        this.osmIdToStreetName = Maps.newHashMap();
     }
 
     @Override
@@ -85,7 +91,8 @@ public class CustomGraphHopperGtfs extends GraphHopperGtfs {
     }
 
     public void collectOsmInfo() {
-        LOG.info("Creating custom OSM reader; reading file and parsing lane tag info.");
+        LOG.info("Creating custom OSM reader; reading file and parsing lane tag and street name info.");
+        List<ReaderRelation> roadRelations = Lists.newArrayList();
         int readCount = 0;
         try (OSMInput input = new OSMInputFile(new File(osmPath)).setWorkerThreads(2).open()) {
             TraversalPermissionLabeler flagLabeler = new USTraversalPermissionLabeler();
@@ -97,6 +104,11 @@ public class CustomGraphHopperGtfs extends GraphHopperGtfs {
                     }
                     final ReaderWay ghReaderWay = (ReaderWay) next;
                     long osmId = ghReaderWay.getId();
+
+                    String wayName = getNameFromOsmElement(ghReaderWay);
+                    if (wayName != null) {
+                        osmIdToStreetName.put(osmId, wayName);
+                    }
 
                     // Parse all tags needed for determining lane counts on edge
                     for (String laneTag : LANE_TAGS) {
@@ -126,11 +138,48 @@ public class CustomGraphHopperGtfs extends GraphHopperGtfs {
                     List<EnumSet<TraversalPermissionLabeler.EdgeFlag>> flags = flagLabeler.getPermissions(way);
                     List<String> flagStrings = Lists.newArrayList(flags.get(0).toString(), flags.get(1).toString());
                     osmIdToAccessFlags.put(ghReaderWay.getId(), flagStrings);
+                } else if (next.isType(ReaderElement.RELATION)) {
+                    if (next.hasTag("route", "road")) {
+                        roadRelations.add((ReaderRelation) next);
+                    }
                 }
             }
             LOG.info("Finished parsing lane tag info from OSM ways. " + readCount + " total ways were parsed.");
+
+            readCount = 0;
+            LOG.info("Scanning road relations to populate street names for Ways that didn't have them set.");
+            for (ReaderRelation relation : roadRelations) {
+                if (relation.hasTag("route", "road")) {
+                    if (++readCount % 1000 == 0) {
+                        LOG.info("Parsing tag info from OSM relations. " + readCount + " read so far.");
+                    }
+                    for (ReaderRelation.Member member : relation.getMembers()) {
+                        if (member.getType() == ReaderRelation.Member.WAY) {
+                            // If we haven't recorded a street name for a Way in this Relation,
+                            // use the Relation's name instead, if it exists
+                            if (!osmIdToStreetName.containsKey(member.getRef())) {
+                                String streetName = getNameFromOsmElement(relation);
+                                if (streetName != null) {
+                                    osmIdToStreetName.put(member.getRef(), streetName);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            LOG.info("Finished scanning road relations for additional street names. " + readCount + " total relations were considered.");
         } catch (Exception e) {
             throw new RuntimeException("Can't open OSM file provided at " + osmPath + "!");
+        }
+    }
+
+    private static String getNameFromOsmElement(ReaderElement wayOrRelation) {
+        if (wayOrRelation.hasTag("name")) {
+            return wayOrRelation.getTag("name");
+        } else if (wayOrRelation.hasTag("ref")) {
+            return wayOrRelation.getTag("ref");
+        } else {
+            return null;
         }
     }
 
@@ -144,5 +193,9 @@ public class CustomGraphHopperGtfs extends GraphHopperGtfs {
 
     public Map<Long, List<String>> getOsmIdToAccessFlags() {
         return osmIdToAccessFlags;
+    }
+
+    public Map<Long, String> getOsmIdToStreetName() {
+        return osmIdToStreetName;
     }
 }

--- a/web-bundle/src/main/java/com/graphhopper/replica/OsmHelper.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/OsmHelper.java
@@ -37,9 +37,16 @@ public class OsmHelper {
                 .valueSerializer(Serializer.JAVA)
                 .make();
 
+        HTreeMap<Long, String> osmIdToStreetName = db
+                .createHashMap("osmIdToStreetName")
+                .keySerializer(Serializer.LONG)
+                .valueSerializer(Serializer.STRING)
+                .make();
+
         osmIdToLaneTags.putAll(graphHopperGtfs.getOsmIdToLaneTags());
         ghIdToOsmId.putAll(graphHopperGtfs.getGhIdToOsmId());
         osmIdToAccessFlags.putAll(graphHopperGtfs.getOsmIdToAccessFlags());
+        osmIdToStreetName.putAll(graphHopperGtfs.getOsmIdToStreetName());
 
         db.commit();
         db.close();

--- a/web-bundle/src/main/java/com/graphhopper/replica/OsmHelper.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/OsmHelper.java
@@ -43,10 +43,17 @@ public class OsmHelper {
                 .valueSerializer(Serializer.STRING)
                 .make();
 
+        HTreeMap<Long, String> osmIdToHighway = db
+                .createHashMap("osmIdToHighway")
+                .keySerializer(Serializer.LONG)
+                .valueSerializer(Serializer.STRING)
+                .make();
+
         osmIdToLaneTags.putAll(graphHopperGtfs.getOsmIdToLaneTags());
         ghIdToOsmId.putAll(graphHopperGtfs.getGhIdToOsmId());
         osmIdToAccessFlags.putAll(graphHopperGtfs.getOsmIdToAccessFlags());
         osmIdToStreetName.putAll(graphHopperGtfs.getOsmIdToStreetName());
+        osmIdToHighway.putAll(graphHopperGtfs.getOsmIdToHighwayTag());
 
         db.commit();
         db.close();

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -18,6 +18,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-csv</artifactId>
+            <version>1.4</version>
+        </dependency>
+        <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-core</artifactId>
             <version>2.0.8</version>

--- a/web/src/main/java/com/graphhopper/http/cli/ExportCommand.java
+++ b/web/src/main/java/com/graphhopper/http/cli/ExportCommand.java
@@ -127,10 +127,6 @@ public class ExportCommand extends ConfiguredCommand<GraphHopperServerConfigurat
                     // Get edge geometry and distance
                     PointList wayGeometry = edgeIterator.fetchWayGeometry(FetchMode.ALL);
                     String geometryString = wayGeometry.toLineString(false).toString();
-
-                    //todo : which distance calc to use?
-                    // edgeIterator.getDistance();
-                    // DistanceCalcEarth.DIST_EARTH.calcDist(startLat, startLon, endLat, endLon);
                     long distanceMeters = Math.round(DistanceCalcEarth.DIST_EARTH.calcDist(startLat, startLon, endLat, endLon));
 
                     // Convert GH's km/h speed to cm/s to match R5's implementation

--- a/web/src/main/java/com/graphhopper/http/cli/ExportCommand.java
+++ b/web/src/main/java/com/graphhopper/http/cli/ExportCommand.java
@@ -20,6 +20,8 @@ import com.graphhopper.util.PointList;
 import io.dropwizard.cli.ConfiguredCommand;
 import io.dropwizard.setup.Bootstrap;
 import net.sourceforge.argparse4j.inf.Namespace;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
 import org.mapdb.DB;
 import org.mapdb.DBMaker;
 import org.slf4j.Logger;
@@ -47,9 +49,8 @@ public class ExportCommand extends ConfiguredCommand<GraphHopperServerConfigurat
     private static final Logger logger = LoggerFactory.getLogger(ExportCommand.class);
 
     private static final List<String> HIGHWAY_FILTER_TAGS = Lists.newArrayList("bridleway", "steps");
-    private static final String COLUMN_HEADERS = "\"stableEdgeId\",\"startVertex\",\"endVertex\"," +
-            "\"startLat\",\"startLon\",\"endLat\",\"endLon\",\"geometry\",\"streetName\",\"distance\",\"osmid\"," +
-            "\"speed\",\"flags\",\"lanes\",\"highway\"";
+    private static final String[] COLUMN_HEADERS = {"stableEdgeId", "startVertex", "endVertex", "startLat", "startLon",
+            "endLat", "endLon", "geometry", "streetName", "distance", "osmid", "speed", "flags", "lanes", "highway"};
 
     public ExportCommand() {
         super("export", "Generates street network CSV file from a GH graph");
@@ -102,125 +103,113 @@ public class ExportCommand extends ConfiguredCommand<GraphHopperServerConfigurat
         CarFlagEncoder carFlagEncoder = (CarFlagEncoder)encodingManager.getEncoder("car");
         DecimalEncodedValue avgSpeedEnc = carFlagEncoder.getAverageSpeedEnc();
 
-        File outputFile = new File(configuredGraphHopper.getGraphHopperLocation() + "/street_edges.csv");
-
         logger.info("Writing street edges...");
-        OutputStream outputStream;
-        try {
-            outputStream = new BufferedOutputStream(new FileOutputStream(outputFile));
-        } catch (FileNotFoundException e) {
-            throw new RuntimeException(e);
-        }
-        PrintStream printStream = new PrintStream(outputStream);
-        printStream.println(COLUMN_HEADERS);
+        File outputFile = new File(configuredGraphHopper.getGraphHopperLocation() + "/street_edges.csv");
 
         // For each bidirectional edge in pre-built graph, calculate value of each CSV column
         // and export new line for each edge direction
         int totalEdgeCount = 0;
         int skippedEdgeCount = 0;
-        while (edgeIterator.next()) {
-            totalEdgeCount++;
-            // Fetch starting and ending vertices
-            int ghEdgeId = edgeIterator.getEdge();
-            int startVertex = edgeIterator.getBaseNode();
-            int endVertex = edgeIterator.getAdjNode();
-            double startLat = nodes.getLat(startVertex);
-            double startLon = nodes.getLon(startVertex);
-            double endLat = nodes.getLat(endVertex);
-            double endLon = nodes.getLon(endVertex);
+        try {
+            FileWriter out = new FileWriter(outputFile);
+            try (CSVPrinter printer = new CSVPrinter(out, CSVFormat.DEFAULT.withHeader(COLUMN_HEADERS))) {
+                while (edgeIterator.next()) {
+                    totalEdgeCount++;
+                    // Fetch starting and ending vertices
+                    int ghEdgeId = edgeIterator.getEdge();
+                    int startVertex = edgeIterator.getBaseNode();
+                    int endVertex = edgeIterator.getAdjNode();
+                    double startLat = nodes.getLat(startVertex);
+                    double startLon = nodes.getLon(startVertex);
+                    double endLat = nodes.getLat(endVertex);
+                    double endLon = nodes.getLon(endVertex);
 
-            // Get edge geometry and distance
-            PointList wayGeometry = edgeIterator.fetchWayGeometry(FetchMode.ALL);
-            String geometryString = wayGeometry.toLineString(false).toString();
+                    // Get edge geometry and distance
+                    PointList wayGeometry = edgeIterator.fetchWayGeometry(FetchMode.ALL);
+                    String geometryString = wayGeometry.toLineString(false).toString();
 
-            //todo : which distance calc to use?
-            // edgeIterator.getDistance();
-            // DistanceCalcEarth.DIST_EARTH.calcDist(startLat, startLon, endLat, endLon);
-            long distanceMeters = Math.round(DistanceCalcEarth.DIST_EARTH.calcDist(startLat, startLon, endLat, endLon));
+                    //todo : which distance calc to use?
+                    // edgeIterator.getDistance();
+                    // DistanceCalcEarth.DIST_EARTH.calcDist(startLat, startLon, endLat, endLon);
+                    long distanceMeters = Math.round(DistanceCalcEarth.DIST_EARTH.calcDist(startLat, startLon, endLat, endLon));
 
-            // Convert GH's km/h speed to cm/s to match R5's implementation
-            int speedcms = (int) (edgeIterator.get(avgSpeedEnc) / 3.6 * 100);
+                    // Convert GH's km/h speed to cm/s to match R5's implementation
+                    int speedcms = (int) (edgeIterator.get(avgSpeedEnc) / 3.6 * 100);
 
-            // Convert GH's distance in meters to millimeters to match R5's implementation
-            long distanceMillimeters = distanceMeters * 1000;
+                    // Convert GH's distance in meters to millimeters to match R5's implementation
+                    long distanceMillimeters = distanceMeters * 1000;
 
-            // Fetch OSM ID, skipping edges from PT meta-graph that have no IDs set (getOsmIdForGhEdge returns -1)
-            long osmId = OsmHelper.getOsmIdForGhEdge(edgeIterator.getEdge(), ghIdToOsmId);
-            if (osmId == -1L) {
-                skippedEdgeCount++;
-                continue;
-            }
+                    // Fetch OSM ID, skipping edges from PT meta-graph that have no IDs set (getOsmIdForGhEdge returns -1)
+                    long osmId = OsmHelper.getOsmIdForGhEdge(edgeIterator.getEdge(), ghIdToOsmId);
+                    if (osmId == -1L) {
+                        skippedEdgeCount++;
+                        continue;
+                    }
 
-            // Use street name parsed from Ways/Relations, if it exists; otherwise, use default GH edge name
-            String streetName = osmIdToStreetName.getOrDefault(osmId, edgeIterator.getName());
+                    // Use street name parsed from Ways/Relations, if it exists; otherwise, use default GH edge name
+                    String streetName = osmIdToStreetName.getOrDefault(osmId, edgeIterator.getName());
 
-            // Grab OSM highway type and encoded stable IDs for both edge directions
-            String highwayTag = osmIdToHighway.getOrDefault(osmId, edgeIterator.get(roadClassEnc).toString());
-            String forwardStableEdgeId = stableIdEncodedValues.getStableId(false, edgeIterator);
-            String backwardStableEdgeId = stableIdEncodedValues.getStableId(true, edgeIterator);
+                    // Grab OSM highway type and encoded stable IDs for both edge directions
+                    String highwayTag = osmIdToHighway.getOrDefault(osmId, edgeIterator.get(roadClassEnc).toString());
+                    String forwardStableEdgeId = stableIdEncodedValues.getStableId(false, edgeIterator);
+                    String backwardStableEdgeId = stableIdEncodedValues.getStableId(true, edgeIterator);
 
-            // Set accessibility flags for each edge direction
-            // Returned flags are from the set {ALLOWS_CAR, ALLOWS_BIKE, ALLOWS_PEDESTRIAN}
-            String forwardFlags = OsmHelper.getFlagsForGhEdge(ghEdgeId, false, osmIdToAccessFlags, ghIdToOsmId);
-            String backwardFlags = OsmHelper.getFlagsForGhEdge(ghEdgeId, true, osmIdToAccessFlags, ghIdToOsmId);
+                    // Set accessibility flags for each edge direction
+                    // Returned flags are from the set {ALLOWS_CAR, ALLOWS_BIKE, ALLOWS_PEDESTRIAN}
+                    String forwardFlags = OsmHelper.getFlagsForGhEdge(ghEdgeId, false, osmIdToAccessFlags, ghIdToOsmId);
+                    String backwardFlags = OsmHelper.getFlagsForGhEdge(ghEdgeId, true, osmIdToAccessFlags, ghIdToOsmId);
 
-            // Calculate number of lanes for edge, as done in R5, based on OSM tags + edge direction
-            int overallLanes = parseLanesTag(osmId, osmIdToLaneTags, "lanes");
-            int forwardLanes = parseLanesTag(osmId, osmIdToLaneTags, "lanes:forward");
-            int backwardLanes = parseLanesTag(osmId, osmIdToLaneTags, "lanes:backward");
+                    // Calculate number of lanes for edge, as done in R5, based on OSM tags + edge direction
+                    int overallLanes = parseLanesTag(osmId, osmIdToLaneTags, "lanes");
+                    int forwardLanes = parseLanesTag(osmId, osmIdToLaneTags, "lanes:forward");
+                    int backwardLanes = parseLanesTag(osmId, osmIdToLaneTags, "lanes:backward");
 
-            if (!backwardFlags.contains("ALLOWS_CAR")) {
-                backwardLanes = 0;
-            }
-            if (backwardLanes == -1) {
-                if (overallLanes != -1) {
-                    if (forwardLanes != -1) {
-                        backwardLanes = overallLanes - forwardLanes;
+                    if (!backwardFlags.contains("ALLOWS_CAR")) {
+                        backwardLanes = 0;
+                    }
+                    if (backwardLanes == -1) {
+                        if (overallLanes != -1) {
+                            if (forwardLanes != -1) {
+                                backwardLanes = overallLanes - forwardLanes;
+                            }
+                        }
+                    }
+
+                    if (!forwardFlags.contains("ALLOWS_CAR")) {
+                        forwardLanes = 0;
+                    }
+                    if (forwardLanes == -1) {
+                        if (overallLanes != -1) {
+                            if (backwardLanes != -1) {
+                                forwardLanes = overallLanes - backwardLanes;
+                            } else if (forwardFlags.contains("ALLOWS_CAR")) {
+                                forwardLanes = overallLanes / 2;
+                            }
+                        }
+                    }
+
+                    // Copy R5's logic; filter out edges with unwanted highway tags and negative OSM IDs
+                    // todo: do negative OSM ids happen in GH? This might have been R5-specific
+                    if (!HIGHWAY_FILTER_TAGS.contains(highwayTag) && osmId >= 0) {
+                        // Print line for each edge direction
+                        printer.printRecord(forwardStableEdgeId, startVertex, endVertex,
+                                startLat, startLon, endLat, endLon, geometryString, streetName,
+                                distanceMillimeters, osmId, speedcms, forwardFlags, forwardLanes, highwayTag);
+                        printer.printRecord(backwardStableEdgeId, endVertex, startVertex,
+                                endLat, endLon, startLat, startLon, geometryString, streetName,
+                                distanceMillimeters, osmId, speedcms, backwardFlags, backwardLanes, highwayTag);
                     }
                 }
             }
-
-            if (!forwardFlags.contains("ALLOWS_CAR")) {
-                forwardLanes = 0;
-            }
-            if (forwardLanes == -1) {
-                if (overallLanes != -1) {
-                    if (backwardLanes != -1) {
-                        forwardLanes = overallLanes - backwardLanes;
-                    } else if (forwardFlags.contains("ALLOWS_CAR")) {
-                        forwardLanes = overallLanes / 2;
-                    }
-                }
-            }
-
-            // Copy R5's logic; filter out edges with unwanted highway tags and negative OSM IDs
-            // todo: do negative OSM ids happen in GH? This might have been R5-specific
-            if (!HIGHWAY_FILTER_TAGS.contains(highwayTag) && osmId >= 0) {
-                // Print line for each edge direction
-                printStream.println(toString(forwardStableEdgeId, startVertex, endVertex,
-                        startLat, startLon, endLat, endLon, geometryString, streetName,
-                        distanceMillimeters, osmId, speedcms, forwardFlags, forwardLanes, highwayTag));
-                printStream.println(toString(backwardStableEdgeId, endVertex, startVertex,
-                        endLat, endLon, startLat, startLon, geometryString, streetName,
-                        distanceMillimeters, osmId, speedcms, backwardFlags, backwardLanes, highwayTag));
-            }
+        } catch (IOException e) {
+            logger.error("IOException raised while writing street network to csv!");
+            throw new RuntimeException(e);
         }
-
-        printStream.close();
         logger.info("Done writing street network to CSV");
         logger.info("A total of " + totalEdgeCount + " edges were considered; " + skippedEdgeCount + " edges were skipped");
         if (!outputFile.exists()) {
             logger.error("Output file can't be found! Export may not have completed successfully");
         }
-    }
-
-    private static String toString(String stableEdgeId, int startVertex, int endVertex, double startLat,
-                                   double startLon, double endLat, double endLon, String geometry, String streetName,
-                                   long distance, long osmId, int speed, String flags, int lanes, String highway) {
-        return String.format("\"%s\",%d,%d,%f,%f,%f,%f,\"%s\",\"%s\",%d,%d,%d,\"%s\",%d,\"%s\"",
-                stableEdgeId, startVertex, endVertex, startLat, startLon, endLat, endLon, geometry,
-                streetName, distance, osmId, speed, flags, lanes, highway
-        );
     }
 
     // Taken from R5's lane parsing logic. See EdgeServiceServer.java in R5 repo


### PR DESCRIPTION
-Fixes missing street names by parsing them from OSM ways/relations, just as[ was done in R5](https://github.com/replicahq/model-r5/commit/b50b709c7b93c557c243013f7441e7c9937ebf42)
-Fixes messed up highway tags (no `motorway_link`s, for example) by parsing this info directly from OSM + including it in export
-uses apache's CSV lib for export, instead of manually writing each line w/ java

Explanation of the change:
To get street names tags, we check each osm way to see if it has a "name" tag, using the "ref" tag as [backup](https://wiki.openstreetmap.org/wiki/Key:ref), storing this info in a map containing (osm ID) -> (street name). For any osm IDs (ie, ways) where we don't have a street name recorded after this, we check the osm relation that contains that way, and see if the relation has a "name" or "ref" tag, and use that if it does.

The process is analogous for parsing highway tags, and is logically identical to how @michaz had set things up in R5 (linked above).