### PR TITLE
Fix method for checking if graph was built with GTFS or not

### DIFF
--- a/nationwide_gh_config.yaml
+++ b/nationwide_gh_config.yaml
@@ -3,7 +3,6 @@
 
 graphhopper:
   datareader.file:
-  gtfs.file:
   graph.location: transit_data/graphhopper
   routing.ch.disabling_allowed: true
   routing.max_visited_nodes: 1500000

--- a/web-bundle/src/main/java/com/graphhopper/http/GraphHopperManaged.java
+++ b/web-bundle/src/main/java/com/graphhopper/http/GraphHopperManaged.java
@@ -72,7 +72,7 @@ public class GraphHopperManaged implements Managed {
             logger.error("Problem while reading border map GeoJSON. Skipping this.", e1);
             landmarkSplittingFeatureCollection = null;
         }
-        if (!configuration.getString("gtfs.file", "").isEmpty()) {
+        if (configuration.has("gtfs.file")) {
             graphHopper = new CustomGraphHopperGtfs(configuration);
         } else {
             graphHopper = new CustomGraphHopperOSM(landmarkSplittingFeatureCollection, configuration).forServer();


### PR DESCRIPTION
One leftover bug fix from #58 ; basically, I messed up a bit in the check that determines if Graphhopper is/was built with GTFS or not, which meant that `import` (where we explicitly provide GTFS on the command line) worked ,but later steps didn't (because we didn't specify GTFS, so that field was empty, meaning Graphhopper tried to load the graph as a `CustomGraphHopperOSM` object, throwing an error)

The fix here is to just use the existence of the `gtfs.file:` field in the Graphhopper config yamls to decide whether or not GTFS was used to build the graph. This still works if we ever want future use cases where we built real routers with OSM only; we'll just have a separate config for those without the `gtfs.file:` field.

All 4 of our custom commands were tested with this (`import`, `export`, `export-nationwide`, and `gtfs-links`)