### PR TITLE
Bump GTFS validator heap to utilize n1-standard-32 machines

### DIFF
--- a/Dockerfile.validate
+++ b/Dockerfile.validate
@@ -3,7 +3,7 @@ FROM $BASE_IMAGE as base
 
 COPY ./full_usa.osm.pbf ./
 
-RUN java -Xmx58g -Ddw.graphhopper.datareader.file=full_usa.osm.pbf \
+RUN java -Xmx115g -Ddw.graphhopper.datareader.file=full_usa.osm.pbf \
   -Ddw.graphhopper.validation=false -classpath web/target/graphhopper-web-1.0-SNAPSHOT.jar \
   com.graphhopper.http.GraphHopperApplication validate-gtfs gtfs_validation_gh_config.yaml \
   && rm ./full_usa.osm.pbf


### PR DESCRIPTION
context: https://replicahq.slack.com/archives/C01EV65JZS6/p1638235652340400?thread_ts=1638218119.332300&cid=C01EV65JZS6

FYI @kaelgreco 