### PR TITLE
Check null stops

### DIFF
--- a/grpc/pom.xml
+++ b/grpc/pom.xml
@@ -64,7 +64,7 @@
                 <artifactId>protobuf-maven-plugin</artifactId>
                 <version>0.6.1</version>
                 <configuration>
-                    <protocArtifact>com.google.protobuf:protoc:3.12.0:exe:${os.detected.classifier}</protocArtifact>
+                    <protocArtifact>com.google.protobuf:protoc:3.14.0:exe:${os.detected.classifier}</protocArtifact>
                     <pluginId>grpc-java</pluginId>
                     <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.31.1:exe:${os.detected.classifier}</pluginArtifact>
                 </configuration>

--- a/grpc/pom.xml
+++ b/grpc/pom.xml
@@ -64,7 +64,7 @@
                 <artifactId>protobuf-maven-plugin</artifactId>
                 <version>0.6.1</version>
                 <configuration>
-                    <protocArtifact>com.google.protobuf:protoc:3.14.0:exe:${os.detected.classifier}</protocArtifact>
+                    <protocArtifact>com.google.protobuf:protoc:3.12.0:exe:${os.detected.classifier}</protocArtifact>
                     <pluginId>grpc-java</pluginId>
                     <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.31.1:exe:${os.detected.classifier}</pluginArtifact>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -3,308 +3,100 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.graphhopper</groupId>
+    <groupId>com.replica</groupId>
     <artifactId>graphhopper-parent</artifactId>
     <name>GraphHopper Parent Project</name>
-    <version>0.11-SNAPSHOT</version>
+    <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
-    <url>https://www.graphhopper.com</url>
-    <inceptionYear>2012</inceptionYear>
-    <description>Super pom of GraphHopper, the fast and flexible routing engine</description>
 
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <slf4j.version>1.7.25</slf4j.version>
-        <log4j.version>1.2.17</log4j.version>
-        <commons-compress.version>1.12</commons-compress.version>
-        <jackson.version>2.9.1</jackson.version>
-        <maven.compiler.target>1.8</maven.compiler.target>
-
-        <org-netbeans-modules-editor-indent.CodeStyle.project.indent-shift-width>4</org-netbeans-modules-editor-indent.CodeStyle.project.indent-shift-width>
-        <org-netbeans-modules-editor-indent.CodeStyle.project.spaces-per-tab>4</org-netbeans-modules-editor-indent.CodeStyle.project.spaces-per-tab>
-        <org-netbeans-modules-editor-indent.CodeStyle.project.tab-size>8</org-netbeans-modules-editor-indent.CodeStyle.project.tab-size>
-        <org-netbeans-modules-editor-indent.CodeStyle.project.text-limit-width>100</org-netbeans-modules-editor-indent.CodeStyle.project.text-limit-width>
-        <org-netbeans-modules-editor-indent.CodeStyle.project.expand-tabs>true</org-netbeans-modules-editor-indent.CodeStyle.project.expand-tabs>
-        <org-netbeans-modules-editor-indent.CodeStyle.usedProfile>project</org-netbeans-modules-editor-indent.CodeStyle.usedProfile>
-        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.redundantIfBraces>LEAVE_ALONE</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.redundantIfBraces>
-        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.alignJavadocExceptionDescriptions>true</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.alignJavadocExceptionDescriptions>
-        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.alignJavadocParameterDescriptions>true</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.alignJavadocParameterDescriptions>
-        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.blankLinesAfterClassHeader>0</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.blankLinesAfterClassHeader>
-        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapCommentText>false</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapCommentText>
-        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapOneLineComment>false</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapOneLineComment>
-        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.alignMultilineMethodParams>true</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.alignMultilineMethodParams>
-        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.alignMultilineFor>true</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.alignMultilineFor>
-        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.alignMultilineTryResources>true</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.alignMultilineTryResources>
+        <maven.compiler.target>14</maven.compiler.target>
     </properties>
 
