### PR TITLE
Fix GTFS validator build github action

### DIFF
--- a/.github/workflows/build_gtfs_validator.yaml
+++ b/.github/workflows/build_gtfs_validator.yaml
@@ -5,6 +5,9 @@ jobs:
     name: Build GTFS Validator Base Image
     runs-on: ubuntu-latest
     steps:
+      - name: Code Checkout
+        uses: actions/checkout@v2
+
       - name: Login to GCP
         # Setup gcloud CLI
         uses: google-github-actions/setup-gcloud@v0.2.0

--- a/.github/workflows/build_gtfs_validator.yaml
+++ b/.github/workflows/build_gtfs_validator.yaml
@@ -2,8 +2,10 @@ name: Build GTFS Validator Image
 on: [workflow_dispatch]
 jobs:
   build:
-    name: Build GTFS Validator Base Image
+    name: "Build GTFS Validator Base Image"
     runs-on: ubuntu-latest
+    env:
+      PROJECT_ID: model-159019
     steps:
       - name: Code Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
I realized upon trying the action that there were a few small bugs in the initial version that caused it to fail (didn't catch them earlier, because you can't run a "new" action in github until after it's been merged).

Proof that fix works: [this](https://github.com/replicahq/graphhopper/actions/runs/1271534366) action kicked off [this](https://console.cloud.google.com/cloud-build/builds;region=global/70f03c61-271b-4af6-9fa4-ef790efc13d9;step=0?project=model-159019&supportedpurview=project) successful build