### PR TITLE
[RAD-2593] Basic functional test for Graphhopper

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,9 +36,33 @@ jobs:
       - run:
           name: Push image
           command: gcloud docker -- push us.gcr.io/model-159019/gh:$(cat /tmp/tag)
-
+  functional-test:
+    docker:
+      - image: google/cloud-sdk
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - run: git submodule sync
+      - run: git submodule update --init
+      - run: &setup_gcloud
+          name: Setup gcloud
+          command: |
+            echo ${GCLOUD_SERVICE_KEY} | base64 -d > ${HOME}/gcp-key.json
+            gcloud auth activate-service-account --key-file ${HOME}/gcp-key.json
+            gcloud --quiet config set project model-159019
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run:
+        name: Install deps
+        command: apt-get install grpcurl jq
+      - run:
+        name: Run functional test
+        command: ./functional_test.sh $(git rev-parse --short=8 HEAD)
 workflows:
   version: 2
   build-and-publish:
     jobs:
       - publish-docker
+      - functional-test:
+        requires:
+          - publish-docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,10 +54,10 @@ jobs:
           docker_layer_caching: true
       - run:
           name: Install apt packages
-          command: apt-get install wget jq
+          command: apt-get install -y wget jq
       - run:
           name: Install grpcurl
-          command: wget https://github.com/fullstorydev/grpcurl/releases/download/v1.1.0/grpcurl_1.1.0_linux_x86_64.tar.gz && tar -xvzf grpcurl_1.1.0_linux_x86_64.tar.gz && chmod +x grpcurl && mv grpcurl /usr/local/bin/grpcurl
+          command: wget https://github.com/fullstorydev/grpcurl/releases/download/v1.8.1/grpcurl_1.8.1_linux_x86_64.tar.gz && tar -xvzf grpcurl_1.8.1_linux_x86_64.tar.gz && chmod +x grpcurl && mv grpcurl /usr/local/bin/grpcurl
       - run:
           name: Run functional test
           command: ./functional_test.sh $(git rev-parse --short=8 HEAD)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,9 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
+          name: Pull image
+          command: gcloud docker -- pull us.gcr.io/model-159019/gh:$(git rev-parse --short=8 HEAD)
+      - run:
           name: Install apt packages
           command: apt-get install -y wget jq
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,16 +53,16 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
-        name: Install deps
-        command: apt-get install grpcurl jq
+          name: Install deps
+          command: apt-get install grpcurl jq
       - run:
-        name: Run functional test
-        command: ./functional_test.sh $(git rev-parse --short=8 HEAD)
+          name: Run functional test
+          command: ./functional_test.sh $(git rev-parse --short=8 HEAD)
 workflows:
   version: 2
   build-and-publish:
     jobs:
       - publish-docker
       - functional-test:
-        requires:
-          - publish-docker
+          requires:
+            - publish-docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,39 +36,8 @@ jobs:
       - run:
           name: Push image
           command: gcloud docker -- push us.gcr.io/model-159019/gh:$(cat /tmp/tag)
-  functional-test:
-    docker:
-      - image: google/cloud-sdk
-    working_directory: ~/repo
-    steps:
-      - checkout
-      - run: git submodule sync
-      - run: git submodule update --init
-      - run: &setup_gcloud
-          name: Setup gcloud
-          command: |
-            echo ${GCLOUD_SERVICE_KEY} | base64 -d > ${HOME}/gcp-key.json
-            gcloud auth activate-service-account --key-file ${HOME}/gcp-key.json
-            gcloud --quiet config set project model-159019
-      - setup_remote_docker:
-          docker_layer_caching: true
-      - run:
-          name: Pull image
-          command: gcloud docker -- pull us.gcr.io/model-159019/gh:$(git rev-parse --short=8 HEAD)
-      - run:
-          name: Install apt packages
-          command: apt-get install -y wget jq
-      - run:
-          name: Install grpcurl
-          command: wget https://github.com/fullstorydev/grpcurl/releases/download/v1.8.1/grpcurl_1.8.1_linux_x86_64.tar.gz && tar -xvzf grpcurl_1.8.1_linux_x86_64.tar.gz && chmod +x grpcurl && mv grpcurl /usr/local/bin/grpcurl
-      - run:
-          name: Run functional test
-          command: ./functional_test.sh $(git rev-parse --short=8 HEAD)
 workflows:
   version: 2
   build-and-publish:
     jobs:
       - publish-docker