-    <scm>
-        <connection>scm:git:git@github.com:graphhopper/graphhopper.git</connection>
-        <developerConnection>scm:git:git@github.com:graphhopper/graphhopper.git</developerConnection>
-        <url>git@github.com:graphhopper/graphhopper.git</url>
-    </scm>
-
-    <licenses>
-        <license>
-            <name>Apache License, Version 2.0</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0</url>
-        </license>
-    </licenses>
-
-    <developers>
-        <developer>
-            <id>karussell</id>
-            <name>Peter Karich</name>
-            <email>my.name@graphhopper.com</email>
-        </developer>
-    </developers>
-
-    <mailingLists>
-        <mailingList>
-            <name>GraphHopper</name>
-            <subscribe>https://discuss.graphhopper.com/</subscribe>
-            <archive>https://discuss.graphhopper.com/</archive>
-        </mailingList>
-    </mailingLists>
-    <issueManagement>
-        <system>GitHub</system>
-        <url>https://github.com/graphhopper/graphhopper/issues</url>
-    </issueManagement>
-
     <modules>
-        <module>core</module>
-        <module>reader-osm</module>
-        <module>isochrone</module>
-        <module>reader-gtfs</module>
-        <module>tools</module>
+        <module>replica-common</module>
         <module>web-bundle</module>
-        <module>api</module>
-        <module>web-api</module>
         <module>web</module>
-        <module>client-hc</module>
+        <module>grpc</module>
     </modules>
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.5.1</version>
+                <version>3.8.1</version>
                 <configuration>
                     <!--
                     <compilerArgument>-Xlint:unchecked</compilerArgument>
                     <compilerArgument>-Xlint:deprecation</compilerArgument>
                     -->
-
-                    <!-- suppress warning about Unsafe functionality -->
-                    <compilerArgument>-XDignore.symbol.file</compilerArgument>
                     <fork>true</fork>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>14</source>
+                    <target>14</target>
                 </configuration>
             </plugin>
-
-            <!-- to run single tests -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.19.1</version>
-                <configuration>
-                    <argLine>-Xmx100m -Xms100m</argLine>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.19.1</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>integration-test</goal>
-                            <goal>verify</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.1.1</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.0.2</version>
-            </plugin>
-            <!-- example https://github.com/tananaev/traccar/blob/master/checkstyle.xml -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>2.17</version>
-                <configuration>
-                    <configLocation>${user.dir}/core/files/checkstyle.xml</configLocation>
-                    <failsOnError>true</failsOnError>
-                    <consoleOutput>true</consoleOutput>
-                    <linkXRef>false</linkXRef>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>findbugs-maven-plugin</artifactId>
-                <version>3.0.5</version>
-                <configuration>
-                    <maxRank>4</maxRank>
-                    <failOnError>true</failOnError>
-                    <excludeFilterFile>core/files/findbugs-exclude.xml</excludeFilterFile>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-pmd-plugin</artifactId>
-                <version>3.7</version>
-                <!-- e.g. under core/target/site/pmd.html
-                <configuration>
-                    <format>html</format>
-                </configuration>
-                -->
-            </plugin>
-            <plugin>
-                <groupId>de.thetaphi</groupId>
-                <artifactId>forbiddenapis</artifactId>
-                <version>2.5</version>
-                <configuration>
-                    <!--
-                      if the used Java version is too new,
-                      don't fail, just do nothing:
-                    -->
-                    <failOnUnsupportedJava>false</failOnUnsupportedJava>
-                    <bundledSignatures>
-                        <!--
-                          This will automatically choose the right
-                          signatures based on 'maven.compiler.target':
-                        -->
-                        <bundledSignature>jdk-unsafe</bundledSignature>
-                        <bundledSignature>jdk-deprecated</bundledSignature>
-                        <!-- disallow undocumented classes like sun.misc.Unsafe: -->
-                        <bundledSignature>jdk-non-portable</bundledSignature>
-                    </bundledSignatures>
-                    <excludes>
-                        <exclude>
-                            com/graphhopper/storage/UnsafeDataAccess.class
-                        </exclude>
-                        <!-- Has a couple of issues with the FileWriter -->
-                        <exclude>
-                            com/graphhopper/tools/Measurement.class
-                        </exclude>
-                    </excludes>
-                </configuration>
+                <version>3.1.1</version>
             </plugin>
         </plugins>
