### PR TITLE
Correctly reverse linestring for reverse edges in export; don't export non-accessible edges

### DIFF
--- a/replica-common/src/main/java/com/graphhopper/export/TraversalPermissionLabeler.java
+++ b/replica-common/src/main/java/com/graphhopper/export/TraversalPermissionLabeler.java
@@ -66,7 +66,7 @@ public abstract class TraversalPermissionLabeler {
         validHighwayTagsConst.put("corridor", false); //Apparently indoor hallway
         validHighwayTags = Collections.unmodifiableMap(validHighwayTagsConst);
 
-        addPermissions("motorway", "access=yes;bicycle=no;foot=no");
+        addPermissions("motorway", "access=yes;access=customers;bicycle=no;foot=no");
         addPermissions("trunk|primary|secondary|tertiary|unclassified|residential|living_street|road|service|track", "access=yes");
         addPermissions("pedestrian", "access=no;foot=yes");
         addPermissions("path", "access=no;foot=yes;bicycle=yes");

--- a/replica-common/src/main/java/com/graphhopper/export/TraversalPermissionLabeler.java
+++ b/replica-common/src/main/java/com/graphhopper/export/TraversalPermissionLabeler.java
@@ -66,7 +66,7 @@ public abstract class TraversalPermissionLabeler {
         validHighwayTagsConst.put("corridor", false); //Apparently indoor hallway
         validHighwayTags = Collections.unmodifiableMap(validHighwayTagsConst);
 
-        addPermissions("motorway", "access=yes;access=customers;bicycle=no;foot=no");
+        addPermissions("motorway", "access=yes;bicycle=no;foot=no");
         addPermissions("trunk|primary|secondary|tertiary|unclassified|residential|living_street|road|service|track", "access=yes");
         addPermissions("pedestrian", "access=no;foot=yes");
         addPermissions("path", "access=no;foot=yes;bicycle=yes");
@@ -476,11 +476,9 @@ public abstract class TraversalPermissionLabeler {
 
         private static boolean isNoThruTraffic(String access) {
             return  "destination".equals(access)
-                    || "customers".equals(access) || "delivery".equals(access)
-                    || "forestry".equals(access)  || "agricultural".equals(access)
-                    || "residents".equals(access) || "resident".equals(access)
-                    || "customer".equals(access)
-                    || "private".equals(access) ;
+                    || "delivery".equals(access) || "forestry".equals(access)
+                    || "agricultural".equals(access) || "residents".equals(access)
+                    || "resident".equals(access) || "private".equals(access) ;
         }
 
         public static Label fromTag (String tag) {
@@ -502,6 +500,8 @@ public abstract class TraversalPermissionLabeler {
                     || "share_busway".equals(tag)
                     //cycleway=crossing it should already have bicycle=yes from highway=cycleway or bicycle=yes
                     || "crossing".equals(tag)
+                    // express lanes/service ways/etc accessible only by paying customers
+                    || "customers".equals(tag) || "customer".equals(tag)
             ) {
                 return YES;
             } else if (isTagFalse(tag) || tag.equals("license")

--- a/replica-common/src/main/java/com/graphhopper/export/TraversalPermissionLabeler.java
+++ b/replica-common/src/main/java/com/graphhopper/export/TraversalPermissionLabeler.java
@@ -109,6 +109,10 @@ public abstract class TraversalPermissionLabeler {
 
         applyDirectionalPermissions(way, forward, backward);
 
+        // Override access being disallowed for motorways+motorway_links with access=customers
+        // Wrong-way oneway motorway links marked as ALLOWS_CARS here will be fixed in oneway checks below
+        applyCustomerMotorwayPermissions(way, forward, backward);
+
         // check for one-way streets. Note that leaf nodes will always be labeled and there is no unknown,
         // so we need not traverse the tree
         EnumMap<Node, OneWay> dir = getDirectionalTree(way);
@@ -137,6 +141,22 @@ public abstract class TraversalPermissionLabeler {
         }
 
         return Lists.newArrayList(forward, backward);
+    }
+
+    // For any links with highway type "motorway" or "motorway_link", and an access tag of "customers"
+    // (or "customer", which is a common mistake in OSM), we want to assign an ALLOWS_CARS access flag,
+    // so the links won't be removed during the export step when we deal with wrong-way oneway highway links;
+    // Links matching this description include toll lanes on major highways, which we do not want removed.
+    private void applyCustomerMotorwayPermissions(Way way, EnumSet<EdgeFlag> forward, EnumSet<EdgeFlag> backward) {
+        for (String highway : new String[]{"motorway", "motorway_link"}) {
+            for (String accessTag : new String[]{"customer", "customers"}) {
+                if (way.hasTag("highway", highway) && way.hasTag("access", accessTag)) {
+                    forward.add(EdgeFlag.ALLOWS_CAR);
+                    backward.add(EdgeFlag.ALLOWS_CAR);
+                    return;
+                }
+            }
+        }
     }
 
     /**
@@ -476,9 +496,11 @@ public abstract class TraversalPermissionLabeler {
 
         private static boolean isNoThruTraffic(String access) {
             return  "destination".equals(access)
-                    || "delivery".equals(access) || "forestry".equals(access)
-                    || "agricultural".equals(access) || "residents".equals(access)
-                    || "resident".equals(access) || "private".equals(access) ;
+                    || "customers".equals(access) || "delivery".equals(access)
+                    || "forestry".equals(access)  || "agricultural".equals(access)
+                    || "residents".equals(access) || "resident".equals(access)
+                    || "customer".equals(access)
+                    || "private".equals(access) ;
         }
 
         public static Label fromTag (String tag) {
@@ -500,8 +522,6 @@ public abstract class TraversalPermissionLabeler {
                     || "share_busway".equals(tag)
                     //cycleway=crossing it should already have bicycle=yes from highway=cycleway or bicycle=yes
                     || "crossing".equals(tag)
-                    // express lanes/service ways/etc accessible only by paying customers
-                    || "customers".equals(tag) || "customer".equals(tag)
             ) {
                 return YES;
             } else if (isTagFalse(tag) || tag.equals("license")

--- a/web/src/main/java/com/graphhopper/http/cli/ExportCommand.java
+++ b/web/src/main/java/com/graphhopper/http/cli/ExportCommand.java
@@ -193,12 +193,12 @@ public class ExportCommand extends ConfiguredCommand<GraphHopperServerConfigurat
                         // Print line for each edge direction, if edge is accessible.
                         // Inaccessible edges have no flags set; flags are stored as stringified lists,
                         // so innaccessible edges will have a flag equal to "[]", the empty list's toString()
-                        if (!forwardFlags.equals(Lists.newArrayList().toString())) {
+                        if (!forwardFlags.equals("[]")) {
                             printer.printRecord(forwardStableEdgeId, startVertex, endVertex,
                                     startLat, startLon, endLat, endLon, geometryString, streetName,
                                     distanceMillimeters, osmId, speedcms, forwardFlags, forwardLanes, highwayTag);
                         }
-                        if (!backwardFlags.equals(Lists.newArrayList().toString())) {
+                        if (!backwardFlags.equals("[]")) {
                             printer.printRecord(backwardStableEdgeId, endVertex, startVertex,
                                     endLat, endLon, startLat, startLon, reverseGeometryString, streetName,
                                     distanceMillimeters, osmId, speedcms, backwardFlags, backwardLanes, highwayTag);

--- a/web/src/main/java/com/graphhopper/http/cli/ExportCommand.java
+++ b/web/src/main/java/com/graphhopper/http/cli/ExportCommand.java
@@ -190,13 +190,19 @@ public class ExportCommand extends ConfiguredCommand<GraphHopperServerConfigurat
                     // Copy R5's logic; filter out edges with unwanted highway tags and negative OSM IDs
                     // todo: do negative OSM ids happen in GH? This might have been R5-specific
                     if (!HIGHWAY_FILTER_TAGS.contains(highwayTag) && osmId >= 0) {
-                        // Print line for each edge direction
-                        printer.printRecord(forwardStableEdgeId, startVertex, endVertex,
-                                startLat, startLon, endLat, endLon, geometryString, streetName,
-                                distanceMillimeters, osmId, speedcms, forwardFlags, forwardLanes, highwayTag);
-                        printer.printRecord(backwardStableEdgeId, endVertex, startVertex,
-                                endLat, endLon, startLat, startLon, reverseGeometryString, streetName,
-                                distanceMillimeters, osmId, speedcms, backwardFlags, backwardLanes, highwayTag);
+                        // Print line for each edge direction, if edge is accessible.
+                        // Inaccessible edges have no flags set; flags are stored as stringified lists,
+                        // so innaccessible edges will have a flag equal to "[]", the empty list's toString()
+                        if (!forwardFlags.equals(Lists.newArrayList().toString())) {
+                            printer.printRecord(forwardStableEdgeId, startVertex, endVertex,
+                                    startLat, startLon, endLat, endLon, geometryString, streetName,
+                                    distanceMillimeters, osmId, speedcms, forwardFlags, forwardLanes, highwayTag);
+                        }
+                        if (!backwardFlags.equals(Lists.newArrayList().toString())) {
+                            printer.printRecord(backwardStableEdgeId, endVertex, startVertex,
+                                    endLat, endLon, startLat, startLon, reverseGeometryString, streetName,
+                                    distanceMillimeters, osmId, speedcms, backwardFlags, backwardLanes, highwayTag);
+                        }
                     }
                 }
             }

--- a/web/src/main/java/com/graphhopper/http/cli/ExportCommand.java
+++ b/web/src/main/java/com/graphhopper/http/cli/ExportCommand.java
@@ -49,6 +49,7 @@ public class ExportCommand extends ConfiguredCommand<GraphHopperServerConfigurat
     private static final Logger logger = LoggerFactory.getLogger(ExportCommand.class);
 
     private static final List<String> HIGHWAY_FILTER_TAGS = Lists.newArrayList("bridleway", "steps");
+    private static final List<String> INACCESSIBLE_MOTORWAY_TAGS = Lists.newArrayList("motorway", "motorway_link");
     private static final String[] COLUMN_HEADERS = {"stableEdgeId", "startVertex", "endVertex", "startLat", "startLon",
             "endLat", "endLon", "geometry", "streetName", "distance", "osmid", "speed", "flags", "lanes", "highway"};
 
@@ -192,13 +193,14 @@ public class ExportCommand extends ConfiguredCommand<GraphHopperServerConfigurat
                     if (!HIGHWAY_FILTER_TAGS.contains(highwayTag) && osmId >= 0) {
                         // Print line for each edge direction, if edge is accessible.
                         // Inaccessible edges have no flags set; flags are stored as stringified lists,
-                        // so innaccessible edges will have a flag equal to "[]", the empty list's toString()
-                        if (!forwardFlags.equals("[]")) {
+                        // so innaccessible edges will have a flag equal to "[]", the empty list's toString().
+                        // Only remove inaccessible edges with highway tags of motorway or motorway_link
+                        if (!(forwardFlags.equals("[]") && INACCESSIBLE_MOTORWAY_TAGS.contains(highwayTag))) {
                             printer.printRecord(forwardStableEdgeId, startVertex, endVertex,
                                     startLat, startLon, endLat, endLon, geometryString, streetName,
                                     distanceMillimeters, osmId, speedcms, forwardFlags, forwardLanes, highwayTag);
                         }
-                        if (!backwardFlags.equals("[]")) {
+                        if (!(backwardFlags.equals("[]") && INACCESSIBLE_MOTORWAY_TAGS.contains(highwayTag))) {
                             printer.printRecord(backwardStableEdgeId, endVertex, startVertex,
                                     endLat, endLon, startLat, startLon, reverseGeometryString, streetName,
                                     distanceMillimeters, osmId, speedcms, backwardFlags, backwardLanes, highwayTag);

--- a/web/src/main/java/com/graphhopper/http/cli/ExportCommand.java
+++ b/web/src/main/java/com/graphhopper/http/cli/ExportCommand.java
@@ -124,9 +124,12 @@ public class ExportCommand extends ConfiguredCommand<GraphHopperServerConfigurat
                     double endLat = nodes.getLat(endVertex);
                     double endLon = nodes.getLon(endVertex);
 
-                    // Get edge geometry and distance
+                    // Get edge geometry for both edge directions, and distance
                     PointList wayGeometry = edgeIterator.fetchWayGeometry(FetchMode.ALL);
                     String geometryString = wayGeometry.toLineString(false).toString();
+                    wayGeometry.reverse();
+                    String reverseGeometryString = wayGeometry.toLineString(false).toString();
+
                     long distanceMeters = Math.round(DistanceCalcEarth.DIST_EARTH.calcDist(startLat, startLon, endLat, endLon));
 
                     // Convert GH's km/h speed to cm/s to match R5's implementation
@@ -192,7 +195,7 @@ public class ExportCommand extends ConfiguredCommand<GraphHopperServerConfigurat
                                 startLat, startLon, endLat, endLon, geometryString, streetName,
                                 distanceMillimeters, osmId, speedcms, forwardFlags, forwardLanes, highwayTag);
                         printer.printRecord(backwardStableEdgeId, endVertex, startVertex,
-                                endLat, endLon, startLat, startLon, geometryString, streetName,
+                                endLat, endLon, startLat, startLon, reverseGeometryString, streetName,
                                 distanceMillimeters, osmId, speedcms, backwardFlags, backwardLanes, highwayTag);
                     }
                 }


### PR DESCRIPTION
Solution for the problem laid out in [this](https://replicahq.atlassian.net/browse/RAD-1637?focusedCommentId=14015) jira comment. 

_Context about edge representations:_ 
Graphhopper's internal edges are bidirectional (even for one-way sections of road). R5's were directed. So, to replicate how R5 output street edges, we also output reverse copies of Graphhopper's edges, so that our street export CSVs end up being directed. The main bug here was that we didn't reverse the linestring geos output for the reversed copies of each edge we created, resulting in weirdness in the frontend when selecting/displaying specific network links

_Context about accessibility flags:_
Accessibility flags are a thing from R5's internal street export code, which we had to port over when we made the switch to Graphhopper exclusively. The [R5 code](https://github.com/replicahq/model-r5/blob/swl_master/src/main/java/com/conveyal/r5/labeling/TraversalPermissionLabeler.java#L62-L133) itself makes sense, generally - it's analyzing OSM tag info in order to determine what type of vehicles/pedestrians/etc can reasonably move along the edge, in that direction. The [ported code in Graphhopper](https://github.com/replicahq/graphhopper/blob/original-direction/replica-common/src/main/java/com/graphhopper/export/TraversalPermissionLabeler.java#L88-L140) is identical to the R5 code, only with minor things taken out (we took out things like determining if an edge `ALLOWS_WHEELCHAIR`, for example). 


_What this does:_
- Fixes bug where we don't reverse the linestring geo for the reverse edge copy we create
- Blocks the outputting of links with no accessibility flags set

_Rationale for not outputting edges with no accessibility flags set_
The issue being addressed with this change is fixing situations where one-way streets, where we might expect only a single unidirection link to be included in the street network CSV export, have a reverse "wrong-way-on-a-one-way" copy also included in the export. I did some testing with GLE's street edge file, and it seems as though the current best way to filter out these specific edges is to find edges with no flags set at all (the three possible flags we set are `ALLOWS_CAR`, `ALLOWS_BIKE`, and `ALLOWS_PEDESTRIAN`). As seen in the screenshots below in GLE, almost all of the affected edges are on highways (where we expect on direction of each link to be totally untraversable), and on various quirky bits in the network, like U-turn lanes on avenues, drop-off loops, parking lots.

<img width="1384" alt="Screen Shot 2021-02-24 at 9 53 49 PM" src="https://user-images.githubusercontent.com/13446427/109109769-c84f5800-76ea-11eb-8fc8-bb391603524c.png">
<img width="1418" alt="Screen Shot 2021-02-24 at 9 54 04 PM" src="https://user-images.githubusercontent.com/13446427/109109789-d1402980-76ea-11eb-99ba-055558879f44.png">
<img width="1401" alt="Screen Shot 2021-02-24 at 9 54 59 PM" src="https://user-images.githubusercontent.com/13446427/109109871-f16fe880-76ea-11eb-82aa-d888bb8f0310.png">

For scale, in GLE, 174651/21233996 (0.8%) of edges have no flags set. Here's a CSV containing all these edges that can be loaded in kepler for more 👀 to take a look (git made me zip it): [gle_no_access.csv.zip](https://github.com/replicahq/graphhopper/files/6040802/gle_no_access.csv.zip)


One other detail - why is it that we don't see many streets in city centers that we know to be one-way streets show up? I spot checked a few of our network link CSV files, and noticed that in almost all of these cases, the reverse direction is only marked as `ALLOWS_PEDESTRIAN`. So, I think reverse links here are used to represent walkable sidewalks etc. This further solidifies why we see wrong-way-one-way highway links as the main links that would be removed with this change - they obviously don't have walkability at all.

_Potential thing to watch out for here_
The only worry I have with removing edges from the street export, even if it's a relatively small number, is that somehow R5's internal accessibility flag logic differs from Graphhopper's routability logic - essentially, we could take things out of the CSV (used everywhere), and Graphhopper could still return routes using some of those links, meaning things might break. On the other hand, this might not really be an issue - perhaps it just means we're not able to display network link volumes for links for which that's the case, and that's OK.