-      - functional-test:
-          requires:
-            - publish-docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,10 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
-          name: Install deps
+          name: Install apt packages
+          command: apt-get install wget jq
+      - run:
+          name: Install grpcurl
           command: wget https://github.com/fullstorydev/grpcurl/releases/download/v1.1.0/grpcurl_1.1.0_linux_x86_64.tar.gz && tar -xvzf grpcurl_1.1.0_linux_x86_64.tar.gz && chmod +x grpcurl && mv grpcurl /usr/local/bin/grpcurl
       - run:
           name: Run functional test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
           docker_layer_caching: true
       - run:
           name: Install deps
-          command: apt-get install grpcurl jq
+          command: wget https://github.com/fullstorydev/grpcurl/releases/download/v1.1.0/grpcurl_1.1.0_linux_x86_64.tar.gz && tar -xvzf grpcurl_1.1.0_linux_x86_64.tar.gz && chmod +x grpcurl && mv grpcurl /usr/local/bin/grpcurl
       - run:
           name: Run functional test
           command: ./functional_test.sh $(git rev-parse --short=8 HEAD)

--- a/functional_test.sh
+++ b/functional_test.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+if [ "$#" -lt 1 ]; then
+    echo "Usage: functional_test.sh TAG"
+    exit 1
+fi
+
+TAG=$1
+
 TMPDIR=$(mktemp -d)
 
 # Import cmd
@@ -7,7 +14,7 @@ docker run \
     -v "$(pwd)/web/test-data/:/graphhopper/test-data/" \
     -v "$TMPDIR:/graphhopper/transit_data/"\
     --rm \
-     us.gcr.io/model-159019/gh:ec387a0e \
+     us.gcr.io/model-159019/gh:"$TAG" \
      java -Xmx2g -Xms1g -XX:+UseG1GC -XX:MetaspaceSize=100M \
      -Ddw.graphhopper.datareader.file=test-data/kansas-city-extract-mini.osm.pbf \
      -Ddw.graphhopper.gtfs.file=test-data/mini_kc_gtfs.tar \
@@ -15,7 +22,7 @@ docker run \
 
 # Run server in background
 docker run --rm  --name functional_test_server -p 50051:50051 -p 8998:8998 -v "$TMPDIR:/graphhopper/transit_data/" \
-    us.gcr.io/model-159019/gh:ec387a0e &
+    us.gcr.io/model-159019/gh:"$TAG" &
 
 echo "Waiting for graphhopper server to start up"
 sleep 30

--- a/functional_test.sh
+++ b/functional_test.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+TMPDIR=$(mktemp -d)
+
+# Import cmd
+docker run \
+    -v "$(pwd)/web/test-data/:/graphhopper/test-data/" \
+    -v "$TMPDIR:/graphhopper/transit_data/"\
+    --rm \
+     us.gcr.io/model-159019/gh:ec387a0e \
+     java -Xmx2g -Xms1g -XX:+UseG1GC -XX:MetaspaceSize=100M \
+     -Ddw.graphhopper.datareader.file=test-data/kansas-city-extract-mini.osm.pbf \
+     -Ddw.graphhopper.gtfs.file=test-data/mini_kc_gtfs.tar \
+     -classpath web/target/graphhopper-web-1.0-SNAPSHOT.jar -server com.graphhopper.http.GraphHopperApplication import default_gh_config.yaml
+
+# Run server in background
+docker run --rm  --name functional_test_server -p 50051:50051 -p 8998:8998 -v "$TMPDIR:/graphhopper/transit_data/" \
+    us.gcr.io/model-159019/gh:ec387a0e &
+
+echo "Waiting for graphhopper server to start up"
+sleep 30
+
+# Make a request for a couple of points in the minikc region
+grpcurl -d @ -plaintext localhost:50051 router.Router/RouteStreetMode <<EOM
+{
+"points":[{"lat":38.96637569955874,"lon":-94.70833304570988},{"lat":38.959204519370815,"lon":-94.69174071738964}],
+"profile": "car"
+}
+EOM
+
+docker kill functional_test_server

