### PR TITLE
Bump GTFS validator heap memory for n1-standard-16 machines

### DIFF
--- a/Dockerfile.validate
+++ b/Dockerfile.validate
@@ -3,7 +3,7 @@ FROM $BASE_IMAGE as base
 
 COPY ./full_usa.osm.pbf ./
 
-RUN java -Xmx28g -Ddw.graphhopper.datareader.file=full_usa.osm.pbf \
+RUN java -Xmx58g -Ddw.graphhopper.datareader.file=full_usa.osm.pbf \
   -Ddw.graphhopper.validation=false -classpath web/target/graphhopper-web-1.0-SNAPSHOT.jar \
   com.graphhopper.http.GraphHopperApplication validate-gtfs gtfs_validation_gh_config.yaml \
   && rm ./full_usa.osm.pbf


### PR DESCRIPTION
Per discussion [here](https://replicahq.slack.com/archives/CK358RL0Z/p1636381674033600), the GTFS validator is getting a heap mem error when validating north atlantic GTFS. This change bumps up JVM heap to a level that would maximize memory on the next-step-up machine type, n1-standard-16.