### PR TITLE
[RAD-1989] Refactor StreetEdgeExporter and add unit test

### DIFF
--- a/web-bundle/src/main/java/com/graphhopper/replica/StreetEdgeExportRecord.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/StreetEdgeExportRecord.java
@@ -1,0 +1,38 @@
+package com.graphhopper.replica;
+
+public class StreetEdgeExportRecord {
+    public String edgeId;
+    public int startVertexId;
+    public int endVertexId;
+    public double startLat;
+    public double startLon;
+    public double endLat;
+    public double endLon;
+    public String geometryString;
+    public String streetName;
+    public long distanceMillimeters;
+    public long osmId;
+    public int speedCms;
+    public String flags;
+    public int lanes;
+    public String highwayTag;
+
+    public StreetEdgeExportRecord(String edgeId, int startVertexId, int endVertexId, double startLat, double startLon, double endLat, double endLon, String geometryString, String streetName, long distanceMillimeters, long osmId, int speedCms, String flags, int lanes, String highwayTag) {
+        this.edgeId = edgeId;
+        this.startVertexId = startVertexId;
+        this.endVertexId = endVertexId;
+        this.startLat = startLat;
+        this.startLon = startLon;
+        this.endLat = endLat;
+        this.endLon = endLon;
+        this.geometryString = geometryString;
+        this.streetName = streetName;
+        this.distanceMillimeters = distanceMillimeters;
+        this.osmId = osmId;
+        this.speedCms = speedCms;
+        this.flags = flags;
+        this.lanes = lanes;
+        this.highwayTag = highwayTag;
+    }
+}
+

