### PR TITLE
Split workflow, add git tagging on merge

### DIFF
--- a/.github/workflows/build_test_push.yaml
+++ b/.github/workflows/build_test_push.yaml
@@ -149,6 +149,7 @@ jobs:
   add-git-tags:
     runs-on: ubuntu-latest
     needs: functional-tests
+    steps:
     - name: Bump version and push tag
       id: create_tag_step
       uses: anothrNick/github-tag-action@1.26.0

--- a/.github/workflows/build_test_push.yaml
+++ b/.github/workflows/build_test_push.yaml
@@ -146,3 +146,16 @@ jobs:
 
       - name: run functional test
         run:  bash functional_test.sh ${{ github.sha }}-server-dev
+  add-git-tags:
+    runs-on: ubuntu-latest
+    needs: functional-tests
+    - name: Bump version and push tag
+      id: create_tag_step
+      uses: anothrNick/github-tag-action@1.26.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        WITH_V: true
+        INITIAL_VERSION: 1.0.0
+        RELEASE_BRANCHES: original-direction
+    - name: "Use tag. example: could reuse git tag as docker image tag"
+      run: echo ">> ${{ steps.create_tag_step.outputs.new_tag }}"

--- a/.github/workflows/build_test_push.yaml
+++ b/.github/workflows/build_test_push.yaml
@@ -71,6 +71,7 @@ jobs:
   
   functional-tests:
     name: "Build server image and run functional tests"
+    needs: unit-tests
     runs-on: ubuntu-latest
     env:
       PROJECT_ID: model-159019

--- a/.github/workflows/build_test_push.yaml
+++ b/.github/workflows/build_test_push.yaml
@@ -150,13 +150,18 @@ jobs:
     runs-on: ubuntu-latest
     needs: functional-tests
     steps:
-    - name: Bump version and push tag
-      id: create_tag_step
-      uses: anothrNick/github-tag-action@1.26.0
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        WITH_V: true
-        INITIAL_VERSION: 1.0.0
-        RELEASE_BRANCHES: original-direction
-    - name: "Use tag. example: could reuse git tag as docker image tag"
-      run: echo ">> ${{ steps.create_tag_step.outputs.new_tag }}"
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: '0'
+    - name: Compute new tag
+      id: compute_new_tag
+      run: |
+        current_tag=$(git for-each-ref --sort=-v:refname --format '%(refname:lstrip=2)' |  grep -E "^v[0-9]+$" | cut -c 2- | head -n1)
+        new_tag="v$(echo "$current_tag+1" | bc)"
+        echo ::set-output name=tag::$new_tag
+    - name: Push tag
+      run: |
+        git config user.name "Replica Robots"
+        git config user.email "robots@replicahq.com"
+        git tag "${{ steps.compute_new_tag.outputs.tag }}"
+        git push origin "${{ steps.compute_new_tag.outputs.tag }}"

--- a/.github/workflows/build_test_push.yaml
+++ b/.github/workflows/build_test_push.yaml
@@ -1,13 +1,16 @@
 name: CI
 on: [push]
 jobs:
-  build:
-    name: build test and push Graphhoper images
+  unit-tests:
+    name: "Build test image and run unit tests"
     runs-on: ubuntu-latest
     env:
       PROJECT_ID: model-159019
     steps:
 
+      # ---------------------
+      # Common steps that we repeat between workflows.
+      # I couldn't find an equivalent of CircleCI's templates; can we consolidate by turning this into an action?
       - name: Code Checkout
         uses: actions/checkout@v2
 
@@ -48,6 +51,7 @@ jobs:
           key: ${{ runner.os }}-graphhopper-buildx-${{ github.sha}}
           restore-keys: |
             ${{ runner.os }}-graphhopper-buildx
+      # ---------------------
 
         # Build image for unit tests
       - name: Build test image
@@ -64,6 +68,58 @@ jobs:
 
       - name: run unit test
         run:  docker run us.gcr.io/model-159019/gh:${{ github.sha }}-dev /bin/bash -c "mvn test"
