### PR TITLE
Add steps to add prod tags to docker images

### DIFF
--- a/.github/workflows/build_test_push.yaml
+++ b/.github/workflows/build_test_push.yaml
@@ -177,11 +177,11 @@ jobs:
     - run: |-
         gcloud --quiet auth configure-docker
     - name: Login to GCR
-        uses: docker/login-action@v1
-        with:
-          registry: gcr.io
-          username: _json_key
-          password: ${{ secrets.GOOGLE_CREDENTIALS }}
+      uses: docker/login-action@v1
+      with:
+        registry: gcr.io
+        username: _json_key
+        password: ${{ secrets.GOOGLE_CREDENTIALS }}
     - name: Update docker tags
       run: |
         docker pull us.gcr.io/model-159019/gh:${{ github.sha }}-server-dev

--- a/.github/workflows/build_test_push.yaml
+++ b/.github/workflows/build_test_push.yaml
@@ -146,7 +146,7 @@ jobs:
 
       - name: run functional test
         run:  bash functional_test.sh ${{ github.sha }}-server-dev
-  add-git-tags:
+  update-tags:
     runs-on: ubuntu-latest
     needs: functional-tests
     steps:
@@ -159,9 +159,32 @@ jobs:
         current_tag=$(git for-each-ref --sort=-v:refname --format '%(refname:lstrip=2)' |  grep -E '^v[0-9]+$' | cut -c 2- | head -n1)
         new_tag="v$(echo "$current_tag+1" | bc)"
         echo ::set-output name=tag::$new_tag
-    - name: Push tag
+    - name: Push git tag
       run: |
         git config user.name "Replica Robots"
         git config user.email "robots@replicahq.com"
         git tag "${{ steps.compute_new_tag.outputs.tag }}"
         git push origin "${{ steps.compute_new_tag.outputs.tag }}"
+    - name: Login to GCP
+      # Setup gcloud CLI
+      uses: google-github-actions/setup-gcloud@v0.2.0
+      with:
+        project_id: ${{ env.PROJECT_ID }}
+        service_account_key: ${{ secrets.GOOGLE_CREDENTIALS }}
+        version: "297.0.1" # Fix https://github.com/google-github-actions/setup-gcloud/issues/128
+    # Configure Docker to use the gcloud command-line tool as a credential
+    # helper for authentication
+    - run: |-
+        gcloud --quiet auth configure-docker
+    - name: Login to GCR
+        uses: docker/login-action@v1
+        with:
+          registry: gcr.io
+          username: _json_key
+          password: ${{ secrets.GOOGLE_CREDENTIALS }}
+    - name: Update docker tags
+      run: |
+        docker pull us.gcr.io/model-159019/gh:${{ github.sha }}-server-dev
+        docker tag us.gcr.io/model-159019/gh:${{ github.sha }}-server-dev us.gcr.io/model-159019/gh:${{ steps.compute_new_tag.outputs.tag }}
+        docker push us.gcr.io/model-159019/gh:${{ steps.compute_new_tag.outputs.tag }}
+


### PR DESCRIPTION
Fixes https://replicahq.atlassian.net/browse/RAD-2592

This is pretty much the last step in our work around graphhopper release management. This adds a step to our CI flow that runs on pushes to master. After functional tests pass and we apply a new git tag, we add a new docker tag matching the git tag.

I also updated a few job/step names that sounded ambiguous in light of the other changes.

To test this, I played around a little bit with some of the docker commands locally, but otherwise will just kind of plan on crossing my fingers that this runs correctly when we merge.

cc @replicahq/router @epotex 