### PR TITLE
Fix functional test (again)

### DIFF
--- a/functional_test.sh
+++ b/functional_test.sh
@@ -26,7 +26,8 @@ docker run \
     --rm \
      "$DOCKER_IMAGE_TAG" \
      /bin/bash -c
-     "cp -r $(pwd)/web/test-data $(pwd)/test-data &&
+     "mkdir $(pwd)/test-data &&
+     cp -r $(pwd)/web/test-data $(pwd)/test-data &&
      java -Xmx2g -Xms1g -XX:+UseG1GC -XX:MetaspaceSize=100M
      -classpath web/target/graphhopper-web-1.0-SNAPSHOT.jar
      -server com.graphhopper.http.GraphHopperApplication import test_gh_config.yaml"

--- a/functional_test.sh
+++ b/functional_test.sh
@@ -25,12 +25,8 @@ docker run \
     -v "$TMPDIR:/graphhopper/transit_data/"\
     --rm \
      "$DOCKER_IMAGE_TAG" \
-     /bin/bash -c
-     "mkdir /graphhopper/test-data &&
-     cp -r /graphhopper/web/test-data /graphhopper/test-data &&
-     java -Xmx2g -Xms1g -XX:+UseG1GC -XX:MetaspaceSize=100M
-     -classpath web/target/graphhopper-web-1.0-SNAPSHOT.jar
-     -server com.graphhopper.http.GraphHopperApplication import test_gh_config.yaml"
+     /bin/bash -c "cp -r ./web/test-data . && java -Xmx2g -Xms1g -XX:+UseG1GC -XX:MetaspaceSize=100M \
+     -classpath web/target/graphhopper-web-1.0-SNAPSHOT.jar -server com.graphhopper.http.GraphHopperApplication import test_gh_config.yaml"
 
 # Run link-mapping step
 docker run \

--- a/functional_test.sh
+++ b/functional_test.sh
@@ -26,7 +26,7 @@ docker run \
     --rm \
      "$DOCKER_IMAGE_TAG" \
      /bin/bash -c
-     "cp -r ./web/test-data ./test-data &&
+     "cp -r $(pwd)/web/test-data $(pwd)/test-data &&
      java -Xmx2g -Xms1g -XX:+UseG1GC -XX:MetaspaceSize=100M
      -classpath web/target/graphhopper-web-1.0-SNAPSHOT.jar
      -server com.graphhopper.http.GraphHopperApplication import test_gh_config.yaml"

--- a/functional_test.sh
+++ b/functional_test.sh
@@ -26,8 +26,8 @@ docker run \
     --rm \
      "$DOCKER_IMAGE_TAG" \
      /bin/bash -c
-     "mkdir $(pwd)/test-data &&
-     cp -r $(pwd)/web/test-data $(pwd)/test-data &&
+     "mkdir /graphhopper/test-data &&
+     cp -r /graphhopper/web/test-data /graphhopper/test-data &&
      java -Xmx2g -Xms1g -XX:+UseG1GC -XX:MetaspaceSize=100M
      -classpath web/target/graphhopper-web-1.0-SNAPSHOT.jar
      -server com.graphhopper.http.GraphHopperApplication import test_gh_config.yaml"

--- a/functional_test.sh
+++ b/functional_test.sh
@@ -25,7 +25,7 @@ docker run \
     -v "$TMPDIR:/graphhopper/transit_data/"\
     --rm \
      "$DOCKER_IMAGE_TAG" \
-     java -Xmx2g -Xms1g -XX:+UseG1GC -XX:MetaspaceSize=100M \
+     ls -la && ls test-data && java -Xmx2g -Xms1g -XX:+UseG1GC -XX:MetaspaceSize=100M \
      -classpath web/target/graphhopper-web-1.0-SNAPSHOT.jar -server com.graphhopper.http.GraphHopperApplication import test_gh_config.yaml
 
 # Run link-mapping step

--- a/functional_test.sh
+++ b/functional_test.sh
@@ -25,9 +25,11 @@ docker run \
     -v "$TMPDIR:/graphhopper/transit_data/"\
     --rm \
      "$DOCKER_IMAGE_TAG" \
-     cp -r ./web/test-data ./test-data && \
-     java -Xmx2g -Xms1g -XX:+UseG1GC -XX:MetaspaceSize=100M \
-     -classpath web/target/graphhopper-web-1.0-SNAPSHOT.jar -server com.graphhopper.http.GraphHopperApplication import test_gh_config.yaml
+     /bin/bash -c
+     "cp -r ./web/test-data ./test-data &&
+     java -Xmx2g -Xms1g -XX:+UseG1GC -XX:MetaspaceSize=100M
+     -classpath web/target/graphhopper-web-1.0-SNAPSHOT.jar
+     -server com.graphhopper.http.GraphHopperApplication import test_gh_config.yaml"
 
 # Run link-mapping step
 docker run \

