### PR TITLE
Change base image for downstream installs and add GRAPHHOPPER_READ_ONLY env var

### DIFF
--- a/Dockerfile.model
+++ b/Dockerfile.model
@@ -53,7 +53,7 @@ RUN mvn -s maven_settings.xml --projects grpc -am -DskipTests=true package && \
 
 
 # copy over JARs + web assets + config YAMLs for running server
-FROM openjdk:14.0.2-jdk
+FROM openjdk:14.0.2-jdk-slim-buster
 
 RUN mkdir -p /data
 WORKDIR /graphhopper

--- a/Dockerfile.model
+++ b/Dockerfile.model
@@ -68,7 +68,7 @@ VOLUME [ "/data" ]
 EXPOSE 50051
 EXPOSE 8998
 
-CMD java -server -Xmx${HEAP_XMX_GB:-13}g -Xms6g \
+CMD java -server -Xms${HEAP_XMS_GB:-6}g -Xmx${HEAP_XMX_GB:-13}g \
   -XX:+UseG1GC -XX:MetaspaceSize=100M \
   -classpath grpc/target/graphhopper-grpc-1.0-SNAPSHOT.jar \
   RouterServer default_gh_config.yaml

--- a/Dockerfile.model
+++ b/Dockerfile.model
@@ -67,3 +67,8 @@ VOLUME [ "/data" ]
 
 EXPOSE 50051
 EXPOSE 8998
+
+CMD java -server -Xmx${HEAP_XMX_GB:-13}g -Xms6g \
+  -XX:+UseG1GC -XX:MetaspaceSize=100M \
+  -classpath grpc/target/graphhopper-grpc-1.0-SNAPSHOT.jar \
+  RouterServer default_gh_config.yaml

--- a/Dockerfile.model
+++ b/Dockerfile.model
@@ -67,8 +67,16 @@ VOLUME [ "/data" ]
 
 EXPOSE 50051
 EXPOSE 8998
+EXPOSE 9010
 
 CMD java -server -Xms${HEAP_XMS_GB:-6}g -Xmx${HEAP_XMX_GB:-13}g \
+  -Dcom.sun.management.jmxremote \
+  -Dcom.sun.management.jmxremote.authenticate=false \
+  -Dcom.sun.management.jmxremote.ssl=false \
+  -Dcom.sun.management.jmxremote.local.only=false \
+  -Dcom.sun.management.jmxremote.port=9010 \
+  -Dcom.sun.management.jmxremote.rmi.port=9010 \
+  -Djava.rmi.server.hostname=127.0.0.1 \
   -XX:+UseG1GC -XX:MetaspaceSize=100M \
   -classpath grpc/target/graphhopper-grpc-1.0-SNAPSHOT.jar \
   RouterServer default_gh_config.yaml

--- a/grpc/src/main/java/RouterServer.java
+++ b/grpc/src/main/java/RouterServer.java
@@ -90,7 +90,7 @@ public class RouterServer {
 
         File linkMappingsDbFile = new File("transit_data/gtfs_link_mappings.db");
         if (linkMappingsDbFile.exists()) {
-            DB db = DBMaker.newFileDB(linkMappingsDbFile).make();
+            DB db = DBMaker.newFileDB(linkMappingsDbFile).readOnly().make();
             gtfsLinkMappings = db.getHashMap("gtfsLinkMappings");
             gtfsRouteInfo = db.getHashMap("gtfsRouteInfo");
             gtfsFeedIdMapping = db.getHashMap("gtfsFeedIdMap");

--- a/web-bundle/src/main/java/com/graphhopper/http/GraphHopperManaged.java
+++ b/web-bundle/src/main/java/com/graphhopper/http/GraphHopperManaged.java
@@ -139,6 +139,7 @@ public class GraphHopperManaged implements Managed {
         graphHopper.setEncodedValueFactory(new EncodedValueFactoryWithStableId());
         graphHopper.init(configuration);
         graphHopper.setPathDetailsBuilderFactory(new PathDetailsBuilderFactoryWithStableId());
+        graphHopper.setAllowWrites(!Boolean.parseBoolean(System.getenv("GRAPHHOPPER_READ_ONLY")));
     }
 
     @Override

--- a/web-bundle/src/main/java/com/graphhopper/resources/PtRouteResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/PtRouteResource.java
@@ -42,7 +42,7 @@ public class PtRouteResource {
 
     // Statically load GTFS link mapping and GTFS route info maps for use in building responses
     static {
-        DB db = DBMaker.newFileDB(new File("transit_data/gtfs_link_mappings.db")).make();
+        DB db = DBMaker.newFileDB(new File("transit_data/gtfs_link_mappings.db")).readOnly().make();
         gtfsLinkMappings = db.getHashMap("gtfsLinkMappings");
         gtfsRouteInfo = db.getHashMap("gtfsRouteInfo");
         gtfsFeedIdMapping = db.getHashMap("gtfsFeedIdMap");

--- a/web/src/main/java/com/graphhopper/http/cli/ExportCommand.java
+++ b/web/src/main/java/com/graphhopper/http/cli/ExportCommand.java
@@ -66,7 +66,7 @@ public class ExportCommand extends ConfiguredCommand<GraphHopperServerConfigurat
         }
 
         // Load OSM info needed for export from MapDB database file
-        DB db = DBMaker.newFileDB(new File("transit_data/osm_info.db")).make();
+        DB db = DBMaker.newFileDB(new File("transit_data/osm_info.db")).readOnly().make();
         Map<Long, Map<String, String>> osmIdToLaneTags = db.getHashMap("osmIdToLaneTags");
         Map<Integer, Long> ghIdToOsmId = db.getHashMap("ghIdToOsmId");
         Map<Long, List<String>> osmIdToAccessFlags = db.getHashMap("osmIdToAccessFlags");


### PR DESCRIPTION
Some downstream images need to install packages, but the stock openjdk image doesn't come with any package manager. The
`slim-buster` image is actually smaller _and_ comes with `apt-get`.

I also added a `GRAPHHOPPER_READ_ONLY` env var to enable GraphHoppers' read only mode (and set the link mapper `DBMaker`
to be read only by default when appropriate).
