### PR TITLE
Don't overwrite test config yaml in server Dockerfile

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -12,7 +12,7 @@ COPY --from=base /graphhopper/grpc/src/main/resources ./grpc/src/main/resources
 COPY --from=base /graphhopper/test_gh_config.yaml ./
 COPY --from=base /graphhopper/web/test-data ./web/test-data
 # pom.xml is used to get the jar file version. see https://github.com/graphhopper/graphhopper/pull/1990#discussion_r409438806
-COPY ./pom.xml ./default_gh_config.yaml ./test_gh_config.yaml ./nationwide_gh_config.yaml ./gtfs_validation_gh_config.yaml ./config-proxy.yaml ./run_gtfs_validation.sh ./
+COPY ./pom.xml ./default_gh_config.yaml ./nationwide_gh_config.yaml ./gtfs_validation_gh_config.yaml ./config-proxy.yaml ./run_gtfs_validation.sh ./
 
 VOLUME [ "/data" ]
 


### PR DESCRIPTION
Sigh.....missed something small when merging the GTFS validator PR (#80) and broke the functional test yet again, this is the fix. Confirmed to fix the test via this manually-kicked off run: https://github.com/replicahq/graphhopper/runs/3355665162?check_suite_focus=true