### PR TITLE
Fix golden response set action (make sure code is checked out)

### DIFF
--- a/.github/workflows/generate-golden-response-set.yaml
+++ b/.github/workflows/generate-golden-response-set.yaml
@@ -9,6 +9,16 @@ jobs:
     steps:
       # ---------------------
       # Common steps that we repeat between workflows.
+      - name: Code Checkout
+        uses: actions/checkout@v2
+
+      - name: Sub modules checkout
+        env:
+          SSH_KEY_FOR_SUBMODULE: ${{secrets.SUBMODULE_GITHUB_KEY}}
+        # set the ssh key for the run
+        run: |
+          mkdir -p /home/runner/.ssh && touch /home/runner/.ssh/id_rsa && echo "$SSH_KEY_FOR_SUBMODULE" > $HOME/.ssh/id_rsa && chmod 600 $HOME/.ssh/id_rsa &&  git submodule sync && git submodule --quiet update --init && echo `git rev-parse --short=8 HEAD ` > TAG.txt
+
       - name: Login to GCP
         # Setup gcloud CLI
         uses: google-github-actions/setup-gcloud@v0.2.0
@@ -23,15 +33,24 @@ jobs:
       - run: |-
           gcloud --quiet auth configure-docker
 
-      - run: |-
-          echo "GOOGLE_CREDENTIALS_FILE=$(basename $GOOGLE_APPLICATION_CREDENTIALS)" >> $GITHUB_ENV
-
       - name: Login to GCR
         uses: docker/login-action@v1
         with:
           registry: gcr.io
           username: _json_key
           password: ${{ secrets.GOOGLE_CREDENTIALS }}
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@master
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-graphhopper-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-graphhopper-buildx
       # ---------------------
 
       - name: Install golang


### PR DESCRIPTION
Realized after manually testing the newly-added golden response set action that I didn't add a step for checking out the code from github before running steps that require scripts in the repo, which meant the step failed. The change here just copies the setup steps currently in use in the main functional test action, and has been tested as working

@kaelgreco @danielhfrank , I'm going to force merge this given how minor it is, so just FYI 