+  
+  functional-tests:
+    name: "Build server image and run functional tests"
+    runs-on: ubuntu-latest
+    env:
+      PROJECT_ID: model-159019
+    steps:
+
+      # ---------------------
+      # Common steps that we repeat between workflows.
+      # I couldn't find an equivalent of CircleCI's templates; can we consolidate by turning this into an action?
+      - name: Code Checkout
+        uses: actions/checkout@v2
+
+      - name: Sub modules checkout
+        env:
+          SSH_KEY_FOR_SUBMODULE: ${{secrets.SUBMODULE_GITHUB_KEY}}
+        #the step below set the ssh key for the run
+        run: |
+          mkdir -p /home/runner/.ssh && touch /home/runner/.ssh/id_rsa && echo "$SSH_KEY_FOR_SUBMODULE" > $HOME/.ssh/id_rsa && chmod 600 $HOME/.ssh/id_rsa &&  git submodule sync && git submodule --quiet update --init && echo `git rev-parse --short=8 HEAD ` > TAG.txt
+
+      - name: Login to GCP
+        # Setup gcloud CLI
+        uses: google-github-actions/setup-gcloud@v0.2.0
+        with:
+          project_id: ${{ env.PROJECT_ID }}
+          service_account_key: ${{ secrets.GOOGLE_CREDENTIALS }}
+          version: "297.0.1" # Fix https://github.com/google-github-actions/setup-gcloud/issues/128
+      # Configure Docker to use the gcloud command-line tool as a credential
+      # helper for authentication
+      - run: |-
+          gcloud --quiet auth configure-docker
+
+      - name: Login to GCR
+        uses: docker/login-action@v1
+        with:
+          registry: gcr.io
+          username: _json_key
+          password: ${{ secrets.GOOGLE_CREDENTIALS }}
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@master
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-graphhopper-buildx-${{ github.sha}}
+          restore-keys: |
+            ${{ runner.os }}-graphhopper-buildx
+      # ---------------------
 
       - name: build the server
         uses: docker/build-push-action@v2

--- a/.github/workflows/build_test_push.yaml
+++ b/.github/workflows/build_test_push.yaml
@@ -156,7 +156,7 @@ jobs:
     - name: Compute new tag
       id: compute_new_tag
       run: |
-        current_tag=$(git for-each-ref --sort=-v:refname --format '%(refname:lstrip=2)' |  grep -E "^v[0-9]+$" | cut -c 2- | head -n1)
+        current_tag=$(git for-each-ref --sort=-v:refname --format '%(refname:lstrip=2)' |  grep -E '^v[0-9]+$' | cut -c 2- | head -n1)
         new_tag="v$(echo "$current_tag+1" | bc)"
         echo ::set-output name=tag::$new_tag
     - name: Push tag

--- a/.github/workflows/build_test_push.yaml
+++ b/.github/workflows/build_test_push.yaml
@@ -72,6 +72,7 @@ jobs:
   functional-tests:
     name: "Build server image and run functional tests"
     needs: unit-tests
+    if: ${{ github.ref == 'refs/heads/original-direction' }}
     runs-on: ubuntu-latest
     env:
       PROJECT_ID: model-159019


### PR DESCRIPTION
This changeset does a couple of things:
1. Splits the existing github actions workflow into multiple jobs. This allows us to run unit tests on every push (including to branches), and the functional test (and full server build) only on merges to master. This rough flow is pretty much what we were trying to evaluate with this whole branch of work
2. Adds another job to the workflow that automatically applies semantic versioning via git tags. This is facilitated via https://github.com/anothrNick/github-tag-action, and there's some documentation there of the options available. As written now, it will start at version 1.0.0, incrementing minor versions by default, unless the user specifies otherwise. This was tested in https://github.com/replicahq/gh-release-actions-test

Some open questions:
* I was unable to find a way to factor out the common setup steps required for the two jobs that involved running tests (e.g. logging into our gcp account). It might be possible to do it by creating an internal github _action_ (not quite the same thing as a workflow), but I didn't get a chance to look into it
* Details around versioning: I don't think it matters a ton what versioning scheme we use, and so I'm happy to pick this one off the shelf and not have to implement anything custom.

Next steps after this change will be to add a workflow step (or job) that uses the version calculated here to add a "prod" docker tag.

cc @replicahq/router 