### PR TITLE
[RAD-2832] Add query time checks to functional test

### DIFF
--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -178,10 +178,10 @@ jobs:
           python-version: 3.9
 
       - name: Install python dependencies
-          run: |
-            python -m pip install --upgrade pip
-            pip install numpy
-            if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        run: |
+          python -m pip install --upgrade pip
+          pip install numpy
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
       - name: Download archived street functional test results
         uses: actions/download-artifact@v2

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -177,6 +177,12 @@ jobs:
         with:
           python-version: 3.9
 
+      - name: Install python dependencies
+          run: |
+            python -m pip install --upgrade pip
+            pip install numpy
+            if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
       - name: Download archived street functional test results
         uses: actions/download-artifact@v2
         with:

--- a/analyze_functional_test_results.py
+++ b/analyze_functional_test_results.py
@@ -45,11 +45,11 @@ def get_unix_timestamp(datetime_string: str) -> int:
 
 
 def calculate_mean_query_time(response_set: dict) -> float:
-    return np.array([r["query_time"] for r in response_set.values()]).mean()
+    return np.array([r["query_time"] for r in response_set.values()]).astype(np.int64).mean()
 
 
 def calculate_query_time_90th_percentile(response_set: dict) -> float:
-    return np.percentile(np.array([r["query_time"] for r in response_set.values()]), 90)
+    return np.percentile(np.array([r["query_time"] for r in response_set.values()]).astype(np.int64), 90)
 
 
 def calculate_transit_ratio(response: dict) -> float:

--- a/analyze_functional_test_results.py
+++ b/analyze_functional_test_results.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from typing import Tuple
 import json
+import numpy as np
 import sys
 import time
 
@@ -12,6 +13,10 @@ TRAVEL_TIME_MPC_THRESHOLD = 0.05
 TRAVEL_TIME_MEAN_APC_THRESHOLD = 0.05
 TRANSIT_RATIO_MPC_THRESHOLD = 0.05
 TRANSIT_RATIO_MEAN_APC_THRESHOLD = 0.05