+        <extensions>
+            <extension>
+                <groupId>com.gkatzioura.maven.cloud</groupId>
+                <artifactId>google-storage-wagon</artifactId>
+                <version>1.7</version>
+            </extension>
+        </extensions>
     </build>
 
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-    </distributionManagement>
+    <repositories>
+        <repository>
+            <id>osgeo</id>
+            <name>OSGeo Release Repository</name>
+            <url>https://repo.osgeo.org/repository/release/</url>
+            <snapshots><enabled>false</enabled></snapshots>
+            <releases><enabled>true</enabled></releases>
+        </repository>
+        <repository>
+            <id>graphhopper-matrix</id>
+            <url>https://packagecloud.io/priv/${env.GRAPHHOPPER_TOKEN}/graphhopper/matrix/maven2</url>
+        </repository>
+        <repository>
+            <id>github-core</id>
+            <name>GraphHopper Core Packages</name>
+            <url>https://maven.pkg.github.com/graphhopper/graphhopper</url>
+        </repository>
+        <repository>
+            <id>github-mm</id>
+            <name>GraphHopper Map Matching Packages</name>
+            <url>https://maven.pkg.github.com/graphhopper/map-matching</url>
+        </repository>
+    </repositories>
 
-    <!-- mvn clean deploy -P release -->
     <profiles>
         <profile>
-            <id>release</id>
+            <id>replica-repo</id>
             <activation>
-                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>useReplicaRepo</name>
+                </property>
             </activation>
-            <!-- this exception is valid for jdk8 profile below too -->
-            <modules>
-                <!-- See https://github.com/graphhopper/graphhopper/pull/874#issuecomment-261231518
-                Currently works for jdk8 only -->
-                <module>reader-shp</module>
-            </modules>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.6</version>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.7</version>
-                        <extensions>true</extensions>
-                        <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                        </configuration>
-                    </plugin>
-
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>2.10.4</version>
-                        <configuration>
-                          <quiet>true</quiet>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>attach-javadocs</id>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-source-plugin</artifactId>
-                        <version>3.0.1</version>
-                        <executions>
-                            <execution>
-                                <id>attach-sources</id>
-                                <goals>
-                                    <goal>jar-no-fork</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
+            <distributionManagement>
+                <snapshotRepository>
+                    <id>gh-replica-gcs-snapshot</id>
+                    <url>gs://model-maven-repo/snapshot</url>
+                </snapshotRepository>
+                <repository>
+                    <id>gh-replica-gcs-release</id>
+                    <url>gs://model-maven-repo/release</url>
+                </repository>
+            </distributionManagement>
         </profile>
-        <profile>
-            <id>include-android</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-            </activation>
-            <modules>
-                <module>android/app</module>
-            </modules>
-        </profile>
-	<profile>
-            <id>jdk10</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-                <jdk>10</jdk>
-            </activation>
-            <properties>
-              <maven.compiler.source>10</maven.compiler.source>
-              <maven.compiler.target>10</maven.compiler.target>
-            </properties>
-        </profile>
-
     </profiles>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,100 +3,308 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.replica</groupId>
+    <groupId>com.graphhopper</groupId>
     <artifactId>graphhopper-parent</artifactId>
     <name>GraphHopper Parent Project</name>
-    <version>1.0-SNAPSHOT</version>
+    <version>0.11-SNAPSHOT</version>
     <packaging>pom</packaging>
+    <url>https://www.graphhopper.com</url>
+    <inceptionYear>2012</inceptionYear>
+    <description>Super pom of GraphHopper, the fast and flexible routing engine</description>
 
     <properties>
