### PR TITLE
Permit gPRC clients to send keepalive pings without data

### DIFF
--- a/grpc/src/main/java/io/grpcweb/GrpcServiceConnectionManager.java
+++ b/grpc/src/main/java/io/grpcweb/GrpcServiceConnectionManager.java
@@ -36,6 +36,7 @@ class GrpcServiceConnectionManager {
   GrpcServiceConnectionManager(int grpcPortNum) {
     // TODO: Manage a connection pool.
     mChannel = ManagedChannelBuilder.forAddress("localhost", grpcPortNum)
+        .keepAliveWithoutCalls(true)
         .usePlaintext()
         .build();
     LOG.info("**** connection channel initiated");


### PR DESCRIPTION
Currently our router performance degrades significantly when jobs are finishing. After looking into gRPC keepalive settings, I believe one issue is that by default gRPC servers only permit 2 keepalive pings outside the context of data being exchanged. Our Python clients are sending keepalive pings every 5 minutes. Therefore, the servers automatically disconnect clients after 10 minutes. The client does not know this until it tries to make its next call, and errors result. There may be other issues as well, but I would like to test changing this one setting first to observe the effects of setting it. 

Helpful documentation:
https://grpc.github.io/grpc-java/javadoc/io/grpc/netty/NettyServerBuilder.html
https://grpc.io/docs/what-is-grpc/core-concepts/#deadlines
https://github.com/grpc/grpc-java/issues/7237
https://github.com/grpc/grpc/issues/17667