--- a/web-bundle/src/main/java/com/graphhopper/replica/StreetEdgeExporter.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/StreetEdgeExporter.java
@@ -46,8 +46,26 @@ public class StreetEdgeExporter {
     //
     private NodeAccess nodes;
     private DecimalEncodedValue avgSpeedEnc;
-    StableIdEncodedValues stableIdEncodedValues;
-    EnumEncodedValue<RoadClass> roadClassEnc;
+    private StableIdEncodedValues stableIdEncodedValues;
+    private EnumEncodedValue<RoadClass> roadClassEnc;
+
+    public StreetEdgeExporter(GraphHopper configuredGraphHopper, Map<Long, Map<String, String>> osmIdToLaneTags, Map<Integer, Long> ghIdToOsmId, Map<Long, List<String>> osmIdToAccessFlags, Map<Long, String> osmIdToStreetName, Map<Long, String> osmIdToHighway) {
+        this.osmIdToLaneTags = osmIdToLaneTags;
+        this.ghIdToOsmId = ghIdToOsmId;
+        this.osmIdToAccessFlags = osmIdToAccessFlags;
+        this.osmIdToStreetName = osmIdToStreetName;
+        this.osmIdToHighway = osmIdToHighway;
+
+        GraphHopperStorage graphHopperStorage = configuredGraphHopper.getGraphHopperStorage();
+        nodes = graphHopperStorage.getNodeAccess();
+
+        // Setup encoders for determining speed and road type info for each edge
+        EncodingManager encodingManager = configuredGraphHopper.getEncodingManager();
+        stableIdEncodedValues = StableIdEncodedValues.fromEncodingManager(encodingManager);
+        roadClassEnc = encodingManager.getEnumEncodedValue(RoadClass.KEY, RoadClass.class);
+        CarFlagEncoder carFlagEncoder = (CarFlagEncoder)encodingManager.getEncoder("car");
+        avgSpeedEnc = carFlagEncoder.getAverageSpeedEnc();
+    }
 
     public List<StreetEdgeExportRecord> generateRecords(EdgeIteratorState iteratorState) {
         List<StreetEdgeExportRecord> output = new ArrayList<>();

--- a/web-bundle/src/main/java/com/graphhopper/replica/StreetEdgeExporter.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/StreetEdgeExporter.java
@@ -56,6 +56,7 @@ public class StreetEdgeExporter {
         this.osmIdToStreetName = osmIdToStreetName;
         this.osmIdToHighway = osmIdToHighway;
 
+        // Grab edge/node iterators for graph loaded from pre-built GH files
         GraphHopperStorage graphHopperStorage = configuredGraphHopper.getGraphHopperStorage();
         nodes = graphHopperStorage.getNodeAccess();
 
@@ -170,20 +171,9 @@ public class StreetEdgeExporter {
                                             Map<Long, String> osmIdToStreetName,
                                             Map<Long, String> osmIdToHighway) {
 
-        // Grab edge/node iterators for graph loaded from pre-built GH files
+        StreetEdgeExporter exporter = new StreetEdgeExporter(configuredGraphHopper, osmIdToLaneTags, ghIdToOsmId, osmIdToAccessFlags, osmIdToStreetName, osmIdToHighway);
         GraphHopperStorage graphHopperStorage = configuredGraphHopper.getGraphHopperStorage();
         AllEdgesIterator edgeIterator = graphHopperStorage.getAllEdges();
-        NodeAccess nodes = graphHopperStorage.getNodeAccess();
-
-        // Setup encoders for determining speed and road type info for each edge
-        EncodingManager encodingManager = configuredGraphHopper.getEncodingManager();
-        StableIdEncodedValues stableIdEncodedValues = StableIdEncodedValues.fromEncodingManager(encodingManager);
-        final EnumEncodedValue<RoadClass> roadClassEnc =
-                encodingManager.getEnumEncodedValue(RoadClass.KEY, RoadClass.class);
-        CarFlagEncoder carFlagEncoder = (CarFlagEncoder)encodingManager.getEncoder("car");
-        DecimalEncodedValue avgSpeedEnc = carFlagEncoder.getAverageSpeedEnc();
-
-        logger.info("Writing street edges...");
         File outputFile = new File(configuredGraphHopper.getGraphHopperLocation() + "/street_edges.csv");
 
         // For each bidirectional edge in pre-built graph, calculate value of each CSV column
@@ -195,94 +185,13 @@ public class StreetEdgeExporter {
             try (CSVPrinter printer = new CSVPrinter(out, CSV_FORMAT)) {
                 while (edgeIterator.next()) {
                     totalEdgeCount++;
-                    // Fetch starting and ending vertices
-                    int ghEdgeId = edgeIterator.getEdge();
-                    int startVertex = edgeIterator.getBaseNode();
-                    int endVertex = edgeIterator.getAdjNode();
-                    double startLat = nodes.getLat(startVertex);
-                    double startLon = nodes.getLon(startVertex);
-                    double endLat = nodes.getLat(endVertex);
-                    double endLon = nodes.getLon(endVertex);
-
-                    // Get edge geometry for both edge directions, and distance
-                    PointList wayGeometry = edgeIterator.fetchWayGeometry(FetchMode.ALL);
-                    String geometryString = wayGeometry.toLineString(false).toString();
-                    wayGeometry.reverse();
-                    String reverseGeometryString = wayGeometry.toLineString(false).toString();
-
-                    long distanceMeters = Math.round(DistanceCalcEarth.DIST_EARTH.calcDist(startLat, startLon, endLat, endLon));
-
-                    int speedcms = getSpeedcms(edgeIterator, avgSpeedEnc);
-
-                    // Convert GH's distance in meters to millimeters to match R5's implementation
-                    long distanceMillimeters = distanceMeters * 1000;
-
-                    // Fetch OSM ID, skipping edges from PT meta-graph that have no IDs set (getOsmIdForGhEdge returns -1)
-                    long osmId = OsmHelper.getOsmIdForGhEdge(edgeIterator.getEdge(), ghIdToOsmId);
-                    if (osmId == -1L) {
+                    List<StreetEdgeExportRecord> records = exporter.generateRecords(edgeIterator);
+                    if(records.isEmpty()){
                         skippedEdgeCount++;
-                        continue;
                     }
-
-                    // Use street name parsed from Ways/Relations, if it exists; otherwise, use default GH edge name
-                    String streetName = osmIdToStreetName.getOrDefault(osmId, edgeIterator.getName());
-
-                    // Grab OSM highway type and encoded stable IDs for both edge directions
-                    String highwayTag = osmIdToHighway.getOrDefault(osmId, edgeIterator.get(roadClassEnc).toString());
-                    String forwardStableEdgeId = stableIdEncodedValues.getStableId(false, edgeIterator);
-                    String backwardStableEdgeId = stableIdEncodedValues.getStableId(true, edgeIterator);
-
-                    // Set accessibility flags for each edge direction
-                    // Returned flags are from the set {ALLOWS_CAR, ALLOWS_BIKE, ALLOWS_PEDESTRIAN}
-                    String forwardFlags = OsmHelper.getFlagsForGhEdge(ghEdgeId, false, osmIdToAccessFlags, ghIdToOsmId);
-                    String backwardFlags = OsmHelper.getFlagsForGhEdge(ghEdgeId, true, osmIdToAccessFlags, ghIdToOsmId);
-
-                    // Calculate number of lanes for edge, as done in R5, based on OSM tags + edge direction
-                    int overallLanes = parseLanesTag(osmId, osmIdToLaneTags, "lanes");
-                    int forwardLanes = parseLanesTag(osmId, osmIdToLaneTags, "lanes:forward");
-                    int backwardLanes = parseLanesTag(osmId, osmIdToLaneTags, "lanes:backward");
-
-                    if (!backwardFlags.contains("ALLOWS_CAR")) {
-                        backwardLanes = 0;
-                    }
-                    if (backwardLanes == -1) {
-                        if (overallLanes != -1) {
-                            if (forwardLanes != -1) {
-                                backwardLanes = overallLanes - forwardLanes;
-                            }
-                        }
-                    }
-
-                    if (!forwardFlags.contains("ALLOWS_CAR")) {
-                        forwardLanes = 0;
-                    }
-                    if (forwardLanes == -1) {
-                        if (overallLanes != -1) {
-                            if (backwardLanes != -1) {
-                                forwardLanes = overallLanes - backwardLanes;
-                            } else if (forwardFlags.contains("ALLOWS_CAR")) {
-                                forwardLanes = overallLanes / 2;
-                            }
-                        }
-                    }
-
-                    // Copy R5's logic; filter out edges with unwanted highway tags and negative OSM IDs
-                    // todo: do negative OSM ids happen in GH? This might have been R5-specific
-                    if (!HIGHWAY_FILTER_TAGS.contains(highwayTag) && osmId >= 0) {
-                        // Print line for each edge direction, if edge is accessible.
-                        // Inaccessible edges have no flags set; flags are stored as stringified lists,
-                        // so innaccessible edges will have a flag equal to "[]", the empty list's toString().
-                        // Only remove inaccessible edges with highway tags of motorway or motorway_link
-                        if (!(forwardFlags.equals("[]") && INACCESSIBLE_MOTORWAY_TAGS.contains(highwayTag))) {
-                            printer.printRecord(forwardStableEdgeId, startVertex, endVertex,
-                                    startLat, startLon, endLat, endLon, geometryString, streetName,
-                                    distanceMillimeters, osmId, speedcms, forwardFlags, forwardLanes, highwayTag);
-                        }
-                        if (!(backwardFlags.equals("[]") && INACCESSIBLE_MOTORWAY_TAGS.contains(highwayTag))) {
-                            printer.printRecord(backwardStableEdgeId, endVertex, startVertex,
-                                    endLat, endLon, startLat, startLon, reverseGeometryString, streetName,
-                                    distanceMillimeters, osmId, speedcms, backwardFlags, backwardLanes, highwayTag);
-                        }
+                    for(StreetEdgeExportRecord r : records) {
+                        printer.printRecord(r.edgeId, r.startVertexId, r.endVertexId, r.startLat, r.startLon, r.endLat, r.endLon,
+                                r.geometryString, r.streetName, r.distanceMillimeters, r.osmId, r.speedCms, r.flags, r.lanes, r.highwayTag);
                     }
                 }
             }

--- a/web/src/main/java/com/graphhopper/http/cli/ExportCommand.java
+++ b/web/src/main/java/com/graphhopper/http/cli/ExportCommand.java
@@ -1,35 +1,18 @@
 package com.graphhopper.http.cli;
 
-import com.google.common.collect.Lists;
 import com.graphhopper.GraphHopper;
 import com.graphhopper.http.GraphHopperManaged;
 import com.graphhopper.http.GraphHopperServerConfiguration;
-import com.graphhopper.replica.OsmHelper;
 import com.graphhopper.replica.StreetEdgeExporter;
-import com.graphhopper.routing.ev.DecimalEncodedValue;
-import com.graphhopper.routing.ev.EnumEncodedValue;
-import com.graphhopper.routing.ev.RoadClass;
-import com.graphhopper.routing.util.AllEdgesIterator;
-import com.graphhopper.routing.util.CarFlagEncoder;
-import com.graphhopper.routing.util.EncodingManager;
-import com.graphhopper.stableid.StableIdEncodedValues;
-import com.graphhopper.storage.GraphHopperStorage;
-import com.graphhopper.storage.NodeAccess;
-import com.graphhopper.util.DistanceCalcEarth;
-import com.graphhopper.util.FetchMode;
-import com.graphhopper.util.PointList;
 import io.dropwizard.cli.ConfiguredCommand;
 import io.dropwizard.setup.Bootstrap;
 import net.sourceforge.argparse4j.inf.Namespace;
-import org.apache.commons.csv.CSVFormat;
-import org.apache.commons.csv.CSVPrinter;
 import org.mapdb.DB;
 import org.mapdb.DBMaker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.*;
-import java.util.Arrays;
+import java.io.File;
 import java.util.List;
 import java.util.Map;
 

--- a/web/src/test/java/com/replica/StreetEdgeExporterTest.java
+++ b/web/src/test/java/com/replica/StreetEdgeExporterTest.java
@@ -122,9 +122,18 @@ public class StreetEdgeExporterTest {
         GraphHopperStorage graphHopperStorage = configuredGraphHopper.getGraphHopperStorage();
         AllEdgesIterator edgeIterator = graphHopperStorage.getAllEdges();
 
+        // Generate the rows for the first item in the edge iterator
         edgeIterator.next();
         List<StreetEdgeExportRecord> records = exporter.generateRecords(edgeIterator);
+        // Expect that two items will be generated
         assertEquals(2, records.size());
+        // They should be each other's reverse edges
+        StreetEdgeExportRecord record0 = records.get(0);
+        StreetEdgeExportRecord record1 = records.get(1);
+        assertEquals(record0.startVertexId, record1.endVertexId);
+        assertEquals(record0.endVertexId, record1.startVertexId);
+        assertEquals(record0.startLat, record1.endLat);
+        assertEquals(record0.startLon, record1.endLon);
 
     }
 }

--- a/web/src/test/java/com/replica/StreetEdgeExporterTest.java
+++ b/web/src/test/java/com/replica/StreetEdgeExporterTest.java
@@ -47,6 +47,7 @@ public class StreetEdgeExporterTest {
     private static final String TARGET_DIR = "./target/gtfs-app-gh/";
     private static final String TRANSIT_DATA_DIR = "transit_data/";
 
+    private Bootstrap<GraphHopperServerConfiguration> bootstrap;
     private Cli cli;
 
     @BeforeAll
@@ -65,7 +66,7 @@ public class StreetEdgeExporterTest {
         when(location.getVersion()).thenReturn(Optional.of("1.0.0"));
 
         // Add commands you want to test
-        final Bootstrap<GraphHopperServerConfiguration> bootstrap = new Bootstrap<>(new GraphHopperApplication());
+        bootstrap = new Bootstrap<>(new GraphHopperApplication());
         bootstrap.addBundle(new GraphHopperBundle());
         bootstrap.addCommand(new ImportCommand());
         bootstrap.addCommand(new ExportCommand());
@@ -101,11 +102,6 @@ public class StreetEdgeExporterTest {
                 putObject("graph.location", TARGET_DIR).
                 setProfiles(Collections.singletonList(new Profile("foot").setVehicle("foot").setWeighting("fastest")));
 
-        // TODO copied from setUp
-        // Add commands you want to test
-        final Bootstrap<GraphHopperServerConfiguration> bootstrap = new Bootstrap<>(new GraphHopperApplication());
-        bootstrap.addBundle(new GraphHopperBundle());
-
         // TODO copied from ExportCommand
         // Read in pre-built GH graph files from /transit_data/graphhopper
         final GraphHopperManaged graphHopper =
@@ -129,5 +125,6 @@ public class StreetEdgeExporterTest {
         edgeIterator.next();
         List<StreetEdgeExportRecord> records = exporter.generateRecords(edgeIterator);
         assertEquals(2, records.size());
+
     }
 }

--- a/web/src/test/java/com/replica/StreetEdgeExporterTest.java
+++ b/web/src/test/java/com/replica/StreetEdgeExporterTest.java
@@ -1,7 +1,6 @@
 package com.replica;
 
 import com.google.common.base.Preconditions;
-import com.graphhopper.config.Profile;
 import com.graphhopper.http.GraphHopperApplication;
 import com.graphhopper.http.GraphHopperBundle;
 import com.graphhopper.http.GraphHopperServerConfiguration;
@@ -11,8 +10,6 @@ import com.graphhopper.replica.StreetEdgeExporter;
 import com.graphhopper.util.Helper;
 import io.dropwizard.cli.Cli;
 import io.dropwizard.setup.Bootstrap;
-import io.dropwizard.testing.junit5.DropwizardAppExtension;
-import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import io.dropwizard.util.JarLocation;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
@@ -21,12 +18,10 @@ import org.apache.commons.csv.CSVRecord;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -35,22 +30,10 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(DropwizardExtensionsSupport.class)
 public class StreetEdgeExporterTest {
 
     private static final String TARGET_DIR = "./target/gtfs-app-gh/";
     private static final String TRANSIT_DATA_DIR = "transit_data/";
-    public static final DropwizardAppExtension<GraphHopperServerConfiguration> app = new DropwizardAppExtension<>(GraphHopperApplication.class, createConfig());
-    private static GraphHopperServerConfiguration createConfig() {
-        GraphHopperServerConfiguration config = new GraphHopperServerConfiguration();
-        config.getGraphHopperConfiguration().
-                putObject("graph.flag_encoders", "car,foot").
-                putObject("datareader.file", "test-data/beatty.osm").
-                putObject("gtfs.file", "test-data/sample-feed.zip").
-                putObject("graph.location", TARGET_DIR).
-                setProfiles(Collections.singletonList(new Profile("car").setVehicle("car").setWeighting("fastest")));
-        return config;
-    }
 
     @BeforeAll
     public static void setUp() {


### PR DESCRIPTION
# Background

As it stands today, `StreetEdgeExporter` contains basically a single method that iterates through all edges in the internal db, generates whatever properties about them we need to know, and writes those out to a csv. My goal here is to decompose that functionality so that the business logic can be unit-tested.

# Description

In this PR, I've tried to decompose that somewhat, so that the "generates whatever properties" part is separated from the iterating and writing to csv. I've then added the seed of a unit test for that business logic. In order to accomplish this, I had to do a few things:
* Create a class to represent a "record", corresponding to one line in the output csv. Our business logic generates 0-2 of these records for each edge that it considers. This was a pretty lazy class, with everything left public - I just wanted a container for a bunch of properties
* Add some fields to the `StreetEdgeExporter` class and create a constructor. This was to have a place to store values that are shared between iterations in the main loop of csv exports. I thought it was a bit more convenient to put them on the class than to pass them as parameters to a function.
* Extract a function that operates on a `EdgeIteratorState` (this is basically what we get when we iterate through edges) and returns the records that correspond to that record
* Add a unit test that calls this function directly, and makes some assertions about its output.

Now, at this point, I'm still using the same test data for both the end-to-end test and this 'unit' test. I'm also making very limited assertions about what I expect to be returned from the test data, because I basically don't know what's reasonable to expect. But, with this structure, it should be possible to generate some synthetic inputs and make more targeted assertions. Let's talk about what we'd like to do there!