-        <maven.compiler.target>14</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <slf4j.version>1.7.25</slf4j.version>
+        <log4j.version>1.2.17</log4j.version>
+        <commons-compress.version>1.12</commons-compress.version>
+        <jackson.version>2.9.1</jackson.version>
+        <maven.compiler.target>1.8</maven.compiler.target>
+
+        <org-netbeans-modules-editor-indent.CodeStyle.project.indent-shift-width>4</org-netbeans-modules-editor-indent.CodeStyle.project.indent-shift-width>
+        <org-netbeans-modules-editor-indent.CodeStyle.project.spaces-per-tab>4</org-netbeans-modules-editor-indent.CodeStyle.project.spaces-per-tab>
+        <org-netbeans-modules-editor-indent.CodeStyle.project.tab-size>8</org-netbeans-modules-editor-indent.CodeStyle.project.tab-size>
+        <org-netbeans-modules-editor-indent.CodeStyle.project.text-limit-width>100</org-netbeans-modules-editor-indent.CodeStyle.project.text-limit-width>
+        <org-netbeans-modules-editor-indent.CodeStyle.project.expand-tabs>true</org-netbeans-modules-editor-indent.CodeStyle.project.expand-tabs>
+        <org-netbeans-modules-editor-indent.CodeStyle.usedProfile>project</org-netbeans-modules-editor-indent.CodeStyle.usedProfile>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.redundantIfBraces>LEAVE_ALONE</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.redundantIfBraces>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.alignJavadocExceptionDescriptions>true</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.alignJavadocExceptionDescriptions>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.alignJavadocParameterDescriptions>true</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.alignJavadocParameterDescriptions>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.blankLinesAfterClassHeader>0</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.blankLinesAfterClassHeader>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapCommentText>false</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapCommentText>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapOneLineComment>false</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.wrapOneLineComment>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.alignMultilineMethodParams>true</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.alignMultilineMethodParams>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.alignMultilineFor>true</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.alignMultilineFor>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.alignMultilineTryResources>true</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.alignMultilineTryResources>
     </properties>
 
+    <scm>
+        <connection>scm:git:git@github.com:graphhopper/graphhopper.git</connection>
+        <developerConnection>scm:git:git@github.com:graphhopper/graphhopper.git</developerConnection>
+        <url>git@github.com:graphhopper/graphhopper.git</url>
+    </scm>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <id>karussell</id>
+            <name>Peter Karich</name>
+            <email>my.name@graphhopper.com</email>
+        </developer>
+    </developers>
+
+    <mailingLists>
+        <mailingList>
+            <name>GraphHopper</name>
+            <subscribe>https://discuss.graphhopper.com/</subscribe>
+            <archive>https://discuss.graphhopper.com/</archive>
+        </mailingList>
+    </mailingLists>
+    <issueManagement>
+        <system>GitHub</system>
+        <url>https://github.com/graphhopper/graphhopper/issues</url>
+    </issueManagement>
+
     <modules>
-        <module>replica-common</module>
+        <module>core</module>
+        <module>reader-osm</module>
+        <module>isochrone</module>
+        <module>reader-gtfs</module>
+        <module>tools</module>
         <module>web-bundle</module>
+        <module>api</module>
+        <module>web-api</module>
         <module>web</module>
-        <module>grpc</module>
+        <module>client-hc</module>
     </modules>
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.5.1</version>
                 <configuration>
                     <!--
                     <compilerArgument>-Xlint:unchecked</compilerArgument>
                     <compilerArgument>-Xlint:deprecation</compilerArgument>
                     -->
+
+                    <!-- suppress warning about Unsafe functionality -->
+                    <compilerArgument>-XDignore.symbol.file</compilerArgument>
                     <fork>true</fork>