--- a/functional_test.sh
+++ b/functional_test.sh
@@ -19,13 +19,14 @@ docker rm --force $(docker ps --all -q)
 # where your credentials will be populated.
 DOCKER_IMAGE_TAG="us.gcr.io/model-159019/gh:$TAG"
 
-# Import data into graphhopper's internal format
+# Import data into graphhopper's internal format. It's necessary to move test data from /web before
+# running import, because import paths are relative to base /graphhopper folder, unlike in `mvn test`
 docker run \
-    -v "$(pwd)/web/test-data/:/graphhopper/test-data/" \
     -v "$TMPDIR:/graphhopper/transit_data/"\
     --rm \
      "$DOCKER_IMAGE_TAG" \
-     ls -la && ls test-data && java -Xmx2g -Xms1g -XX:+UseG1GC -XX:MetaspaceSize=100M \
+     cp -r ./web/test-data ./test-data && \
+     java -Xmx2g -Xms1g -XX:+UseG1GC -XX:MetaspaceSize=100M \
      -classpath web/target/graphhopper-web-1.0-SNAPSHOT.jar -server com.graphhopper.http.GraphHopperApplication import test_gh_config.yaml
 
 # Run link-mapping step

--- a/setup_tests.sh
+++ b/setup_tests.sh
@@ -47,7 +47,7 @@ done
 
 echo "Checking test_gh_config.yaml; updating paths to test OSM/GTFS if needed"
 if grep -q TEST_OSM ./test_gh_config.yaml; then
-  sed -i -e "s/{{ TEST_OSM }}/test-data\/micro_nor_cal.osm.pbf/g" ./test_gh_config.yaml
+  sed -i -e "s/{{ TEST_OSM }}/.\/test-data\/micro_nor_cal.osm.pbf/g" ./test_gh_config.yaml
 fi
 
 if grep -q TEST_GTFS ./test_gh_config.yaml; then

--- a/setup_tests.sh
+++ b/setup_tests.sh
@@ -47,7 +47,7 @@ done
 
 echo "Checking test_gh_config.yaml; updating paths to test OSM/GTFS if needed"
 if grep -q TEST_OSM ./test_gh_config.yaml; then
-  sed -i -e "s/{{ TEST_OSM }}/.\/test-data\/micro_nor_cal.osm.pbf/g" ./test_gh_config.yaml
+  sed -i -e "s/{{ TEST_OSM }}/web\/test-data\/micro_nor_cal.osm.pbf/g" ./test_gh_config.yaml
 fi
 
 if grep -q TEST_GTFS ./test_gh_config.yaml; then

--- a/setup_tests.sh
+++ b/setup_tests.sh
@@ -47,7 +47,7 @@ done
 
 echo "Checking test_gh_config.yaml; updating paths to test OSM/GTFS if needed"
 if grep -q TEST_OSM ./test_gh_config.yaml; then
-  sed -i -e "s/{{ TEST_OSM }}/web\/test-data\/micro_nor_cal.osm.pbf/g" ./test_gh_config.yaml
+  sed -i -e "s/{{ TEST_OSM }}/test-data\/micro_nor_cal.osm.pbf/g" ./test_gh_config.yaml
 fi
 
 if grep -q TEST_GTFS ./test_gh_config.yaml; then


### PR DESCRIPTION
_Actually_ fixes the functional test, proven by this [manual run](https://github.com/replicahq/graphhopper/actions/runs/1137806613) succeeding (shoutout to @danielhfrank for making that possible!).

TLDR on the actual fix: In the last "fix" PR I merged, I moved the micro nor cal test data setup from a step that runs outside of docker in CI into the actual build of the base image itself (basically wrapping the test data into the image, instead of copying the data from CI into a running container to run the tests). However, the functional test was still setup to use the old approach - mounting the CI-based test data as a volume on a container that would run the import + gtfs link mapping steps, before being queried as a routing server for the actual test.

The fix here just no longer mounts that volume (as the data lives in the image itself), and instead just makes sure that the test data is in the proper spot before running the `import` step so it gets picked up correctly by graphhopper. 

I addressed this in a code comment, but the reason we need to do this funny `cp` before running `import` is because `mvn test` understands paths as relative to the submodule the tests are being run in (in our case, `/web`), while `import` understands paths as relative to the root `graphhopper` folder. The paths we're using in `test_gh_config.yaml` look like `/test-data/<file>`, so if we don't do the `cp`, graphhopper can't find the OSM/GTFS at import time, because they're actually in `/web/test-data` (which maven understands, because our tests currently run out of `/web`). There may be a maven option that allows you to change how maven interprets relative paths in this way, but I couldn't find it easily, and this approach seems straightforward enough

cc @kaelgreco but he's OOO today 😁 