### PR TITLE
Fix route type check for adding link-mapped edge IDs in PT server

### DIFF
--- a/grpc/src/main/java/RouterImpl.java
+++ b/grpc/src/main/java/RouterImpl.java
@@ -436,7 +436,7 @@ public class RouterImpl extends router.RouterGrpc.RouterImplBase {
         String routeType = routeInfo.get(3);
 
         List<String> stableEdgeIdsList = Lists.newArrayList();
-        if (STREET_BASED_ROUTE_TYPES.contains(routeType)) {
+        if (STREET_BASED_ROUTE_TYPES.contains(Integer.parseInt(routeType))) {
             // Retrieve stable edge IDs for each stop->stop segment of leg
             List<Trip.Stop> stops = leg.stops;
             List<String> stableEdgeIdSegments = Lists.newArrayList();


### PR DESCRIPTION
While making [this](https://github.com/replicahq/graphhopper/pull/57) fix to how edge IDs found by the GTFS link mapper get returned by the server at query time, a bug was introduced on [this](https://github.com/replicahq/graphhopper/pull/57/files#diff-267115fa81fbfa77f290254a70b8013854fd1262c25bd622f67a125eea452982R427) line. Specifically, we're checking a java `String` (which should always hold a numeric value, like `3`) against a set of java `Integer`s; java lets you do this, because technically both are `Object`s, but logically, we should be casting the string to an int before doing the check (otherwise, it will always return `false`). 

The impact here is that no link-mapped edge IDs were returned for PT responses since the bug was introduced.