### PR TITLE
[RAD-2751 pt 1] Bash script for downloading + setting up micro nor cal test files

### DIFF
--- a/setup_tests.sh
+++ b/setup_tests.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -o errexit
 
+# bbox used to cut down mini_nor_cal's OSM to just north bay + Sacramento area, aka "micro_nor_cal"
+# micro_nor_cal is large enough to meaningfully test routing, but reduces build time by ~75%
+MICRO_NOR_CAL_BBOX="-122.30986499194101,37.91724446910281,-120.68388843649487,39.42040570561121"
+
+# This script assumes that the following env vars are set, holding GCS paths to mini_nor_cal OSM + GTFS
 if [[ -z "${MININORCAL_OSM_PATH}" || -z "${MININORCAL_GTFS_PATH}" ]]; then
   echo "MININORCAL_OSM_PATH or MININORCAL_GTFS_PATH env vars are not set! Set these appropraitely and try again"
   exit 1
@@ -10,7 +15,7 @@ else
 fi
 
 echo "Checking if OSM + GTFS test files exist; downloading if needed"
-if [[ ! -f "./web/test-data/mini_nor_cal.osm.pbf" ]]; then
+if [[ ! -f "./web/test-data/micro_nor_cal.osm.pbf" ]]; then
   echo "Downloading OSM data for mini_nor_cal test region"
   gsutil -m -o "GSUtil:parallel_process_count=1" cp $MININORCAL_OSM_PATH ./web/test-data/mini_nor_cal.osm.pbf
   echo "Cutting down downloaded mini_nor_cal OSM to smaller cutout"
@@ -21,7 +26,7 @@ if [[ ! -f "./web/test-data/mini_nor_cal.osm.pbf" ]]; then
       apt install -y osmctools
     fi
   fi
-  osmconvert ./web/test-data/mini_nor_cal.osm.pbf -b=-122.30986499194101,37.91724446910281,-120.68388843649487,39.42040570561121 --complete-ways --out-pbf > ./web/test-data/micro_nor_cal.osm.pbf
+  osmconvert ./web/test-data/mini_nor_cal.osm.pbf -b=$MICRO_NOR_CAL_BBOX --complete-ways --out-pbf > ./web/test-data/micro_nor_cal.osm.pbf
   rm ./web/test-data/mini_nor_cal.osm.pbf
 fi
 

