### PR TITLE
Fix GTFS link mapper unit test file handling

### DIFF
--- a/web/src/test/java/com/replica/GtfsLinkMapperTest.java
+++ b/web/src/test/java/com/replica/GtfsLinkMapperTest.java
@@ -95,7 +95,7 @@ public class GtfsLinkMapperTest extends ReplicaGraphHopperTest {
     }
 
     @AfterAll
-    public static void cleanupGraphDir() {
+    public static void cleanupGraphDir() throws Exception {
         // If link mapping files exist from main unit tests, copy back from tmp location
         File mainLinkMappings = new File("transit_data/gtfs_link_mappings_tmp.db");
         if (mainLinkMappings.exists()) {
@@ -106,5 +106,8 @@ public class GtfsLinkMapperTest extends ReplicaGraphHopperTest {
         }
         Helper.removeDir(new File(GRAPH_FILES_DIR));
         closeGraphhopper();
+
+        // Reload default test graph files so remaining unit tests work
+        loadGraphhopper();
     }
 }

--- a/web/src/test/java/com/replica/GtfsLinkMapperTest.java
+++ b/web/src/test/java/com/replica/GtfsLinkMapperTest.java
@@ -8,6 +8,7 @@ import com.graphhopper.gtfs.GraphHopperGtfs;
 import com.graphhopper.gtfs.GtfsStorage;
 import com.graphhopper.replica.GtfsLinkMapperHelper;
 import com.graphhopper.util.Helper;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -31,11 +32,11 @@ public class GtfsLinkMapperTest extends ReplicaGraphHopperTest {
 
     @BeforeAll
     public static void setup() throws Exception {
-        // If link mapping files exist from main unit tests, copy to tmp location
-        File existingLinkMapping = new File("transit_data/gtfs_link_mappings.db");
-        if (existingLinkMapping.exists()) {
-            logger.info("Existing link mappings being moved to transit_data/gtfs_link_mappings_tmp.db temporarily");
-            existingLinkMapping.renameTo(new File("transit_data/gtfs_link_mappings_tmp.db"));
+        // If graph files exist from main unit tests, copy to tmp location
+        File existingGraphFolder = new File("./transit_data");
+        if (existingGraphFolder.exists()) {
+            logger.info("Existing graph files being moved to tmp_transit_data folder temporarily");
+            FileUtils.copyDirectory(existingGraphFolder, new File("./tmp_transit_data"));
         }
         setup(TEST_GRAPHHOPPER_CONFIG_PATH, GRAPH_FILES_DIR);
     }
@@ -96,16 +97,16 @@ public class GtfsLinkMapperTest extends ReplicaGraphHopperTest {
 
     @AfterAll
     public static void cleanupGraphDir() throws Exception {
-        // If link mapping files exist from main unit tests, copy back from tmp location
-        File mainLinkMappings = new File("transit_data/gtfs_link_mappings_tmp.db");
-        if (mainLinkMappings.exists()) {
-            logger.info("Main test link mappings being moved back to transit_data/gtfs_link_mappings.db from temp location");
-            File existingLinkMappings = new File("transit_data/gtfs_link_mappings.db");
-            existingLinkMappings.delete();
-            mainLinkMappings.renameTo(new File("transit_data/gtfs_link_mappings.db"));
-        }
         Helper.removeDir(new File(GRAPH_FILES_DIR));
+        Helper.removeDir(new File(TRANSIT_DATA_DIR));
         closeGraphhopper();
+
+        // If we copied existing graph files before running tests, copy back from tmp location
+        File existingGraphFolder = new File("./tmp_transit_data");
+        if (existingGraphFolder.exists()) {
+            logger.info("Already-existing graph files being moved back to transit_data from temp location");
+            FileUtils.copyDirectory(existingGraphFolder, new File("./transit_data"));
+        }
 
         // Reload default test graph files so remaining unit tests work
         loadGraphhopper();

--- a/web/src/test/java/com/replica/ReplicaGraphHopperTest.java
+++ b/web/src/test/java/com/replica/ReplicaGraphHopperTest.java
@@ -67,6 +67,10 @@ public class ReplicaGraphHopperTest {
         return yaml.convertValue(yamlNode.get("graphhopper"), GraphHopperConfig.class);
     }
 
+    protected static void loadGraphhopper() throws Exception {
+        loadGraphhopper(TEST_GRAPHHOPPER_CONFIG_PATH);
+    }
+
     protected static void loadGraphhopper(String configPath) throws Exception {
         graphHopperConfiguration = loadGhConfig(configPath);
         ObjectMapper json = Jackson.newObjectMapper();


### PR DESCRIPTION
I had to set up hacky pre/post-test setup/cleanup when initially adding the GTFS link mapper unit tests, because they utilize a paired-down special GTFS feed that needs to be imported into graphhopper on its own (not shared by other tests).

Turns out I messed this up initially, but I'm guessing previous CI didn't catch this because unit test order isn't guaranteed (and if the "wrong" link mapper test runs last, nothing breaks).

The fix is basically to take the existing, already-built graph files used in all other unit tests and to move them to/from a tmp folder location before/after the link mapper test runs.