### PR TITLE
[RAD-2830] Query golden OD set and store results in functional test

### DIFF
--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -56,9 +56,6 @@ jobs:
       - run: |-
           gcloud --quiet auth configure-docker
 
-      - run: |-
-          echo "GOOGLE_CREDENTIALS_FILE=$(basename $GOOGLE_APPLICATION_CREDENTIALS)" >> $GITHUB_ENV
-
       - name: Login to GCR
         uses: docker/login-action@v1
         with:
@@ -113,13 +110,13 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: functional-test-street-results
-          path: $TMPDIR/street_responses.json
+          path: ${{ env.TMPDIR }}/street_responses.json
 
       - name: Archive transit functional test results
         uses: actions/upload-artifact@v2
         with:
           name: functional-test-transit-results
-          path: $TMPDIR/transit_responses.json
+          path: ${{ env.TMPDIR }}/transit_responses.json
 
   update-tags:
     runs-on: ubuntu-latest

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -28,8 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PROJECT_ID: model-159019
+      TMPDIR: $(mktemp -d)
     steps:
-
       # ---------------------
       # Common steps that we repeat between workflows.
       # I couldn't find an equivalent of CircleCI's templates; can we consolidate by turning this into an action?
@@ -39,7 +39,7 @@ jobs:
       - name: Sub modules checkout
         env:
           SSH_KEY_FOR_SUBMODULE: ${{secrets.SUBMODULE_GITHUB_KEY}}
-        #the step below set the ssh key for the run
+        # set the ssh key for the run
         run: |
           mkdir -p /home/runner/.ssh && touch /home/runner/.ssh/id_rsa && echo "$SSH_KEY_FOR_SUBMODULE" > $HOME/.ssh/id_rsa && chmod 600 $HOME/.ssh/id_rsa &&  git submodule sync && git submodule --quiet update --init && echo `git rev-parse --short=8 HEAD ` > TAG.txt
 
@@ -75,7 +75,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-graphhopper-buildx-${{ github.sha}}
+          key: ${{ runner.os }}-graphhopper-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-graphhopper-buildx
       # ---------------------
@@ -103,7 +103,6 @@ jobs:
 
       - name: Run functional test queries
         run: |
-          export TMPDIR=$(mktemp -d)
           bash query_functional_test.sh ${{ github.sha }}-server-dev
 
       # todo: use job-specific archive names to prevent parallel jobs from overwriting each other's results?
@@ -112,13 +111,13 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: functional-test-street-results
-          path: $TMPDIR/street_responses.json
+          path: ${{ env.TMPDIR }}/street_responses.json
 
       - name: Archive transit functional test results
         uses: actions/upload-artifact@v2
         with:
           name: functional-test-transit-results
-          path: $TMPDIR/transit_responses.json
+          path: ${{ env.TMPDIR }}/transit_responses.json
 
   update-tags:
     runs-on: ubuntu-latest

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -28,7 +28,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PROJECT_ID: model-159019
-      TMPDIR: $(mktemp -d)
     steps:
       # ---------------------
       # Common steps that we repeat between workflows.
@@ -80,6 +79,9 @@ jobs:
             ${{ runner.os }}-graphhopper-buildx
       # ---------------------
 
+      - name: Set temp directory env variable
+        run: echo "TMPDIR=$(mktemp -d)" >> $GITHUB_ENV
+
       - name: build the server
         uses: docker/build-push-action@v2
         with:
@@ -111,13 +113,13 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: functional-test-street-results
-          path: ${{ env.TMPDIR }}/street_responses.json
+          path: $TMPDIR/street_responses.json
 
       - name: Archive transit functional test results
         uses: actions/upload-artifact@v2
         with:
           name: functional-test-transit-results
-          path: ${{ env.TMPDIR }}/transit_responses.json
+          path: $TMPDIR/transit_responses.json
 
   update-tags:
     runs-on: ubuntu-latest

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -1,7 +1,8 @@
 name: Functional Test
 # This test does the following:
 # * Builds the "server" docker image that is used by the model repo
