### PR TITLE
RAD-1834: Fix NPEs when paths in matrix request aren't found

### DIFF
--- a/grpc/src/main/java/RouterImpl.java
+++ b/grpc/src/main/java/RouterImpl.java
@@ -197,10 +197,10 @@ public class RouterImpl extends router.RouterGrpc.RouterImplBase {
                     }
 
                     long time = element.getTime();
-                    timeRow.add(time == Long.MAX_VALUE ? null : Math.round((double)time / 1000.0D));
+                    timeRow.add(time == Long.MAX_VALUE ? -1 : Math.round((double)time / 1000.0D));
 
                     double distance = element.getDistance();
-                    distanceRow.add(distance == Double.MAX_VALUE ? null : Math.round(distance));
+                    distanceRow.add(distance == Double.MAX_VALUE ? -1 : Math.round(distance));
 
                     debugBuilder.append(element.getDebugInfo());
                 }


### PR DESCRIPTION
@hardisty noticed some NPEs being thrown by matrix route requests in recent runs (example of error [here](https://console.cloud.google.com/logs/query;pinnedLogId=2021-03-17T22:44:00.070371388Z%2Fqx8nl1g5upnx5n;query=hardisty-f45e158e-routerservicegh-northcentral-bfcbd4db9-kj26x%0Atimestamp%3D%222021-03-17T22:44:00.070371388Z%22%0AinsertId%3D%22qx8nl1g5upnx5n%22?project=model-159019)).

After poking around, it turns out that the issue is caused by how we construct proto objects for matrix requests in the case where certain paths in the matrix request can't be found (in other words, there's an OD pair that are unroutable). Current behavior stores a `null` in this case, which proto then rejects upon building a response object (proto essentially doesn't support null values at all).

My current fix sets times/distances in this case each to `-1`; if we go this route, I'm guessing we'd need to add client code to properly handle these cases so they're interpreted properly downstream as "no route was found between this particular pair". 

With this bug, current behavior is these errors are being caught server-side, a GRPC `INTERNAL` error is sent back to the client, and the client is setup to not retry on that error. I unfortunately think the implication is that for any matrix request where there's an O+D combo that are unroutable, we just error out without retrying...not great if you're using the matrix API for routability queries :/ 