-                    <source>14</source>
-                    <target>14</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
+
+            <!-- to run single tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.19.1</version>
+                <configuration>
+                    <argLine>-Xmx100m -Xms100m</argLine>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.19.1</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>3.0.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>3.0.2</version>
+            </plugin>
+            <!-- example https://github.com/tananaev/traccar/blob/master/checkstyle.xml -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>2.17</version>
+                <configuration>
+                    <configLocation>${user.dir}/core/files/checkstyle.xml</configLocation>
+                    <failsOnError>true</failsOnError>
+                    <consoleOutput>true</consoleOutput>
+                    <linkXRef>false</linkXRef>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>findbugs-maven-plugin</artifactId>
+                <version>3.0.5</version>
+                <configuration>
+                    <maxRank>4</maxRank>
+                    <failOnError>true</failOnError>
+                    <excludeFilterFile>core/files/findbugs-exclude.xml</excludeFilterFile>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+                <version>3.7</version>
+                <!-- e.g. under core/target/site/pmd.html
+                <configuration>
+                    <format>html</format>
+                </configuration>
+                -->
+            </plugin>
+            <plugin>
+                <groupId>de.thetaphi</groupId>
+                <artifactId>forbiddenapis</artifactId>
+                <version>2.5</version>
+                <configuration>
+                    <!--
+                      if the used Java version is too new,
+                      don't fail, just do nothing:
+                    -->
+                    <failOnUnsupportedJava>false</failOnUnsupportedJava>
+                    <bundledSignatures>
+                        <!--
+                          This will automatically choose the right
+                          signatures based on 'maven.compiler.target':
+                        -->
+                        <bundledSignature>jdk-unsafe</bundledSignature>
+                        <bundledSignature>jdk-deprecated</bundledSignature>
+                        <!-- disallow undocumented classes like sun.misc.Unsafe: -->
+                        <bundledSignature>jdk-non-portable</bundledSignature>
+                    </bundledSignatures>
+                    <excludes>
+                        <exclude>
+                            com/graphhopper/storage/UnsafeDataAccess.class
+                        </exclude>
+                        <!-- Has a couple of issues with the FileWriter -->
+                        <exclude>
+                            com/graphhopper/tools/Measurement.class
+                        </exclude>
+                    </excludes>
+                </configuration>
             </plugin>
         </plugins>
-        <extensions>
-            <extension>
-                <groupId>com.gkatzioura.maven.cloud</groupId>
-                <artifactId>google-storage-wagon</artifactId>
-                <version>1.7</version>
-            </extension>
-        </extensions>
     </build>
 
-    <repositories>
-        <repository>
-            <id>osgeo</id>
-            <name>OSGeo Release Repository</name>
-            <url>https://repo.osgeo.org/repository/release/</url>
-            <snapshots><enabled>false</enabled></snapshots>
-            <releases><enabled>true</enabled></releases>
-        </repository>
-        <repository>
-            <id>graphhopper-matrix</id>
-            <url>https://packagecloud.io/priv/${env.GRAPHHOPPER_TOKEN}/graphhopper/matrix/maven2</url>
-        </repository>
-        <repository>
-            <id>github-core</id>
-            <name>GraphHopper Core Packages</name>
-            <url>https://maven.pkg.github.com/graphhopper/graphhopper</url>
-        </repository>
-        <repository>
-            <id>github-mm</id>
-            <name>GraphHopper Map Matching Packages</name>
-            <url>https://maven.pkg.github.com/graphhopper/map-matching</url>
-        </repository>
-    </repositories>
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+    </distributionManagement>
 
+    <!-- mvn clean deploy -P release -->
     <profiles>
         <profile>
-            <id>replica-repo</id>
+            <id>release</id>
             <activation>
-                <property>
-                    <name>useReplicaRepo</name>
-                </property>
+                <activeByDefault>false</activeByDefault>
             </activation>
-            <distributionManagement>
-                <snapshotRepository>
-                    <id>gh-replica-gcs-snapshot</id>
-                    <url>gs://model-maven-repo/snapshot</url>
-                </snapshotRepository>
-                <repository>
-                    <id>gh-replica-gcs-release</id>
-                    <url>gs://model-maven-repo/release</url>
-                </repository>
-            </distributionManagement>
+            <!-- this exception is valid for jdk8 profile below too -->
+            <modules>
+                <!-- See https://github.com/graphhopper/graphhopper/pull/874#issuecomment-261231518
+                Currently works for jdk8 only -->
+                <module>reader-shp</module>
+            </modules>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.6</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>1.6.7</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <serverId>ossrh</serverId>
+                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                        </configuration>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>2.10.4</version>
+                        <configuration>
+                          <quiet>true</quiet>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>3.0.1</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
+        <profile>
+            <id>include-android</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <modules>
+                <module>android/app</module>
+            </modules>
+        </profile>
+	<profile>
+            <id>jdk10</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <jdk>10</jdk>
+            </activation>
+            <properties>
+              <maven.compiler.source>10</maven.compiler.source>
+              <maven.compiler.target>10</maven.compiler.target>
+            </properties>
+        </profile>
+
     </profiles>
