### PR TITLE
Change filters on functional test workflow

### DIFF
--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -14,6 +14,13 @@ on:
   workflow_dispatch:
 
 jobs:
+  dump-context:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJSON(github) }}
+        run: echo "$GITHUB_CONTEXT"
   functional-tests:
     name: "Build server image and run functional tests"
     runs-on: ubuntu-latest

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -8,6 +8,7 @@ name: Functional Test
 on:
   workflow_run:
     workflows: ["CI"]
+    branches: ["original-direction"]
     types:
       - completed
   workflow_dispatch:
@@ -15,7 +16,6 @@ on:
 jobs:
   functional-tests:
     name: "Build server image and run functional tests"
-    if: github.event_name == 'workflow_dispatch' || (github.ref == 'refs/heads/original-direction' && github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
     env:
       PROJECT_ID: model-159019

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -23,6 +23,7 @@ jobs:
         run: echo "$GITHUB_CONTEXT"
   functional-tests:
     name: "Build server image and run functional tests"
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     env:
       PROJECT_ID: model-159019
@@ -105,7 +106,8 @@ jobs:
   update-tags:
     runs-on: ubuntu-latest
     needs: functional-tests
-    if: github.ref == 'refs/heads/original-direction' && github.event.workflow_run.conclusion == 'success'
+    # Only update tags if this was triggered by completion of CI upstream
+    if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
# Background

A couple of folks have noticed that our workflows which are supposed to run only on merges to master have been running, occasionally, on regular pushes.

# Description

Here's what I thought should have been happening:
* Every time the CI workflow completes (on every push), we trigger the functional test _workflow_
* That workflow will then inspect the contents of what triggered it (e.g. to see if the CI workflow was actually successful), and then may or may not run its _jobs_ (jobs will appear in grey if workflow was triggered but jobs were skipped). In particular, it will check if it was triggered on the main branch.

What's actually happening: sometimes the functional tests run after pushes of commits to feature branches. It's been a little hard to tell whether this is deterministic or not.

What I am doing to address it:
* Changing from inspecting branch name at the job level to specifying branches on the workflow level. This is just a feature that I didn't notice when I first implemented things, and should reduce the number of spurious workflow triggers anyway.
* Adding a step to splat out all the info from the event that triggered the workflow. This is just for debugging purposes, so that if workflows continue to be triggered in ways that we don't expect, we'll have better visibility into why.

# Testing

Have been doing some tests with manual workflow runs; things appeared to be running as expected but of course the behavior we're really trying to evaluate is controlled by github.

# cc

@replicahq/router @JacobHayes 