-# * Runs functional tests
+# * Runs functional tests queries against micro nor cal golden OD set
+# * (todo: analyzes results of functional test queries, comparing against golden result set)
 # * If tests pass, updates git and docker tags
 # The workflow is configured to run on merges to original-direction, after unit tests pass.
 # It can also be run manually, in which case it will NOT execute the steps to update git and docker tags
@@ -21,8 +22,8 @@ jobs:
         env:
           GITHUB_CONTEXT: ${{ toJSON(github) }}
         run: echo "$GITHUB_CONTEXT"
-  functional-tests:
-    name: "Build server image and run functional tests"
+  functional-test-queries:
+    name: "Build server image and run functional test queries"
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     env:
@@ -100,12 +101,28 @@ jobs:
           go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest
           grpcurl -version
 
-      - name: run functional test
-        run:  bash functional_test.sh ${{ github.sha }}-server-dev
+      - name: Run functional test queries
+        run: |
+          export TMPDIR=$(mktemp -d)
+          bash query_functional_test.sh ${{ github.sha }}-server-dev
+
+      # todo: use job-specific archive names to prevent parallel jobs from overwriting each other's results?
+      # Does it matter, given the results will be analyzed instantly after this?
+      - name: Archive street functional test results
+        uses: actions/upload-artifact@v2
+        with:
+          name: functional-test-street-results
+          path: $TMPDIR/street_responses.json
+
+      - name: Archive transit functional test results
+        uses: actions/upload-artifact@v2
+        with:
+          name: functional-test-transit-results
+          path: $TMPDIR/transit_responses.json
 
   update-tags:
     runs-on: ubuntu-latest
-    needs: functional-tests
+    needs: functional-test-queries
     # Only update tags if this was triggered by completion of CI upstream
     if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'
     steps:

--- a/.github/workflows/generate-golden-response-set.yaml
+++ b/.github/workflows/generate-golden-response-set.yaml
@@ -53,13 +53,9 @@ jobs:
           bash query_functional_test.sh ${{ github.sha }}-server-dev
 
       - name: Archive street functional test results as golden set
-        uses: actions/upload-artifact@v2
-        with:
-          name: functional-test-golden-street-results
-          path: ${{ env.TMPDIR }}/street_responses.json
+        run: |
+          gsutil cp ${{ env.TMPDIR }}/street_responses.json gs://graphhopper_test_artifacts/golden_street_response_sets/${{ github.sha }}
 
       - name: Archive transit functional test results as golden set
-        uses: actions/upload-artifact@v2
-        with:
-          name: functional-test-golden-transit-results
-          path: ${{ env.TMPDIR }}/transit_responses.json
+        run: |
+          gsutil cp ${{ env.TMPDIR }}/transit_responses.json gs://graphhopper_test_artifacts/golden_transit_response_sets/${{ github.sha }}

--- a/.github/workflows/generate-golden-response-set.yaml
+++ b/.github/workflows/generate-golden-response-set.yaml
@@ -45,19 +45,21 @@ jobs:
           go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest
           grpcurl -version
 
+      - name: Set temp directory env variable
+        run: echo "TMPDIR=$(mktemp -d)" >> $GITHUB_ENV
+
       - name: Run functional test queries
         run: |
-          export TMPDIR=$(mktemp -d)
           bash query_functional_test.sh ${{ github.sha }}-server-dev
 
       - name: Archive street functional test results as golden set
         uses: actions/upload-artifact@v2
         with:
           name: functional-test-golden-street-results
-          path: $TMPDIR/street_responses.json
+          path: ${{ env.TMPDIR }}/street_responses.json
 
       - name: Archive transit functional test results as golden set
         uses: actions/upload-artifact@v2
         with:
           name: functional-test-golden-transit-results
-          path: $TMPDIR/transit_responses.json
+          path: ${{ env.TMPDIR }}/transit_responses.json