+STREET_MEAN_QUERY_TIME_THRESHOLD_MS = 300
+STREET_90TH_PERCENTILE_QUERY_TIME_THRESHOLD_MS = 750
+TRANSIT_MEAN_QUERY_TIME_THRESHOLD_MS = 500
+TRANSIT_90TH_PERCENTILE_QUERY_TIME_THRESHOLD_MS = 1000
 
 
 def import_query_results(
@@ -37,6 +42,14 @@ def get_unix_timestamp(datetime_string: str) -> int:
     return time.mktime(
         datetime.strptime(datetime_string, "%Y-%m-%dT%H:%M:%SZ").timetuple()
     )
+
+
+def calculate_mean_query_time(response_set: dict) -> float:
+    return np.array([r["query_time"] for r in response_set.values()]).mean()
+
+
+def calculate_query_time_90th_percentile(response_set: dict) -> float:
+    return np.percentile(np.array([r["query_time"] for r in response_set.values()]), 90)
 
 
 def calculate_transit_ratio(response: dict) -> float:
@@ -86,7 +99,7 @@ def percent_matched_routes(
     return matched_count / len(golden_response_set)
 
 
-# Note: The following 4 checks only consider routes that are found across both runs,
+# Note: The following 2 checks only consider routes that are found across both runs,
 # and only consider the first path of each properly matched response
 # Mean percent change over n response paths = (1/n) * sum over n((T_new - T_old) / T_old)
 # Mean absolute percent change over n response paths = (1/n) * sum over n(abs((T_new - T_old) / T_old))
@@ -185,6 +198,13 @@ def run_all_validations(
             golden_response_set, responses_to_validate, True
         )
 
+    validation_results["mean_query_time"] = calculate_mean_query_time(
+        responses_to_validate
+    )
+    validation_results[
+        "90th_percentile_query_time"
+    ] = calculate_query_time_90th_percentile(responses_to_validate)
+
     print("Results of validation: \n" + str(validation_results))
 
     assert validation_results["new_routes_found"] <= NEW_ROUTES_FOUND_THRESHOLD
@@ -199,6 +219,22 @@ def run_all_validations(
         assert (
             validation_results["transit_ratio_mean_apc"]
             <= TRANSIT_RATIO_MEAN_APC_THRESHOLD
+        )
+        assert (
+            validation_results["mean_query_time"]
+            <= TRANSIT_MEAN_QUERY_TIME_THRESHOLD_MS
+        )
+        assert (
+            validation_results["90th_percentile_query_time"]
+            <= TRANSIT_90TH_PERCENTILE_QUERY_TIME_THRESHOLD_MS
+        )
+    else:
+        assert (
+            validation_results["mean_query_time"] <= STREET_MEAN_QUERY_TIME_THRESHOLD_MS
+        )
+        assert (
+            validation_results["90th_percentile_query_time"]
+            <= STREET_90TH_PERCENTILE_QUERY_TIME_THRESHOLD_MS
         )
 
 

--- a/analyze_functional_test_results.py
+++ b/analyze_functional_test_results.py
@@ -96,18 +96,22 @@ def percent_matched_routes(
         if person_id in golden_response_set and person_id in responses_to_validate:
             golden_entry = golden_response_set[person_id]
             to_validate_entry = responses_to_validate[person_id]
-            golden_compare = copy.deepcopy(golden_entry)
-            to_validate_compare = copy.deepcopy(to_validate_entry)
-
+            # remove query_time field before doing comparison
+            golden_compare = {
+                copy.deepcopy(k): copy.deepcopy(v)
+                for k, v in golden_entry.items()
+                if k != "query_time"
+            }
+            to_validate_compare = {
+                copy.deepcopy(k): copy.deepcopy(v)
+                for k, v in to_validate_entry.items()
+                if k != "query_time"
+            }
             # round distance_meters to nearest meter, because it seems to be slightly inconsistent/nondeterministic
             for path in golden_compare["paths"]:
                 path["distance_meters"] = int(path["distance_meters"])
             for path in to_validate_compare["paths"]:
                 path["distance_meters"] = int(path["distance_meters"])
-            # remove query_time field before doing comparison
-            golden_compare.pop("query_time", None)
-            to_validate_compare.pop("query_time", None)
-
             if golden_compare == to_validate_compare:
                 matched_count += 1
     return matched_count / len(golden_response_set)

--- a/query_functional_test.sh
+++ b/query_functional_test.sh
@@ -65,7 +65,7 @@ EOM
     END=$(python -c 'import time; print(int(time.time() * 1000))')
     QUERY_TIME=$((END-START))
     # Add JSON query result, appended with person_id and query time fields, to street_responses JSONL output file
-    jq -c --arg person "$person_id" '. |= . + {"person_id": $person}' --arg query_time "$QUERY_TIME" '. |= . + {"query_time": $QUERY_TIME}' "$TMPDIR"/response.json >> "$TMPDIR"/street_responses.json
+    jq -c --arg person "$person_id" --arg query_time "$QUERY_TIME" '. |= . + {"person_id": $person} + {"query_time": $query_time}' "$TMPDIR"/response.json >> "$TMPDIR"/street_responses.json
     rm "$TMPDIR"/response.json
   fi
 done < ./web/test-data/micro_nor_cal_golden_od_set.csv
@@ -92,7 +92,7 @@ EOM
     END=$(python -c 'import time; print(int(time.time() * 1000))')
     QUERY_TIME=$((END-START))
     # Add JSON query result, appended with person_id and query time fields, to street_responses JSONL output file
-    jq -c --arg person "$person_id" '. |= . + {"person_id": $person}' --arg query_time "$QUERY_TIME" '. |= . + {"query_time": $QUERY_TIME}' "$TMPDIR"/pt_response.json >> "$TMPDIR"/transit_responses.json
+    jq -c --arg person "$person_id" --arg query_time "$QUERY_TIME" '. |= . + {"person_id": $person} + {"query_time": $query_time}' "$TMPDIR"/pt_response.json >> "$TMPDIR"/transit_responses.json
     rm "$TMPDIR"/pt_response.json
   fi
 done < ./web/test-data/micro_nor_cal_golden_od_set.csv


### PR DESCRIPTION
Records the query time, in milliseconds, for each query run in the functional test and records that time as a new `query_time` field in the functional test result sets. Also, adds new check to the functional test result analysis step to ensure that query times for street + transit requests are under the thresholds we have set up in the model repo (outlined in [this](https://docs.google.com/document/d/1RdeFZCbdlCbLJyXE5JqOeFD0WQyc7bR2cSUJtxUN5uw/edit#heading=h.goh6q06cb6l6) doc).

[Proof of successful functional test run, showing mean + 90th percentile query time results](https://github.com/replicahq/graphhopper/runs/3499340303?check_suite_focus=true)

cc @danielhfrank 