### PR TITLE
[RAD-2831] Analyze functional test results against golden OD response sets (ie, "stable routing")

### DIFF
--- a/.github/workflows/build_test_push.yaml
+++ b/.github/workflows/build_test_push.yaml
@@ -78,5 +78,3 @@ jobs:
         run: |
           docker run -t -d --name testrunner us.gcr.io/model-159019/gh:${{ github.sha }}-dev /bin/bash
           docker exec -i testrunner /bin/bash -c "mvn test"
-  
-

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -122,8 +122,6 @@ jobs:
     name: "Analyze functional test results by comparing to golden OD response set"
     runs-on: ubuntu-latest
     needs: functional-test-queries
-    # Only allow run if functional-test-queries step has succeeded
-    if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'
     env:
       PROJECT_ID: model-159019
     steps:

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -2,7 +2,7 @@ name: Functional Test
 # This test does the following:
 # * Builds the "server" docker image that is used by the model repo
 # * Runs functional tests queries against micro nor cal golden OD set
-# * analyzes results of functional test queries, comparing against golden result set
+# * Analyzes results of functional test queries, comparing against golden result set
 # * If tests pass, updates git and docker tags
 # The workflow is configured to run on merges to original-direction, after unit tests pass.
 # It can also be run manually, in which case it will NOT execute the steps to update git and docker tags
@@ -120,10 +120,10 @@ jobs:
 
   analyze-functional-test-results:
     name: "Analyze functional test results by comparing to golden OD response set"
-    # Only allow run if functional-test-queries step has succeeded
-    if: github.event_name == 'workflow_dispatch' && github.event.workflow_run.conclusion == 'success'
-    needs: functional-test-queries
     runs-on: ubuntu-latest
+    needs: functional-test-queries
+    # Only allow run if functional-test-queries step has succeeded
+    if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'
     env:
       PROJECT_ID: model-159019
     steps:

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -2,7 +2,7 @@ name: Functional Test
 # This test does the following:
 # * Builds the "server" docker image that is used by the model repo
 # * Runs functional tests queries against micro nor cal golden OD set
-# * (todo: analyzes results of functional test queries, comparing against golden result set)
+# * analyzes results of functional test queries, comparing against golden result set
 # * If tests pass, updates git and docker tags
 # The workflow is configured to run on merges to original-direction, after unit tests pass.
 # It can also be run manually, in which case it will NOT execute the steps to update git and docker tags
@@ -118,9 +118,92 @@ jobs:
           name: functional-test-transit-results
           path: ${{ env.TMPDIR }}/transit_responses.json
 