--- a/functional_test.sh
+++ b/functional_test.sh
@@ -49,4 +49,18 @@ grpcurl -d @ -plaintext localhost:50051 router.Router/RouteStreetMode <<EOM
 }
 EOM
 
+# Make a PT request too
+grpcurl -d @ -plaintext localhost:50051 router.Router/RoutePt <<EOM
+{
+"points":[{"lat":38.96637569955874,"lon":-94.70833304570988},{"lat":38.959204519370815,"lon":-94.69174071738964}],
+"earliest_departure_time":"2018-02-04T08:25:00Z",
+"limit_solutions":4,
+"max_profile_duration":10,
+"beta_walk_time":1.5,
+"limit_street_time_seconds":1440,
+"use_pareto":false,
+"betaTransfers":1440000
+}
+EOM
+
 docker kill functional_test_server

--- a/functional_test.sh
+++ b/functional_test.sh
@@ -9,12 +9,16 @@ TAG=$1
 
 TMPDIR=$(mktemp -d)
 
+# To run this script locally, you may need to run `docker pull $tag` from the model repo,
+# where your credentials will be populated.
+DOCKER_IMAGE_TAG="us.gcr.io/model-159019/gh:$TAG"
+
 # Import cmd
 docker run \
     -v "$(pwd)/web/test-data/:/graphhopper/test-data/" \
     -v "$TMPDIR:/graphhopper/transit_data/"\
     --rm \
-     us.gcr.io/model-159019/gh:"$TAG" \
+     "$DOCKER_IMAGE_TAG" \
      java -Xmx2g -Xms1g -XX:+UseG1GC -XX:MetaspaceSize=100M \
      -Ddw.graphhopper.datareader.file=test-data/kansas-city-extract-mini.osm.pbf \
      -Ddw.graphhopper.gtfs.file=test-data/mini_kc_gtfs.tar \
@@ -22,7 +26,7 @@ docker run \
 
 # Run server in background
 docker run --rm  --name functional_test_server -p 50051:50051 -p 8998:8998 -v "$TMPDIR:/graphhopper/transit_data/" \
-    us.gcr.io/model-159019/gh:"$TAG" &
+    "$DOCKER_IMAGE_TAG" &
 
 echo "Waiting for graphhopper server to start up"
 sleep 30


### PR DESCRIPTION
See linked issue for a little more detail on what the motivations are here. As described in the ticket, the purpose of this test will be to exercise the actual docker image that we publish, and to provide _something_ to use as a gate for releasing to "prod", just so that we can trial out our preferred release flow.

So with that being said, this functional test does just a few things: builds a region, starts a server using that region, and makes a request to the server with grpcurl. I don't love that I couldn't use the build logic that we use for prod (because it lives in the model repo), but as stated above and in the ticket, I figure this should give us some minimal validation.

For simplicity here, I used the minikc data that's already in the repo. As noted in https://github.com/replicahq/graphhopper/pull/72, it might make some sense to use mini-norcal instead; my motivations would be to build a less trivial region, and I guess it could support more queries? I figure that can come as a follow-up.

Finally, right now I'm including this in the main circleci flow, but my intention will be to only have it run on master (i.e. I will make that change when this is ready for review). It's also possible that @epotex will want to use github actions instead; I didn't care to experiment with other runners in order to get this off the ground though.