--- a/.github/workflows/generate-golden-response-set.yaml
+++ b/.github/workflows/generate-golden-response-set.yaml
@@ -1,0 +1,63 @@
+name: Generate Functional Test Golden Response Set
+on: [workflow_dispatch]
+jobs:
+  functional-test-golden-response-set:
+    name: "Run functional test queries to generate golden set of responses"
+    runs-on: ubuntu-latest
+    env:
+      PROJECT_ID: model-159019
+    steps:
+      # ---------------------
+      # Common steps that we repeat between workflows.
+      - name: Login to GCP
+        # Setup gcloud CLI
+        uses: google-github-actions/setup-gcloud@v0.2.0
+        with:
+          project_id: ${{ env.PROJECT_ID }}
+          service_account_key: ${{ secrets.GOOGLE_CREDENTIALS }}
+          version: "297.0.1" # Fix https://github.com/google-github-actions/setup-gcloud/issues/128
+          export_default_credentials: true
+
+      # Configure Docker to use the gcloud command-line tool as a credential
+      # helper for authentication
+      - run: |-
+          gcloud --quiet auth configure-docker
+
+      - run: |-
+          echo "GOOGLE_CREDENTIALS_FILE=$(basename $GOOGLE_APPLICATION_CREDENTIALS)" >> $GITHUB_ENV
+
+      - name: Login to GCR
+        uses: docker/login-action@v1
+        with:
+          registry: gcr.io
+          username: _json_key
+          password: ${{ secrets.GOOGLE_CREDENTIALS }}
+      # ---------------------
+
+      - name: Install golang
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1.16.6'
+
+      - name: Install grpcurl
+        run: |
+          go get github.com/fullstorydev/grpcurl/...
+          go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest
+          grpcurl -version
+
+      - name: Run functional test queries
+        run: |
+          export TMPDIR=$(mktemp -d)
+          bash query_functional_test.sh ${{ github.sha }}-server-dev
+
+      - name: Archive street functional test results as golden set
+        uses: actions/upload-artifact@v2
+        with:
+          name: functional-test-golden-street-results
+          path: $TMPDIR/street_responses.json
+
+      - name: Archive transit functional test results as golden set
+        uses: actions/upload-artifact@v2
+        with:
+          name: functional-test-golden-transit-results
+          path: $TMPDIR/transit_responses.json

--- a/query_functional_test.sh
+++ b/query_functional_test.sh
@@ -12,7 +12,7 @@ fi
 
 TAG=$1
 
-#make sure the env is clean:
+# Make sure the docker env is clean
 docker rm --force $(docker ps --all -q)
 
 # To run this script locally, you may need to run `docker pull $tag` from the model repo,
@@ -43,7 +43,7 @@ docker run --rm --name functional_test_server -p 50051:50051 -p 8998:8998 -v "$T
 echo "Waiting for graphhopper server to start up"
 sleep 30
 
-# grab the server ip:
+# Grab the server ip:
 SERVER=$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' functional_test_server }})
 
 touch "$TMPDIR"/street_responses.json
@@ -53,7 +53,7 @@ touch "$TMPDIR"/transit_responses.json
 while IFS=, read -r person_id lat lng lat_work lng_work tract tract_work ; do
   # Don't forget to skip the header line
   if [ "$person_id" != "person_id" ] ; then
-grpcurl  -d @ -plaintext $SERVER:50051 router.Router/RouteStreetMode > "$TMPDIR"/response.json <<EOM
+grpcurl -d @ -plaintext $SERVER:50051 router.Router/RouteStreetMode > "$TMPDIR"/response.json <<EOM
 {
 "points":[{"lat":"$lat","lon":"$lng"},{"lat":"$lat_work","lon":"$lng_work"}],
 "profile": "car"
@@ -65,7 +65,6 @@ EOM
     rm "$TMPDIR"/response.json
   fi
 done < ./web/test-data/micro_nor_cal_golden_od_set.csv
-
 
 # Make transit requests for each point in golden OD set for the micro_nor_cal region
 while IFS=, read -r person_id lat lng lat_work lng_work tract tract_work ; do
@@ -84,9 +83,9 @@ grpcurl -d @ -plaintext localhost:50051 router.Router/RoutePt  > "$TMPDIR"/pt_re
 }
 EOM
     # Add JSON query result, appended with person_id field, to street_responses JSONL output file