--- a/setup_tests.sh
+++ b/setup_tests.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -o errexit
+
+if [[ -z "${MININORCAL_OSM_PATH}" || -z "${MININORCAL_GTFS_PATH}" ]]; then
+  echo "MININORCAL_OSM_PATH or MININORCAL_GTFS_PATH env vars are not set! Set these appropraitely and try again"
+  exit 1
+else
+  MININORCAL_OSM_PATH="${MININORCAL_OSM_PATH}"
+  MININORCAL_GTFS_PATH="${MININORCAL_GTFS_PATH}"
+fi
+
+echo "Checking if OSM + GTFS test files exist; downloading if needed"
+if [[ ! -f "./web/test-data/mini_nor_cal.osm.pbf" ]]; then
+  echo "Downloading OSM data for mini_nor_cal test region"
+  gsutil -m -o "GSUtil:parallel_process_count=1" cp $MININORCAL_OSM_PATH ./web/test-data/mini_nor_cal.osm.pbf
+  echo "Cutting down downloaded mini_nor_cal OSM to smaller cutout"
+  if ! command -v osmconvert; then
+    if [[ $OSTYPE == 'darwin'* ]]; then
+      brew install osmfilter
+    else
+      apt install -y osmctools
+    fi
+  fi
+  osmconvert ./web/test-data/mini_nor_cal.osm.pbf -b=-122.30986499194101,37.91724446910281,-120.68388843649487,39.42040570561121 --complete-ways --out-pbf > ./web/test-data/micro_nor_cal.osm.pbf
+  rm ./web/test-data/mini_nor_cal.osm.pbf
+fi
+
+if [[ -z "$(ls -A ./web/test-data/gtfs)" ]]; then
+  echo "Downloading GTFS data for mini_nor_cal test region"
+  mkdir -p ./web/test-data/gtfs/
+  gsutil -m -o "GSUtil:parallel_process_count=1" cp $MININORCAL_GTFS_PATH - | tar -C ./web/test-data/gtfs/ -xvf -
+fi
+
+echo "Removing GTFS files to create transit network defined in test_gtfs_files.txt"
+for file in ./web/test-data/gtfs/*.zip; do
+  filename="$(basename $file)"
+  if ! grep -qxe "$filename" ./web/test-data/test_gtfs_files.txt; then
+      echo "Deleting $filename"
+      rm "./web/test-data/gtfs/$filename"
+  fi
+done
+
+echo "Checking test_gh_config.yaml; updating paths to test OSM/GTFS if needed"
+if grep -q TEST_OSM ./test_gh_config.yaml; then
+  sed -i -e "s/TEST_OSM/.\/test-data\/micro_nor_cal.osm.pbf/g" ./test_gh_config.yaml
+fi
+
+if grep -q TEST_GTFS ./test_gh_config.yaml; then
+  export GTFS_FILE_LIST=$(ls ./web/test-data/gtfs/ | awk '{print "./test-data/gtfs/"$1}' | paste -s -d, -)
+  sed -i -e "s/TEST_GTFS/${GTFS_FILE_LIST//\//\\/}/g" ./test_gh_config.yaml
+fi
+
+echo "Setup complete! Tests can now be run with 'mvn test'"

--- a/test_gh_config.yaml
+++ b/test_gh_config.yaml
@@ -2,8 +2,8 @@
 # 1 profile loaded with default speeds is defined for each vehicle type
 
 graphhopper:
-  datareader.file: TEST_OSM
-  gtfs.file: TEST_GTFS
+  datareader.file: test-data/kansas-city-extract-mini.osm.pbf
+  gtfs.file: test-data/mini_kc_gtfs.tar
   gtfs.max_transfer_interpolation_walk_time_seconds: 300
   graph.location: transit_data/graphhopper
   routing.ch.disabling_allowed: true

--- a/test_gh_config.yaml
+++ b/test_gh_config.yaml
@@ -2,8 +2,8 @@
 # 1 profile loaded with default speeds is defined for each vehicle type
 
 graphhopper:
-  datareader.file: test-data/kansas-city-extract-mini.osm.pbf
-  gtfs.file: test-data/mini_kc_gtfs.tar
+  datareader.file: TEST_OSM
+  gtfs.file: TEST_GTFS
   gtfs.max_transfer_interpolation_walk_time_seconds: 300
   graph.location: transit_data/graphhopper
   routing.ch.disabling_allowed: true

--- a/web/test-data/test_gtfs_files.txt
+++ b/web/test-data/test_gtfs_files.txt
@@ -1,0 +1,4 @@
+f-9qc-fairfield~ca~us.zip
+rosevill.zip
+srtd.zip
+vacaville.zip


### PR DESCRIPTION
Step 1 of the necessary changes for https://replicahq.atlassian.net/browse/RAD-2751 (more to come just after this is merged). The overall goal here is to move to a new, more representative test region than mini_kc, which I'm dubbing `micro_nor_cal`, a pared-down version of mini_nor_cal (takes 5 mins to run tests instead of >20 with the full mini_nor_cal).

This setup script does a few things:
1. Downloads mini_nor_cal OSM + GTFS to a specific test data folder
2. Takes a specific subsample of GTFS feeds from the downloaded tar, and removes the rest
3. performs an OSM cutout on the mini nor cal OSM to reduce it to a much smaller bbox, basically encompassing the Sacramento region
4. Updates the OSM + GTFS file paths in `test_gh_config.yaml` (the graphhopper config file used for running tests) to point to the newly downloaded + pared down OSM + GTFS files
5. Works both locally and in CI (Linux), assuming OSM + GTFS path env vars are set correctly. Should also handle basically every case of partial setup gracefully (eg, you've downloaded OSM but not GTFS, running the script will gracefully skip OSM download and continue with everything else)

cc @epotex @danielhfrank @JacobHayes 