+  analyze-functional-test-results:
+    name: "Analyze functional test results by comparing to golden OD response set"
+    # Only allow run if functional-test-queries step has succeeded
+    if: github.event_name == 'workflow_dispatch' && github.event.workflow_run.conclusion == 'success'
+    needs: functional-test-queries
+    runs-on: ubuntu-latest
+    env:
+      PROJECT_ID: model-159019
+    steps:
+      # ---------------------
+      # Common steps that we repeat between workflows.
+      # I couldn't find an equivalent of CircleCI's templates; can we consolidate by turning this into an action?
+      - name: Code Checkout
+        uses: actions/checkout@v2
+
+      - name: Sub modules checkout
+        env:
+          SSH_KEY_FOR_SUBMODULE: ${{secrets.SUBMODULE_GITHUB_KEY}}
+        # set the ssh key for the run
+        run: |
+          mkdir -p /home/runner/.ssh && touch /home/runner/.ssh/id_rsa && echo "$SSH_KEY_FOR_SUBMODULE" > $HOME/.ssh/id_rsa && chmod 600 $HOME/.ssh/id_rsa &&  git submodule sync && git submodule --quiet update --init && echo `git rev-parse --short=8 HEAD ` > TAG.txt
+
+      - name: Login to GCP
+        # Setup gcloud CLI
+        uses: google-github-actions/setup-gcloud@v0.2.0
+        with:
+          project_id: ${{ env.PROJECT_ID }}
+          service_account_key: ${{ secrets.GOOGLE_CREDENTIALS }}
+          version: "297.0.1" # Fix https://github.com/google-github-actions/setup-gcloud/issues/128
+          export_default_credentials: true
+
+      # Configure Docker to use the gcloud command-line tool as a credential
+      # helper for authentication
+      - run: |-
+          gcloud --quiet auth configure-docker
+
+      - name: Login to GCR
+        uses: docker/login-action@v1
+        with:
+          registry: gcr.io
+          username: _json_key
+          password: ${{ secrets.GOOGLE_CREDENTIALS }}
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@master
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-graphhopper-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-graphhopper-buildx
+      # ---------------------
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Download archived street functional test results
+        uses: actions/download-artifact@v2
+        with:
+          name: functional-test-street-results
+
+      - name: Download transit functional test results
+        uses: actions/download-artifact@v2
+        with:
+          name: functional-test-transit-results
+
+      - name: Download latest street + transit golden OD response sets
+        run: |
+          GOLDEN_STREET_PATH=$(gsutil ls gs://graphhopper_test_artifacts/golden_street_response_sets | sort -k 2 | tail -2 | head -1)
+          GOLDEN_TRANSIT_PATH=$(gsutil ls gs://graphhopper_test_artifacts/golden_transit_response_sets | sort -k 2 | tail -2 | head -1)
+          gsutil cp $GOLDEN_STREET_PATH golden_street_responses.json
+          gsutil cp $GOLDEN_TRANSIT_PATH golden_transit_responses.json
+          echo "Using golden street response set $GOLDEN_STREET_PATH + golden transit response set $GOLDEN_TRANSIT_PATH"
+
+      - name: Run analysis of functional test results vs. golden result sets
+        run: |
+          python analyze_functional_test_results.py golden_street_responses.json golden_transit_responses.json street_responses.json transit_responses.json
+
   update-tags:
     runs-on: ubuntu-latest
-    needs: functional-test-queries
+    needs: analyze-functional-test-results
     # Only update tags if this was triggered by completion of CI upstream
     if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'
     steps:
@@ -161,4 +244,3 @@ jobs:
         docker pull us.gcr.io/model-159019/gh:${{ github.sha }}-server-dev
         docker tag us.gcr.io/model-159019/gh:${{ github.sha }}-server-dev us.gcr.io/model-159019/gh:${{ steps.compute_new_tag.outputs.tag }}
         docker push us.gcr.io/model-159019/gh:${{ steps.compute_new_tag.outputs.tag }}
-

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -189,8 +189,8 @@ jobs:
 
       - name: Download latest street + transit golden OD response sets
         run: |
-          GOLDEN_STREET_PATH=$(gsutil ls gs://graphhopper_test_artifacts/golden_street_response_sets | sort -k 2 | tail -2 | head -1)
-          GOLDEN_TRANSIT_PATH=$(gsutil ls gs://graphhopper_test_artifacts/golden_transit_response_sets | sort -k 2 | tail -2 | head -1)
+          GOLDEN_STREET_PATH=$(gsutil ls -l gs://graphhopper_test_artifacts/golden_street_response_sets | sort -k 2 | tail -2 | head -1 | rev | cut -d' ' -f 1 | rev)
+          GOLDEN_TRANSIT_PATH=$(gsutil ls -l gs://graphhopper_test_artifacts/golden_transit_response_sets | sort -k 2 | tail -2 | head -1 | rev | cut -d' ' -f 1 | rev)
           gsutil cp $GOLDEN_STREET_PATH golden_street_responses.json
           gsutil cp $GOLDEN_TRANSIT_PATH golden_transit_responses.json
           echo "Using golden street response set $GOLDEN_STREET_PATH + golden transit response set $GOLDEN_TRANSIT_PATH"

--- a/.github/workflows/generate-golden-response-set.yaml
+++ b/.github/workflows/generate-golden-response-set.yaml
@@ -9,6 +9,16 @@ jobs:
     steps:
       # ---------------------
       # Common steps that we repeat between workflows.
+      - name: Code Checkout
+        uses: actions/checkout@v2
+
+      - name: Sub modules checkout
+        env:
+          SSH_KEY_FOR_SUBMODULE: ${{secrets.SUBMODULE_GITHUB_KEY}}
+        #the step below set the ssh key for the run
+        run: |
+          mkdir -p /home/runner/.ssh && touch /home/runner/.ssh/id_rsa && echo "$SSH_KEY_FOR_SUBMODULE" > $HOME/.ssh/id_rsa && chmod 600 $HOME/.ssh/id_rsa &&  git submodule sync && git submodule --quiet update --init && echo `git rev-parse --short=8 HEAD ` > TAG.txt
+
       - name: Login to GCP
         # Setup gcloud CLI
         uses: google-github-actions/setup-gcloud@v0.2.0
@@ -32,6 +42,18 @@ jobs:
           registry: gcr.io
           username: _json_key
           password: ${{ secrets.GOOGLE_CREDENTIALS }}
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@master
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-graphhopper-buildx-${{ github.sha}}
+          restore-keys: |
+            ${{ runner.os }}-graphhopper-buildx
       # ---------------------
 
       - name: Install golang

--- a/analyze_functional_test_results.py
+++ b/analyze_functional_test_results.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Tuple
 import json
 import sys
 import time

--- a/analyze_functional_test_results.py
+++ b/analyze_functional_test_results.py
@@ -3,76 +3,137 @@ import json
 import sys
 import time
 
-def import_query_results(street_path='street_responses.json', transit_path='transit_responses.json'):
+
+NEW_ROUTES_FOUND_THRESHOLD = 0.05
+OLD_ROUTES_NOT_FOUND_THRESHOLD = 0.05
+MATCHED_ROUTES_THRESHOLD = 0.95
+TRAVEL_TIME_MPC_THRESHOLD = 0.05
+TRAVEL_TIME_MEAN_APC_THRESHOLD = 0.05
+TRANSIT_RATIO_MPC_THRESHOLD = 0.05
+TRANSIT_RATIO_MEAN_APC_THRESHOLD = 0.05
+
+
+def import_query_results(
+    street_path: str = "street_responses.json",
+    transit_path: str = "transit_responses.json",
+) -> Tuple[dict, dict]:
     with open(street_path) as street_response_file:
-        street_results_json = [json.loads(jline) for jline in street_response_file.read().splitlines()]
+        street_results_json = [
+            json.loads(jline) for jline in street_response_file.read().splitlines()
+        ]
 
     with open(transit_path) as transit_response_file:
-        transit_results_json = [json.loads(jline) for jline in transit_response_file.read().splitlines()]
+        transit_results_json = [
+            json.loads(jline) for jline in transit_response_file.read().splitlines()
+        ]
 
-    street_results_map = dict(map(lambda x: (x['person_id'], x), street_results_json))
-    transit_results_map = dict(map(lambda x: (x['person_id'], x), transit_results_json))
+    street_results_map = {res["person_id"]: res for res in street_results_json}
+    transit_results_map = {res["person_id"]: res for res in transit_results_json}
     return street_results_map, transit_results_map
 
-def get_unix_timestamp(datetime_string):
-    return time.mktime(datetime.strptime(datetime_string, '%Y-%m-%dT%H:%M:%SZ').timetuple())
 
-def calculate_transit_ratio(response):
-    first_path = response['paths'][0]
-    transit_time_millis = sum((get_unix_timestamp(leg['arrival_time']) - get_unix_timestamp(leg['departure_time'])) * 1000 for leg in first_path['pt_legs'])
-    return transit_time_millis / int(first_path['duration_millis'])
+def get_unix_timestamp(datetime_string: str) -> int:
+    return time.mktime(
+        datetime.strptime(datetime_string, "%Y-%m-%dT%H:%M:%SZ").timetuple()
+    )
 
-def percent_new_routes_found(golden_response_set, responses_to_validate):
+
+def calculate_transit_ratio(response: dict) -> float:
+    first_path = response["paths"][0]
+    transit_time_millis = sum(
+        (
+            get_unix_timestamp(leg["arrival_time"])
+            - get_unix_timestamp(leg["departure_time"])
+        )
+        * 1000
+        for leg in first_path["pt_legs"]
+    )
+    return transit_time_millis / int(first_path["duration_millis"])
+
+
+def percent_new_routes_found(
+    golden_response_set: dict, responses_to_validate: dict
+) -> float:
     new_routes_count = len(responses_to_validate.keys() - golden_response_set.keys())
     return new_routes_count / len(golden_response_set)
 
-def percent_old_routes_not_found(golden_response_set, responses_to_validate):
-    old_routes_not_found_count = len(golden_response_set.keys() - responses_to_validate.keys())
+
+def percent_old_routes_not_found(
+    golden_response_set: dict, responses_to_validate: dict
+) -> float:
+    old_routes_not_found_count = len(
+        golden_response_set.keys() - responses_to_validate.keys()
+    )
     return old_routes_not_found_count / len(golden_response_set)
 
-def percent_matched_routes(golden_response_set, responses_to_validate):
+
+def percent_matched_routes(
+    golden_response_set: dict, responses_to_validate: dict
+) -> float:
     matched_count = 0
     for person_id in golden_response_set.keys() & responses_to_validate.keys():
         if person_id in golden_response_set and person_id in responses_to_validate:
             golden_entry = golden_response_set[person_id]
             to_validate_entry = responses_to_validate[person_id]
             # round distance_meters to nearest meter, because it seems to be slightly inconsistent/nondeterministic
-            for path in golden_entry['paths']:
-                path['distance_meters'] = int(path['distance_meters'])
-            for path in to_validate_entry['paths']:
-                path['distance_meters'] = int(path['distance_meters'])
+            for path in golden_entry["paths"]:
+                path["distance_meters"] = int(path["distance_meters"])
+            for path in to_validate_entry["paths"]:
+                path["distance_meters"] = int(path["distance_meters"])
             if golden_entry == to_validate_entry:
                 matched_count += 1
     return matched_count / len(golden_response_set)
+
 
 # Note: The following 4 checks only consider routes that are found across both runs,
 # and only consider the first path of each properly matched response
 # Mean percent change over n response paths = (1/n) * sum over n((T_new - T_old) / T_old)
 # Mean absolute percent change over n response paths = (1/n) * sum over n(abs((T_new - T_old) / T_old))
-def travel_time_mean_percent_change(golden_response_set, responses_to_validate, is_transit):
+def travel_time_mean_percent_change(
+    golden_response_set: dict, responses_to_validate: dict, is_transit: bool
+) -> float:
     matched_count = 0
     sum_of_changes = 0.0
-    for person_id in golden_response_set.keys():
-        golden_response = golden_response_set.get(person_id)
+    for person_id, golden_response in golden_response_set.items():
         to_compare = responses_to_validate.get(person_id)
         if to_compare:
             matched_count += 1
-            first_golden = golden_response['paths'][0]
-            first_to_compare = to_compare['paths'][0]
+            first_golden = golden_response["paths"][0]
+            first_to_compare = to_compare["paths"][0]
             if is_transit:
-                golden_travel_time = sum((get_unix_timestamp(leg['arrival_time']) - get_unix_timestamp(leg['departure_time'])) * 1000 for leg in (first_golden['pt_legs'] + first_golden['foot_legs']))
-                to_compare_travel_time = sum((get_unix_timestamp(leg['arrival_time']) - get_unix_timestamp(leg['departure_time'])) * 1000 for leg in (first_to_compare['pt_legs'] + first_to_compare['foot_legs']))
+                golden_travel_time = sum(
+                    (
+                        get_unix_timestamp(leg["arrival_time"])
+                        - get_unix_timestamp(leg["departure_time"])
+                    )
+                    * 1000
+                    for leg in (first_golden["pt_legs"] + first_golden["foot_legs"])
+                )
+                to_compare_travel_time = sum(
+                    (
+                        get_unix_timestamp(leg["arrival_time"])
+                        - get_unix_timestamp(leg["departure_time"])
+                    )
+                    * 1000
+                    for leg in (
+                        first_to_compare["pt_legs"] + first_to_compare["foot_legs"]
+                    )
+                )
             else:
-                golden_travel_time = first_golden['duration_millis']
-                to_compare_travel_time = first_to_compare['duration_millis']
-            sum_of_changes += (int(to_compare_travel_time) - int(golden_travel_time)) / int(golden_travel_time)
+                golden_travel_time = first_golden["duration_millis"]
+                to_compare_travel_time = first_to_compare["duration_millis"]
+            sum_of_changes += (
+                int(to_compare_travel_time) - int(golden_travel_time)
+            ) / int(golden_travel_time)
     return (1 / matched_count) * sum_of_changes
 
-def transit_ratio_mean_percent_change(golden_response_set, responses_to_validate):
+
+def transit_ratio_mean_percent_change(
+    golden_response_set: dict, responses_to_validate: dict
+) -> float:
     matched_count = 0
     sum_of_changes = 0.0
-    for person_id in golden_response_set.keys():
-        golden_response = golden_response_set.get(person_id)
+    for person_id, golden_response in golden_response_set.items():
         to_compare = responses_to_validate.get(person_id)
         if to_compare:
             matched_count += 1
@@ -81,30 +142,53 @@ def transit_ratio_mean_percent_change(golden_response_set, responses_to_validate
             sum_of_changes += (to_compare_ratio - golden_ratio) / golden_ratio
     return (1 / matched_count) * sum_of_changes
 
-def travel_time_mean_absolute_percent_change(golden_response_set, responses_to_validate, is_transit):
+
+def travel_time_mean_absolute_percent_change(
+    golden_response_set: dict, responses_to_validate: dict, is_transit: bool
+) -> float:
     matched_count = 0
     sum_of_changes = 0.0
-    for person_id in golden_response_set.keys():
-        golden_response = golden_response_set.get(person_id)
+    for person_id, golden_response in golden_response_set.items():
         to_compare = responses_to_validate.get(person_id)
         if to_compare:
             matched_count += 1
-            first_golden = golden_response['paths'][0]
-            first_to_compare = to_compare['paths'][0]
+            first_golden = golden_response["paths"][0]
+            first_to_compare = to_compare["paths"][0]
             if is_transit:
-                golden_travel_time = sum((get_unix_timestamp(leg['arrival_time']) - get_unix_timestamp(leg['departure_time'])) * 1000 for leg in (first_golden['pt_legs'] + first_golden['foot_legs']))
-                to_compare_travel_time = sum((get_unix_timestamp(leg['arrival_time']) - get_unix_timestamp(leg['departure_time'])) * 1000 for leg in (first_to_compare['pt_legs'] + first_to_compare['foot_legs']))
+                golden_travel_time = sum(
+                    (
+                        get_unix_timestamp(leg["arrival_time"])
+                        - get_unix_timestamp(leg["departure_time"])
+                    )
+                    * 1000
+                    for leg in (first_golden["pt_legs"] + first_golden["foot_legs"])
+                )
+                to_compare_travel_time = sum(
+                    (
+                        get_unix_timestamp(leg["arrival_time"])
+                        - get_unix_timestamp(leg["departure_time"])
+                    )
+                    * 1000
+                    for leg in (
+                        first_to_compare["pt_legs"] + first_to_compare["foot_legs"]
+                    )
+                )
             else:
-                golden_travel_time = first_golden['duration_millis']
-                to_compare_travel_time = first_to_compare['duration_millis']
-            sum_of_changes += abs((int(to_compare_travel_time) - int(golden_travel_time)) / int(golden_travel_time))
+                golden_travel_time = first_golden["duration_millis"]
+                to_compare_travel_time = first_to_compare["duration_millis"]
+            sum_of_changes += abs(
+                (int(to_compare_travel_time) - int(golden_travel_time))
+                / int(golden_travel_time)
+            )
     return (1 / matched_count) * sum_of_changes
 
-def transit_ratio_mean_absolute_percent_change(golden_response_set, responses_to_validate):
+
+def transit_ratio_mean_absolute_percent_change(
+    golden_response_set: dict, responses_to_validate: dict
+) -> float:
     matched_count = 0
     sum_of_changes = 0.0
-    for person_id in golden_response_set.keys():
-        golden_response = golden_response_set.get(person_id)
+    for person_id, golden_response in golden_response_set.items():
         to_compare = responses_to_validate.get(person_id)
         if to_compare:
             matched_count += 1
@@ -113,35 +197,67 @@ def transit_ratio_mean_absolute_percent_change(golden_response_set, responses_to
             sum_of_changes += abs((to_compare_ratio - golden_ratio) / golden_ratio)
     return (1 / matched_count) * sum_of_changes
 
-# todo: add print statements to show all results before/during actual assertions
-def run_all_validations(golden_response_set, responses_to_validate, is_transit):
+
+def run_all_validations(
+    golden_response_set: dict, responses_to_validate: dict, is_transit: bool
+):
     validation_results = {}
-    validation_results['new_routes_found'] = percent_new_routes_found(golden_response_set, responses_to_validate)
-    validation_results['old_routes_not_found'] = percent_old_routes_not_found(golden_response_set, responses_to_validate)
-    validation_results['matched_routes'] = percent_matched_routes(golden_response_set, responses_to_validate)
-    validation_results['travel_time_mpc'] = travel_time_mean_percent_change(golden_response_set, responses_to_validate, is_transit)
-    validation_results['travel_time_mean_apc'] = travel_time_mean_absolute_percent_change(golden_response_set, responses_to_validate, is_transit)
+    validation_results["new_routes_found"] = percent_new_routes_found(
+        golden_response_set, responses_to_validate
+    )
+    validation_results["old_routes_not_found"] = percent_old_routes_not_found(
+        golden_response_set, responses_to_validate
+    )
+    validation_results["matched_routes"] = percent_matched_routes(
+        golden_response_set, responses_to_validate
+    )
+    validation_results["travel_time_mpc"] = travel_time_mean_percent_change(
+        golden_response_set, responses_to_validate, is_transit
+    )
+    validation_results[
+        "travel_time_mean_apc"
+    ] = travel_time_mean_absolute_percent_change(
+        golden_response_set, responses_to_validate, is_transit
+    )
     if is_transit:
-        validation_results['transit_ratio_mpc'] = transit_ratio_mean_percent_change(golden_response_set, responses_to_validate)
-        validation_results['transit_ratio_mean_apc'] = transit_ratio_mean_absolute_percent_change(golden_response_set, responses_to_validate)
+        validation_results["transit_ratio_mpc"] = transit_ratio_mean_percent_change(
+            golden_response_set, responses_to_validate
+        )
+        validation_results[
+            "transit_ratio_mean_apc"
+        ] = transit_ratio_mean_absolute_percent_change(
+            golden_response_set, responses_to_validate
+        )
 
     print("Results of validation: \n" + str(validation_results))
 
-    assert validation_results['new_routes_found'] <= 0.05
-    assert validation_results['old_routes_not_found'] <= 0.05
-    assert validation_results['matched_routes'] >= 0.95
-    assert abs(validation_results['travel_time_mpc']) <= 0.05
-    assert validation_results['travel_time_mean_apc'] <= 0.05
+    assert validation_results["new_routes_found"] <= NEW_ROUTES_FOUND_THRESHOLD
+    assert validation_results["old_routes_not_found"] <= OLD_ROUTES_NOT_FOUND_THRESHOLD
+    assert validation_results["matched_routes"] >= MATCHED_ROUTES_THRESHOLD
+    assert abs(validation_results["travel_time_mpc"]) <= TRAVEL_TIME_MPC_THRESHOLD
+    assert validation_results["travel_time_mean_apc"] <= TRAVEL_TIME_MEAN_APC_THRESHOLD
     if is_transit:
-        assert abs(validation_results['transit_ratio_mpc']) <= 0.05
-        assert validation_results['transit_ratio_mean_apc'] <= 0.05
+        assert (
+            abs(validation_results["transit_ratio_mpc"]) <= TRANSIT_RATIO_MPC_THRESHOLD
+        )
+        assert (
+            validation_results["transit_ratio_mean_apc"]
+            <= TRANSIT_RATIO_MEAN_APC_THRESHOLD
+        )
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     if len(sys.argv) != 5:
-        print("Improper number of arguments provided! Be sure 4 response sets are being passed as input")
+        print(
+            "Improper number of arguments provided! Be sure 4 response sets are being passed as input"
+        )
         raise
-    golden_street_responses, golden_transit_responses = import_query_results(sys.argv[1], sys.argv[2])
-    to_validate_street_responses, to_validate_transit_responses = import_query_results(sys.argv[3], sys.argv[4])
+    golden_street_responses, golden_transit_responses = import_query_results(
+        sys.argv[1], sys.argv[2]
+    )
+    to_validate_street_responses, to_validate_transit_responses = import_query_results(
+        sys.argv[3], sys.argv[4]
+    )
     print("Running validations for street responses")
     run_all_validations(golden_street_responses, to_validate_street_responses, False)
     print("Running validations for transit responses")

--- a/analyze_functional_test_results.py
+++ b/analyze_functional_test_results.py
@@ -1,4 +1,7 @@
+from datetime import datetime
 import json
+import sys
+import time
 
 def import_query_results(street_path='street_responses.json', transit_path='transit_responses.json'):
     with open(street_path) as street_response_file:
@@ -11,10 +14,13 @@ def import_query_results(street_path='street_responses.json', transit_path='tran
     transit_results_map = dict(map(lambda x: (x['person_id'], x), transit_results_json))
     return street_results_map, transit_results_map
 
+def get_unix_timestamp(datetime_string):
+    return time.mktime(datetime.strptime(datetime_string, '%Y-%m-%dT%H:%M:%SZ').timetuple())
+
 def calculate_transit_ratio(response):
-    first_path = response.paths[0]
-    transit_time_millis = sum((leg.arrival_time.seconds - leg.departure_time.seconds) * 1000 for leg in first_path.pt_legs)
-    return transit_time_millis / first_path.duration_millis
+    first_path = response['paths'][0]
+    transit_time_millis = sum((get_unix_timestamp(leg['arrival_time']) - get_unix_timestamp(leg['departure_time'])) * 1000 for leg in first_path['pt_legs'])
+    return transit_time_millis / int(first_path['duration_millis'])
 
 def percent_new_routes_found(golden_response_set, responses_to_validate):
     new_routes_count = len(responses_to_validate.keys() - golden_response_set.keys())
@@ -28,7 +34,14 @@ def percent_matched_routes(golden_response_set, responses_to_validate):
     matched_count = 0
     for person_id in golden_response_set.keys() & responses_to_validate.keys():
         if person_id in golden_response_set and person_id in responses_to_validate:
-            if golden_response_set[person_id] == responses_to_validate[person_id]:
+            golden_entry = golden_response_set[person_id]
+            to_validate_entry = responses_to_validate[person_id]
+            # round distance_meters to nearest meter, because it seems to be slightly inconsistent/nondeterministic
+            for path in golden_entry['paths']:
+                path['distance_meters'] = int(path['distance_meters'])
+            for path in to_validate_entry['paths']:
+                path['distance_meters'] = int(path['distance_meters'])
+            if golden_entry == to_validate_entry:
                 matched_count += 1
     return matched_count / len(golden_response_set)
 
@@ -36,8 +49,7 @@ def percent_matched_routes(golden_response_set, responses_to_validate):
 # and only consider the first path of each properly matched response
 # Mean percent change over n response paths = (1/n) * sum over n((T_new - T_old) / T_old)
 # Mean absolute percent change over n response paths = (1/n) * sum over n(abs((T_new - T_old) / T_old))
-
-def travel_time_mean_percent_change(golden_response_set, responses_to_validate):
+def travel_time_mean_percent_change(golden_response_set, responses_to_validate, is_transit):
     matched_count = 0
     sum_of_changes = 0.0
     for person_id in golden_response_set.keys():
@@ -45,7 +57,15 @@ def travel_time_mean_percent_change(golden_response_set, responses_to_validate):
         to_compare = responses_to_validate.get(person_id)
         if to_compare:
             matched_count += 1
-            sum_of_changes += (to_compare.paths[0].duration_millis - golden_response.paths[0].duration_millis) / golden_response.paths[0].duration_millis
+            first_golden = golden_response['paths'][0]
+            first_to_compare = to_compare['paths'][0]
+            if is_transit:
+                golden_travel_time = sum((get_unix_timestamp(leg['arrival_time']) - get_unix_timestamp(leg['departure_time'])) * 1000 for leg in (first_golden['pt_legs'] + first_golden['foot_legs']))
+                to_compare_travel_time = sum((get_unix_timestamp(leg['arrival_time']) - get_unix_timestamp(leg['departure_time'])) * 1000 for leg in (first_to_compare['pt_legs'] + first_to_compare['foot_legs']))
+            else:
+                golden_travel_time = first_golden['duration_millis']
+                to_compare_travel_time = first_to_compare['duration_millis']
+            sum_of_changes += (int(to_compare_travel_time) - int(golden_travel_time)) / int(golden_travel_time)
     return (1 / matched_count) * sum_of_changes
 
 def transit_ratio_mean_percent_change(golden_response_set, responses_to_validate):
@@ -61,7 +81,7 @@ def transit_ratio_mean_percent_change(golden_response_set, responses_to_validate
             sum_of_changes += (to_compare_ratio - golden_ratio) / golden_ratio
     return (1 / matched_count) * sum_of_changes
 
-def travel_time_mean_absolute_percent_change(golden_response_set, responses_to_validate):
+def travel_time_mean_absolute_percent_change(golden_response_set, responses_to_validate, is_transit):
     matched_count = 0
     sum_of_changes = 0.0
     for person_id in golden_response_set.keys():
@@ -69,7 +89,15 @@ def travel_time_mean_absolute_percent_change(golden_response_set, responses_to_v
         to_compare = responses_to_validate.get(person_id)
         if to_compare:
             matched_count += 1
-            sum_of_changes += abs((to_compare.paths[0].duration_millis - golden_response.paths[0].duration_millis) / golden_response.paths[0].duration_millis)
+            first_golden = golden_response['paths'][0]
+            first_to_compare = to_compare['paths'][0]
+            if is_transit:
+                golden_travel_time = sum((get_unix_timestamp(leg['arrival_time']) - get_unix_timestamp(leg['departure_time'])) * 1000 for leg in (first_golden['pt_legs'] + first_golden['foot_legs']))
+                to_compare_travel_time = sum((get_unix_timestamp(leg['arrival_time']) - get_unix_timestamp(leg['departure_time'])) * 1000 for leg in (first_to_compare['pt_legs'] + first_to_compare['foot_legs']))
+            else:
+                golden_travel_time = first_golden['duration_millis']
+                to_compare_travel_time = first_to_compare['duration_millis']
+            sum_of_changes += abs((int(to_compare_travel_time) - int(golden_travel_time)) / int(golden_travel_time))
     return (1 / matched_count) * sum_of_changes
 
 def transit_ratio_mean_absolute_percent_change(golden_response_set, responses_to_validate):
@@ -86,19 +114,35 @@ def transit_ratio_mean_absolute_percent_change(golden_response_set, responses_to
     return (1 / matched_count) * sum_of_changes
 
 # todo: add print statements to show all results before/during actual assertions
-def run_all_validations(golden_response_set, responses_to_validate):
-    assert percent_new_routes_found(golden_response_set, responses_to_validate) <= 0.05
-    assert percent_old_routes_not_found(golden_response_set, responses_to_validate) <= 0.05
-    assert percent_matched_routes(golden_response_set, responses_to_validate) >= 0.95
-    assert abs(travel_time_mean_percent_change(golden_response_set, responses_to_validate)) <= 0.05
-    assert abs(transit_ratio_mean_percent_change(golden_response_set, responses_to_validate)) <= 0.05
-    assert travel_time_mean_absolute_percent_change(golden_response_set, responses_to_validate) <= 0.05
-    assert transit_ratio_mean_absolute_percent_change(golden_response_set, responses_to_validate) <= 0.05
+def run_all_validations(golden_response_set, responses_to_validate, is_transit):
+    validation_results = {}
+    validation_results['new_routes_found'] = percent_new_routes_found(golden_response_set, responses_to_validate)
+    validation_results['old_routes_not_found'] = percent_old_routes_not_found(golden_response_set, responses_to_validate)
+    validation_results['matched_routes'] = percent_matched_routes(golden_response_set, responses_to_validate)
+    validation_results['travel_time_mpc'] = travel_time_mean_percent_change(golden_response_set, responses_to_validate, is_transit)
+    validation_results['travel_time_mean_apc'] = travel_time_mean_absolute_percent_change(golden_response_set, responses_to_validate, is_transit)
+    if is_transit:
+        validation_results['transit_ratio_mpc'] = transit_ratio_mean_percent_change(golden_response_set, responses_to_validate)
+        validation_results['transit_ratio_mean_apc'] = transit_ratio_mean_absolute_percent_change(golden_response_set, responses_to_validate)
+
+    print("Results of validation: \n" + str(validation_results))
+
+    assert validation_results['new_routes_found'] <= 0.05
+    assert validation_results['old_routes_not_found'] <= 0.05
+    assert validation_results['matched_routes'] >= 0.95
+    assert abs(validation_results['travel_time_mpc']) <= 0.05
+    assert validation_results['travel_time_mean_apc'] <= 0.05
+    if is_transit:
+        assert abs(validation_results['transit_ratio_mpc']) <= 0.05
+        assert validation_results['transit_ratio_mean_apc'] <= 0.05
 
 if __name__ == '__main__':
-    golden_street_responses, golden_transit_responses = import_query_results()
-    to_validate_street_responses, to_validate_transit_responses = import_query_results()
+    if len(sys.argv) != 5:
+        print("Improper number of arguments provided! Be sure 4 response sets are being passed as input")
+        raise
+    golden_street_responses, golden_transit_responses = import_query_results(sys.argv[1], sys.argv[2])
+    to_validate_street_responses, to_validate_transit_responses = import_query_results(sys.argv[3], sys.argv[4])
     print("Running validations for street responses")
-    run_all_validations(golden_street_responses, to_validate_street_responses)
+    run_all_validations(golden_street_responses, to_validate_street_responses, False)
     print("Running validations for transit responses")
-    run_all_validations(golden_transit_responses, to_validate_transit_responses)
+    run_all_validations(golden_transit_responses, to_validate_transit_responses, True)

--- a/analyze_functional_test_results.py
+++ b/analyze_functional_test_results.py
@@ -1,0 +1,104 @@
+import json
+
+def import_query_results(street_path='street_responses.json', transit_path='transit_responses.json'):
+    with open(street_path) as street_response_file:
+        street_results_json = [json.loads(jline) for jline in street_response_file.read().splitlines()]
+
+    with open(transit_path) as transit_response_file:
+        transit_results_json = [json.loads(jline) for jline in transit_response_file.read().splitlines()]
+
+    street_results_map = dict(map(lambda x: (x['person_id'], x), street_results_json))
+    transit_results_map = dict(map(lambda x: (x['person_id'], x), transit_results_json))
+    return street_results_map, transit_results_map
+
+def calculate_transit_ratio(response):
+    first_path = response.paths[0]
+    transit_time_millis = sum((leg.arrival_time.seconds - leg.departure_time.seconds) * 1000 for leg in first_path.pt_legs)
+    return transit_time_millis / first_path.duration_millis
+
+def percent_new_routes_found(golden_response_set, responses_to_validate):
+    new_routes_count = len(responses_to_validate.keys() - golden_response_set.keys())
+    return new_routes_count / len(golden_response_set)
+
+def percent_old_routes_not_found(golden_response_set, responses_to_validate):
+    old_routes_not_found_count = len(golden_response_set.keys() - responses_to_validate.keys())
+    return old_routes_not_found_count / len(golden_response_set)
+
+def percent_matched_routes(golden_response_set, responses_to_validate):
+    matched_count = 0
+    for person_id in golden_response_set.keys() & responses_to_validate.keys():
+        if person_id in golden_response_set and person_id in responses_to_validate:
+            if golden_response_set[person_id] == responses_to_validate[person_id]:
+                matched_count += 1
+    return matched_count / len(golden_response_set)
+
+# Note: The following 4 checks only consider routes that are found across both runs,
+# and only consider the first path of each properly matched response
+# Mean percent change over n response paths = (1/n) * sum over n((T_new - T_old) / T_old)
+# Mean absolute percent change over n response paths = (1/n) * sum over n(abs((T_new - T_old) / T_old))
+
+def travel_time_mean_percent_change(golden_response_set, responses_to_validate):
+    matched_count = 0
+    sum_of_changes = 0.0
+    for person_id in golden_response_set.keys():
+        golden_response = golden_response_set.get(person_id)
+        to_compare = responses_to_validate.get(person_id)
+        if to_compare:
+            matched_count += 1
+            sum_of_changes += (to_compare.paths[0].duration_millis - golden_response.paths[0].duration_millis) / golden_response.paths[0].duration_millis
+    return (1 / matched_count) * sum_of_changes
+
+def transit_ratio_mean_percent_change(golden_response_set, responses_to_validate):
+    matched_count = 0
+    sum_of_changes = 0.0
+    for person_id in golden_response_set.keys():
+        golden_response = golden_response_set.get(person_id)
+        to_compare = responses_to_validate.get(person_id)
+        if to_compare:
+            matched_count += 1
+            golden_ratio = calculate_transit_ratio(golden_response)
+            to_compare_ratio = calculate_transit_ratio(to_compare)
+            sum_of_changes += (to_compare_ratio - golden_ratio) / golden_ratio
+    return (1 / matched_count) * sum_of_changes
+
+def travel_time_mean_absolute_percent_change(golden_response_set, responses_to_validate):
+    matched_count = 0
+    sum_of_changes = 0.0
+    for person_id in golden_response_set.keys():
+        golden_response = golden_response_set.get(person_id)
+        to_compare = responses_to_validate.get(person_id)
+        if to_compare:
+            matched_count += 1
+            sum_of_changes += abs((to_compare.paths[0].duration_millis - golden_response.paths[0].duration_millis) / golden_response.paths[0].duration_millis)
+    return (1 / matched_count) * sum_of_changes
+
+def transit_ratio_mean_absolute_percent_change(golden_response_set, responses_to_validate):
+    matched_count = 0
+    sum_of_changes = 0.0
+    for person_id in golden_response_set.keys():
+        golden_response = golden_response_set.get(person_id)
+        to_compare = responses_to_validate.get(person_id)
+        if to_compare:
+            matched_count += 1
+            golden_ratio = calculate_transit_ratio(golden_response)
+            to_compare_ratio = calculate_transit_ratio(to_compare)
+            sum_of_changes += abs((to_compare_ratio - golden_ratio) / golden_ratio)
+    return (1 / matched_count) * sum_of_changes
+
+# todo: add print statements to show all results before/during actual assertions
+def run_all_validations(golden_response_set, responses_to_validate):
+    assert percent_new_routes_found(golden_response_set, responses_to_validate) <= 0.05
+    assert percent_old_routes_not_found(golden_response_set, responses_to_validate) <= 0.05
+    assert percent_matched_routes(golden_response_set, responses_to_validate) >= 0.95
+    assert abs(travel_time_mean_percent_change(golden_response_set, responses_to_validate)) <= 0.05
+    assert abs(transit_ratio_mean_percent_change(golden_response_set, responses_to_validate)) <= 0.05
+    assert travel_time_mean_absolute_percent_change(golden_response_set, responses_to_validate) <= 0.05
+    assert transit_ratio_mean_absolute_percent_change(golden_response_set, responses_to_validate) <= 0.05
+
+if __name__ == '__main__':
+    golden_street_responses, golden_transit_responses = import_query_results()
+    to_validate_street_responses, to_validate_transit_responses = import_query_results()
+    print("Running validations for street responses")
+    run_all_validations(golden_street_responses, to_validate_street_responses)
+    print("Running validations for transit responses")
+    run_all_validations(golden_transit_responses, to_validate_transit_responses)


### PR DESCRIPTION
Adds a new step to the functional test workflow that compares the output of the functional test's queries against every OD in the golden OD set (which we added + started storing results for in #88) with the last-generated golden query result set (created via an action also added in #88). The purpose is to ensure that when new changes are introduced, a test is run to be sure that several core aspects of the routes being created don't stray too far from routes we've generated in the past (ie, the routing engine is "stable").

A python script is added to run the analysis; the main attributes being tested against are laid out in [this doc](https://docs.google.com/document/d/1RdeFZCbdlCbLJyXE5JqOeFD0WQyc7bR2cSUJtxUN5uw/edit#). A [new bucket](https://console.cloud.google.com/storage/browser/graphhopper_test_artifacts?project=model-159019&pageState=(%22StorageObjectListTable%22:(%22f%22:%22%255B%255D%22))&prefix=&forceOnObjectsSortingFiltering=false) was created to store golden set test results; it's from here that the last-generated golden result set is pulled.

Proof of the test running in CI and working as expected is [here](https://github.com/replicahq/graphhopper/runs/3427508269?check_suite_focus=true) (in this test, I generated a new golden result set just before on the same branch, so this functional test run is showing that there's a 0% change in all categories, basically).

I've also ensured that real changes actually trigger something in the analysis step, by generating another golden set with a [GTFS feed removed ](https://github.com/replicahq/graphhopper/compare/original-direction...replicahq:func_test_tester?expand=1)from the micro nor cal region, and running the python script with this branch's golden set vs. the set generated with less GTFS coverage. Results below (a large difference is found in transit route attributes):
```
Running validations for street responses
Results of validation:
{'new_routes_found': 0.0, 'old_routes_not_found': 0.0, 'matched_routes': 1.0, 'travel_time_mpc': 0.0, 'travel_time_mean_apc': 0.0}
Running validations for transit responses
Results of validation:
{'new_routes_found': 0.0, 'old_routes_not_found': 0.07692307692307693, 'matched_routes': 0.9190283400809717, 'travel_time_mpc': -0.00023825975078030066, 'travel_time_mean_apc': 0.00023825975078030066, 'transit_ratio_mpc': -0.00031772761211813126, 'transit_ratio_mean_apc': 0.00031772761211813126}
```

fyi @danielhfrank @alexeisw 