-    jq -c --arg person "$person_id" '. |= . + {"person_id": $person}' "$TMPDIR"/response.json >> "$TMPDIR"/transit_responses.json
+    jq -c --arg person "$person_id" '. |= . + {"person_id": $person}' "$TMPDIR"/pt_response.json >> "$TMPDIR"/transit_responses.json
     # wc -l "$TMPDIR"/street_responses.json
-    rm "$TMPDIR"/response.json
+    rm "$TMPDIR"/pt_response.json
   fi
 done < ./web/test-data/micro_nor_cal_golden_od_set.csv
 

--- a/query_functional_test.sh
+++ b/query_functional_test.sh
@@ -43,8 +43,8 @@ docker run --rm --name functional_test_server -p 50051:50051 -p 8998:8998 -v "$T
 echo "Waiting for graphhopper server to start up"
 sleep 30
 
-# greb the server ip:
-SERVER= $(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' functional_test_server }})
+# grab the server ip:
+SERVER=$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' functional_test_server }})
 
 touch "$TMPDIR"/street_responses.json
 touch "$TMPDIR"/transit_responses.json

--- a/query_functional_test.sh
+++ b/query_functional_test.sh
@@ -63,7 +63,6 @@ grpcurl -d @ -plaintext $SERVER:50051 router.Router/RouteStreetMode > "$TMPDIR"/
 EOM
     # Add JSON query result, appended with person_id field, to street_responses JSONL output file
     jq -c --arg person "$person_id" '. |= . + {"person_id": $person}' "$TMPDIR"/response.json >> "$TMPDIR"/street_responses.json
-    # wc -l "$TMPDIR"/street_responses.json
     rm "$TMPDIR"/response.json
   fi
 done < ./web/test-data/micro_nor_cal_golden_od_set.csv
@@ -88,7 +87,6 @@ grpcurl -d @ -plaintext localhost:50051 router.Router/RoutePt  > "$TMPDIR"/pt_re
 EOM
     # Add JSON query result, appended with person_id field, to street_responses JSONL output file
     jq -c --arg person "$person_id" '. |= . + {"person_id": $person}' "$TMPDIR"/pt_response.json >> "$TMPDIR"/transit_responses.json
-    # wc -l "$TMPDIR"/street_responses.json
     rm "$TMPDIR"/pt_response.json
   fi
 done < ./web/test-data/micro_nor_cal_golden_od_set.csv


### PR DESCRIPTION
Main goal: update the current functional test to actually loop through + query every OD in the golden OD set (generated via the script in #83), storing the results in a format that will make analyzing the results (coming up next [here](https://replicahq.atlassian.net/browse/RAD-2831)) easy.

---------------
Full set of changes:
- Updates functional test script to loop through golden OD set (which is stored in github currently) for both transit + street (auto) queries, storing each set of results in JSON line files (newline delineated JSON). Results from each `grpcurl` request are parsed using `jq` into the proper format. Changed the script name from `functional_test` to `query_functional_test` to separate it from the analysis step that will be added in the next PR
- Update current functional test github action to store results of each run's queries as artifacts, which will be used right away in the analysis step once that's added in the next PR. Also do some cleanup
- Add a new github action to generate the "golden result set" and store it as a fixed-name github artifact. This is the set of results that we'll use to compare against the results from each run of the functional test. As it's currently set up, running this action will overwrite what the current golden set is, in the event we make changes to the routing engine in the future that would invalidate the set

NOTE: This currently is set up to not do any analysis on the result set. So, technically, this is removing the (very small) validation we currently have in the functional test. However, this will be very temporary - the next PR will be up soon and will add back in a full suite of analysis/validation

---------------
[Proof of successful functional test run](https://github.com/replicahq/graphhopper/runs/3386369622?check_suite_focus=true)

Don't think I can test the standalone golden request workflow because it's never been merged into `original-direction` (so the `gh` command line approach doesn't seem to work)

Verified that functional test [artifacts](https://github.com/replicahq/graphhopper/actions/runs/1152272775) are in proper format with

```
import json

with open('street_responses.json') as street_response_file:
    street_results = [json.loads(jline) for jline in street_response_file.read().splitlines()]
    print(len(street_results))
```

cc @danielhfrank @kaelgreco @epotex @JacobHayes 