### PR TITLE
Fix an NPE

### DIFF
--- a/grpc/src/main/java/RouterImpl.java
+++ b/grpc/src/main/java/RouterImpl.java
@@ -319,8 +319,8 @@ public class RouterImpl extends router.RouterGrpc.RouterImplBase {
                                     .setTripId(leg.trip_id)
                                     .setRouteId(leg.route_id)
                                     .setAgencyName(leg.agencyName)
-                                    .setRouteShortName(leg.routeShortName != null ? leg.routeShortName : "")
-                                    .setRouteLongName(leg.routeLongName != null ? leg.routeLongName : "")
+                                    .setRouteShortName(leg.routeShortName)
+                                    .setRouteLongName(leg.routeLongName)
                                     .setRouteType(leg.routeType)
                                     .setDirection(leg.trip_headsign)
                                     .addAllStops(leg.stops.stream().map(stop -> Stop.newBuilder()
@@ -361,7 +361,7 @@ public class RouterImpl extends router.RouterGrpc.RouterImplBase {
                     .build();
             responseObserver.onError(StatusProto.toStatusRuntimeException(status));
         } catch (Exception e) {
-            logger.error("ERRRRRRRROR! ", e);
+            logger.error("GraphHopper internal error! ", e);
             Status status = Status.newBuilder()
                     .setCode(Code.INTERNAL.getNumber())
                     .setMessage("GH internal error! Path could not be found between " + fromPoint.getLat() + "," +
@@ -433,6 +433,9 @@ public class RouterImpl extends router.RouterGrpc.RouterImplBase {
 
         // Ordered list of GTFS route info, containing agency_name, route_short_name, route_long_name, route_type
         List<String> routeInfo = gtfsRouteInfo.getOrDefault(gtfsRouteInfoKey(leg), Lists.newArrayList("", "", "", ""));
+
+        // Convert any missing info to empty string to prevent NPE
+        routeInfo = routeInfo.stream().map(info -> info == null ? "" : info).collect(toList());
 
         if (!gtfsRouteInfo.containsKey(gtfsRouteInfoKey(leg))) {
             logger.info("Failed to find route info for route " + leg.route_id + " for PT trip leg " + leg.toString());

--- a/grpc/src/main/java/RouterImpl.java
+++ b/grpc/src/main/java/RouterImpl.java
@@ -319,8 +319,8 @@ public class RouterImpl extends router.RouterGrpc.RouterImplBase {
                                     .setTripId(leg.trip_id)
                                     .setRouteId(leg.route_id)
                                     .setAgencyName(leg.agencyName)
-                                    .setRouteShortName(leg.routeShortName)
-                                    .setRouteLongName(leg.routeLongName)
+                                    .setRouteShortName(leg.routeShortName != null ? leg.routeShortName : "")
+                                    .setRouteLongName(leg.routeLongName != null ? leg.routeLongName : "")
                                     .setRouteType(leg.routeType)
                                     .setDirection(leg.trip_headsign)
                                     .addAllStops(leg.stops.stream().map(stop -> Stop.newBuilder()
@@ -361,7 +361,7 @@ public class RouterImpl extends router.RouterGrpc.RouterImplBase {
                     .build();
             responseObserver.onError(StatusProto.toStatusRuntimeException(status));
         } catch (Exception e) {
-            logger.error("ERRRRRRRROR! " + e.getMessage());
+            logger.error("ERRRRRRRROR! ", e);
             Status status = Status.newBuilder()
                     .setCode(Code.INTERNAL.getNumber())
                     .setMessage("GH internal error! Path could not be found between " + fromPoint.getLat() + "," +


### PR DESCRIPTION
This fixes an occasional NullPointerException I encountered while working on integrating the PT GUI (coming up).

route.shortName and route.longName are, as far as GTFS is concerned, optional. Only one of them has to be set. In the proto definition, however, both are currently required, so setting a null value here raises an NPE. I replaced it with an empty string for the time being.

I also changed the error logging so we get a complete stack trace (for debugging).

Not sure what happens to erroring requests downstream -- perhaps this is a source of missing transit routes?