### PR TITLE
Interpolate transfers

### DIFF
--- a/default_gh_config.yaml
+++ b/default_gh_config.yaml
@@ -4,6 +4,7 @@
 graphhopper:
   datareader.file:
   gtfs.file:
+  gtfs.max_transfer_interpolation_walk_time_seconds: 300
   graph.location: transit_data/graphhopper
   routing.ch.disabling_allowed: true
   routing.max_visited_nodes: 1500000

--- a/default_gh_config.yaml
+++ b/default_gh_config.yaml
@@ -4,7 +4,7 @@
 graphhopper:
   datareader.file:
   gtfs.file:
-  gtfs.max_transfer_interpolation_walk_time_seconds: 300
+  gtfs.max_transfer_interpolation_walk_time_seconds: 600
   graph.location: transit_data/graphhopper
   routing.ch.disabling_allowed: true
   routing.max_visited_nodes: 1500000

--- a/grpc/src/main/java/RouterImpl.java
+++ b/grpc/src/main/java/RouterImpl.java
@@ -35,6 +35,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import router.RouterOuterClass.*;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -247,6 +248,8 @@ public class RouterImpl extends router.RouterGrpc.RouterImplBase {
         ghPtRequest.setLocale(Locale.US);
         ghPtRequest.setArriveBy(false);
         ghPtRequest.setPathDetails(Lists.newArrayList("stable_edge_ids"));
+        ghPtRequest.setProfileQuery(true);
+        ghPtRequest.setMaxProfileDuration(Duration.ofMinutes(request.getMaxProfileDuration()));
 
         try {
             GHResponse ghResponse = ptRouter.route(ghPtRequest);

--- a/grpc/src/main/java/RouterImpl.java
+++ b/grpc/src/main/java/RouterImpl.java
@@ -250,6 +250,7 @@ public class RouterImpl extends router.RouterGrpc.RouterImplBase {
         ghPtRequest.setPathDetails(Lists.newArrayList("stable_edge_ids"));
         ghPtRequest.setProfileQuery(true);
         ghPtRequest.setMaxProfileDuration(Duration.ofMinutes(request.getMaxProfileDuration()));
+        ghPtRequest.setBetaWalkTime(request.getBetaWalkTime());
 
         try {
             GHResponse ghResponse = ptRouter.route(ghPtRequest);

--- a/grpc/src/main/resources/assets/pt/src/data/Query.js
+++ b/grpc/src/main/resources/assets/pt/src/data/Query.js
@@ -24,6 +24,7 @@ const CreateQuery = (baseUrl, search) => {
     url.searchParams.set("profile", "pt");
     url.searchParams.set("pt.limit_solutions", search.limitSolutions);
     url.searchParams.set("pt.max_profile_duration", search.maxProfileDuration);
+    url.searchParams.set("pt.beta_walk_time", search.betaWalkTime);
     return url.toString();
 };
 
@@ -63,6 +64,8 @@ const ParseQuery = (search, searchParams) => {
     parse("pt.profile_duration", "rangeQueryDuration", searchParams);
     parse("pt.limit_street_time", "limitStreetTime", searchParams);
     parse("pt.ignore_transfers", "ignoreTransfers", searchParams);
+    parse("pt.max_profile_duration", "maxProfileDuration", searchParams);
+    parse("pt.beta_walk_time", "betaWalkTime", searchParams);
     return search;
 };
 

--- a/grpc/src/main/resources/assets/pt/src/data/Query.js
+++ b/grpc/src/main/resources/assets/pt/src/data/Query.js
@@ -23,6 +23,7 @@ const CreateQuery = (baseUrl, search) => {
     url.searchParams.set("locale", "en-US");
     url.searchParams.set("profile", "pt");
     url.searchParams.set("pt.limit_solutions", search.limitSolutions);
+    url.searchParams.set("pt.max_profile_duration", search.maxProfileDuration);
     return url.toString();
 };
 

--- a/grpc/src/main/resources/assets/pt/src/view/App.js
+++ b/grpc/src/main/resources/assets/pt/src/view/App.js
@@ -31,9 +31,9 @@ export default class App extends React.Component {
             from: null,
             to: null,
             departureDateTime: new moment(),
-            limitSolutions: 3,
-            maxProfileDuration: 5,
-            betaWalkTime: 1.0,
+            limitSolutions: 4,
+            maxProfileDuration: 10,
+            betaWalkTime: 1.5,
             routes: {
                 query: null,
                 isFetching: false

--- a/grpc/src/main/resources/assets/pt/src/view/App.js
+++ b/grpc/src/main/resources/assets/pt/src/view/App.js
@@ -33,6 +33,7 @@ export default class App extends React.Component {
             departureDateTime: new moment(),
             limitSolutions: 3,
             maxProfileDuration: 5,
+            betaWalkTime: 1.0,
             routes: {
                 query: null,
                 isFetching: false
@@ -85,6 +86,7 @@ export default class App extends React.Component {
                     ptRouteRequest.setEarliestDepartureTime(timestampFromDate);
                     ptRouteRequest.setLimitSolutions(this.state.limitSolutions);
                     ptRouteRequest.setMaxProfileDuration(this.state.maxProfileDuration);
+                    ptRouteRequest.setBetaWalkTime(this.state.betaWalkTime);
                     var component = this;
                     var router = new Router.RouterClient('/api');
                     router.routePt(ptRouteRequest, null, function(err, response) {

--- a/grpc/src/main/resources/assets/pt/src/view/App.js
+++ b/grpc/src/main/resources/assets/pt/src/view/App.js
@@ -32,6 +32,7 @@ export default class App extends React.Component {
             to: null,
             departureDateTime: new moment(),
             limitSolutions: 3,
+            maxProfileDuration: 5,
             routes: {
                 query: null,
                 isFetching: false
@@ -83,6 +84,7 @@ export default class App extends React.Component {
                     const timestampFromDate = timestamp_pb.Timestamp.fromDate(this.state.departureDateTime.toDate());
                     ptRouteRequest.setEarliestDepartureTime(timestampFromDate);
                     ptRouteRequest.setLimitSolutions(this.state.limitSolutions);
+                    ptRouteRequest.setMaxProfileDuration(this.state.maxProfileDuration);
                     var component = this;
                     var router = new Router.RouterClient('/api');
                     router.routePt(ptRouteRequest, null, function(err, response) {

--- a/grpc/src/main/resources/assets/pt/src/view/sidebar/SearchInput.js
+++ b/grpc/src/main/resources/assets/pt/src/view/sidebar/SearchInput.js
@@ -74,6 +74,12 @@ class SearchInput extends React.Component {
                 label: "Max profile duration (minutes)",
                 onChange: this.handleInputChange,
                 actionType: "maxProfileDuration"
+            }),
+            React.createElement(NumberInput, {
+                value: this.props.search.betaWalkTime,
+                label: "Beta walk time (values > 1.0 disincentivize walking)",
+                onChange: this.handleInputChange,
+                actionType: "betaWalkTime"
             })
         ) : ""));
     }

--- a/grpc/src/main/resources/assets/pt/src/view/sidebar/SearchInput.js
+++ b/grpc/src/main/resources/assets/pt/src/view/sidebar/SearchInput.js
@@ -68,6 +68,12 @@ class SearchInput extends React.Component {
                 label: "Limit # solutions",
                 onChange: this.handleInputChange,
                 actionType: "limitSolutions"
+            }),
+            React.createElement(NumberInput, {
+                value: this.props.search.maxProfileDuration,
+                label: "Max profile duration (minutes)",
+                onChange: this.handleInputChange,
+                actionType: "maxProfileDuration"
             })
         ) : ""));
     }

--- a/replica-common/pom.xml
+++ b/replica-common/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>com.graphhopper</groupId>
             <artifactId>graphhopper-matrix</artifactId>
-            <version>3.0-replica2</version>
+            <version>3.0-replica3</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Transfers through the street network are now generated (interpolated, as GTFS spec calls it) by walking through the street network around stations, similar to how it was already being done between different feeds.

This happens even when a `transfers.txt` is present -- but specified transfer times, if present, override those obtained by routing.

The radius around stations that is explored is a config parameter:

```
gtfs.max_transfer_interpolation_walk_time_seconds: 300
```

I'd suggest experimenting locally -- set it too high and we'll likely see a slowdown.

It's possible that this will also go some way towards solving the **parent/child-station**-issue: We should now get transfers from platform to platform of different stations, and within stations, through the auto-detection alone.