### PR TITLE
Use correct key into GTFS link mapping in PT server

### DIFF
--- a/grpc/src/main/java/RouterImpl.java
+++ b/grpc/src/main/java/RouterImpl.java
@@ -491,7 +491,7 @@ public class RouterImpl extends router.RouterGrpc.RouterImplBase {
             List<Trip.Stop> stops = leg.stops;
             List<String> stableEdgeIdSegments = Lists.newArrayList();
             for (int i = 0; i < stops.size() - 1; i++) {
-                String stopPair = leg.feed_id + ":" + stops.get(i).stop_id + "," + stops.get(i + 1).stop_id;
+                String stopPair = gtfsFeedIdMapping.get(leg.feed_id) + ":" + stops.get(i).stop_id + "," + stops.get(i + 1).stop_id;
                 if (gtfsLinkMappings.containsKey(stopPair)) {
                     if (!gtfsLinkMappings.get(stopPair).isEmpty()) {
                         stableEdgeIdSegments.add(gtfsLinkMappings.get(stopPair));


### PR DESCRIPTION
In #67 , we corrected an issue with the key we used in the internal GTFS link mapping we store that's used by the transit routing server at query time. However, there was a bug in our implementation - the new key is supposed to be `feed id + first stop id + next stop id`, but we were using graphhopper's internal feed ID coming from the transit leg, which is usually something like `feed_1`, instead of what we really wanted, the filename of the feed (eg `srtd`).

It turns out, we've hit this issue before, and already store a mapping of graphhoppers internal feed id -> the filename of the feed. So, we just need to look in that mapping to grab the correct feed ID for use in the key into the link mappings.

Tested locally with sacramento - built link mappings fresh, spun up server, queried, saw stable edge IDs in PT legs in result.