+
 </project>

--- a/web-bundle/src/main/java/com/graphhopper/replica/GtfsLinkMapper.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/GtfsLinkMapper.java
@@ -224,33 +224,35 @@ public class GtfsLinkMapper {
                                                    HTreeMap<String, String> gtfsLinkMappings) {
         List<String> rowsForFeed = Lists.newArrayList();
         for (String routeId : routeIdToTripsInRoute.keySet()) {
-            for (String tripIdInRoute : routeIdToTripsInRoute.get(routeId)) {
-                for (Pair<Stop, Stop> stopStopPair : tripIdToStopPairsInTrip.get(tripIdInRoute)) {
-                    // Filter out stop-stop pairs where the stops are identical
-                    if (stopStopPair.getLeft().stop_id.equals(stopStopPair.getRight().stop_id)) {
-                        continue;
-                    }
+	    if (routeIdToTripsInRoute.containsKey(routeId)) {
+                for (String tripIdInRoute : routeIdToTripsInRoute.get(routeId)) {
+                    for (Pair<Stop, Stop> stopStopPair : tripIdToStopPairsInTrip.get(tripIdInRoute)) {
+                        // Filter out stop-stop pairs where the stops are identical
+                        if (stopStopPair.getLeft().stop_id.equals(stopStopPair.getRight().stop_id)) {
+                            continue;
+                        }
 
-                    // Skip stop-stop pairs where we couldn't find a valid route
-                    String stopPairString = stopStopPair.getLeft().stop_id + "," + stopStopPair.getRight().stop_id;
-                    if (!gtfsLinkMappings.containsKey(stopPairString)) {
-                        continue;
-                    }
-                    List<String> stableEdgeIds = Lists.newArrayList(gtfsLinkMappings.get(stopPairString).split(","));
-                    String stableEdgeIdString = stableEdgeIds.size() == 0 ? ""
-                            : String.format("\"[%s]\"", stableEdgeIds.stream().map(id -> "'" + id + "'").collect(Collectors.joining(",")));
+                        // Skip stop-stop pairs where we couldn't find a valid route
+                        String stopPairString = stopStopPair.getLeft().stop_id + "," + stopStopPair.getRight().stop_id;
+                        if (!gtfsLinkMappings.containsKey(stopPairString)) {
+                            continue;
+                        }
+                        List<String> stableEdgeIds = Lists.newArrayList(gtfsLinkMappings.get(stopPairString).split(","));
+                        String stableEdgeIdString = stableEdgeIds.size() == 0 ? ""
+                                : String.format("\"[%s]\"", stableEdgeIds.stream().map(id -> "'" + id + "'").collect(Collectors.joining(",")));
 
-                    Stop stop = stopStopPair.getLeft();
-                    Stop nextStop = stopStopPair.getRight();
+                        Stop stop = stopStopPair.getLeft();
+                        Stop nextStop = stopStopPair.getRight();
 
-                    // format: "{feed_id}:{route_id}/{feed_id}:{stop_id}/{feed_id}:{next_stop_id}"
-                    String transitEdgeString = stop.feed_id + ":" + routeId + "/" + stop.feed_id + ":"
-                            + stop.stop_id + "/" + stop.feed_id + ":" + nextStop.stop_id;
+                        // format: "{feed_id}:{route_id}/{feed_id}:{stop_id}/{feed_id}:{next_stop_id}"
+                        String transitEdgeString = stop.feed_id + ":" + routeId + "/" + stop.feed_id + ":"
+                                + stop.stop_id + "/" + stop.feed_id + ":" + nextStop.stop_id;
 
-                    rowsForFeed.add(getCsvLine(routeId, stop.feed_id, stop.stop_id, nextStop.stop_id,
+                        rowsForFeed.add(getCsvLine(routeId, stop.feed_id, stop.stop_id, nextStop.stop_id,
                             stop.stop_lat, stop.stop_lon, nextStop.stop_lat, nextStop.stop_lon,
                             stableEdgeIdString, transitEdgeString));
-                }
+                    }
+		}
             }
         }
         return rowsForFeed;

--- a/web-bundle/src/main/java/com/graphhopper/replica/GtfsLinkMapper.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/GtfsLinkMapper.java
@@ -224,10 +224,11 @@ public class GtfsLinkMapper {
                                                    HTreeMap<String, String> gtfsLinkMappings) {
         List<String> rowsForFeed = Lists.newArrayList();
         for (String routeId : routeIdToTripsInRoute.keySet()) {
-	    if (!routeIdToTripsInRoute.containsKey(routeId)) {
-		    continue;
-	    }
 	    for (String tripIdInRoute : routeIdToTripsInRoute.get(routeId)) {
+	        if (!tripIdToStopPairsInTrip.containsKey(tripIdInRoute)) {
+		    continue;
+		}
+
                 for (Pair<Stop, Stop> stopStopPair : tripIdToStopPairsInTrip.get(tripIdInRoute)) {
                     // Filter out stop-stop pairs where the stops are identical
                     if (stopStopPair.getLeft().stop_id.equals(stopStopPair.getRight().stop_id)) {

--- a/web-bundle/src/main/java/com/graphhopper/replica/GtfsLinkMapper.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/GtfsLinkMapper.java
@@ -251,8 +251,8 @@ public class GtfsLinkMapper {
                             + stop.stop_id + "/" + stop.feed_id + ":" + nextStop.stop_id;
 
                     rowsForFeed.add(getCsvLine(routeId, stop.feed_id, stop.stop_id, nextStop.stop_id,
-                        stop.stop_lat, stop.stop_lon, nextStop.stop_lat, nextStop.stop_lon,
-                        stableEdgeIdString, transitEdgeString));
+                            stop.stop_lat, stop.stop_lon, nextStop.stop_lat, nextStop.stop_lon,
+                            stableEdgeIdString, transitEdgeString));
                 }
             }
         }

--- a/web-bundle/src/main/java/com/graphhopper/replica/GtfsLinkMapper.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/GtfsLinkMapper.java
@@ -224,11 +224,10 @@ public class GtfsLinkMapper {
                                                    HTreeMap<String, String> gtfsLinkMappings) {
         List<String> rowsForFeed = Lists.newArrayList();
         for (String routeId : routeIdToTripsInRoute.keySet()) {
-	    for (String tripIdInRoute : routeIdToTripsInRoute.get(routeId)) {
-	        if (!tripIdToStopPairsInTrip.containsKey(tripIdInRoute)) {
-		    continue;
-		}
-
+            for (String tripIdInRoute : routeIdToTripsInRoute.get(routeId)) {
+                if (!tripIdToStopPairsInTrip.containsKey(tripIdInRoute)) {
+                    continue;
+                }
                 for (Pair<Stop, Stop> stopStopPair : tripIdToStopPairsInTrip.get(tripIdInRoute)) {
                     // Filter out stop-stop pairs where the stops are identical
                     if (stopStopPair.getLeft().stop_id.equals(stopStopPair.getRight().stop_id)) {

--- a/web-bundle/src/main/java/com/graphhopper/replica/GtfsLinkMapper.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/GtfsLinkMapper.java
@@ -224,35 +224,36 @@ public class GtfsLinkMapper {
                                                    HTreeMap<String, String> gtfsLinkMappings) {
         List<String> rowsForFeed = Lists.newArrayList();
         for (String routeId : routeIdToTripsInRoute.keySet()) {
-	    if (routeIdToTripsInRoute.containsKey(routeId)) {
-                for (String tripIdInRoute : routeIdToTripsInRoute.get(routeId)) {
-                    for (Pair<Stop, Stop> stopStopPair : tripIdToStopPairsInTrip.get(tripIdInRoute)) {
-                        // Filter out stop-stop pairs where the stops are identical
-                        if (stopStopPair.getLeft().stop_id.equals(stopStopPair.getRight().stop_id)) {
-                            continue;
-                        }
-
-                        // Skip stop-stop pairs where we couldn't find a valid route
-                        String stopPairString = stopStopPair.getLeft().stop_id + "," + stopStopPair.getRight().stop_id;
-                        if (!gtfsLinkMappings.containsKey(stopPairString)) {
-                            continue;
-                        }
-                        List<String> stableEdgeIds = Lists.newArrayList(gtfsLinkMappings.get(stopPairString).split(","));
-                        String stableEdgeIdString = stableEdgeIds.size() == 0 ? ""
-                                : String.format("\"[%s]\"", stableEdgeIds.stream().map(id -> "'" + id + "'").collect(Collectors.joining(",")));
-
-                        Stop stop = stopStopPair.getLeft();
-                        Stop nextStop = stopStopPair.getRight();
-
-                        // format: "{feed_id}:{route_id}/{feed_id}:{stop_id}/{feed_id}:{next_stop_id}"
-                        String transitEdgeString = stop.feed_id + ":" + routeId + "/" + stop.feed_id + ":"
-                                + stop.stop_id + "/" + stop.feed_id + ":" + nextStop.stop_id;
-
-                        rowsForFeed.add(getCsvLine(routeId, stop.feed_id, stop.stop_id, nextStop.stop_id,
-                            stop.stop_lat, stop.stop_lon, nextStop.stop_lat, nextStop.stop_lon,
-                            stableEdgeIdString, transitEdgeString));
+	    if (!routeIdToTripsInRoute.containsKey(routeId)) {
+		    continue;
+	    }
+	    for (String tripIdInRoute : routeIdToTripsInRoute.get(routeId)) {
+                for (Pair<Stop, Stop> stopStopPair : tripIdToStopPairsInTrip.get(tripIdInRoute)) {
+                    // Filter out stop-stop pairs where the stops are identical
+                    if (stopStopPair.getLeft().stop_id.equals(stopStopPair.getRight().stop_id)) {
+                        continue;
                     }
-		}
+
+                    // Skip stop-stop pairs where we couldn't find a valid route
+                    String stopPairString = stopStopPair.getLeft().stop_id + "," + stopStopPair.getRight().stop_id;
+                    if (!gtfsLinkMappings.containsKey(stopPairString)) {
+                        continue;
+                    }
+                    List<String> stableEdgeIds = Lists.newArrayList(gtfsLinkMappings.get(stopPairString).split(","));
+                    String stableEdgeIdString = stableEdgeIds.size() == 0 ? ""
+                            : String.format("\"[%s]\"", stableEdgeIds.stream().map(id -> "'" + id + "'").collect(Collectors.joining(",")));
+
+                    Stop stop = stopStopPair.getLeft();
+                    Stop nextStop = stopStopPair.getRight();
+
+                    // format: "{feed_id}:{route_id}/{feed_id}:{stop_id}/{feed_id}:{next_stop_id}"
+                    String transitEdgeString = stop.feed_id + ":" + routeId + "/" + stop.feed_id + ":"
+                            + stop.stop_id + "/" + stop.feed_id + ":" + nextStop.stop_id;
+
+                    rowsForFeed.add(getCsvLine(routeId, stop.feed_id, stop.stop_id, nextStop.stop_id,
+                        stop.stop_lat, stop.stop_lon, nextStop.stop_lat, nextStop.stop_lon,
+                        stableEdgeIdString, transitEdgeString));
+                }
             }
         }
         return rowsForFeed;


### PR DESCRIPTION
Caught a bug in the gtfs link mapper for Sacramento where a trip did not have any associated stops. Seems to be fine if we ignore bad trips in the csv output