### PR TITLE
Bump correct heap value for GTFS validator

### DIFF
--- a/Dockerfile.validate
+++ b/Dockerfile.validate
@@ -3,7 +3,7 @@ FROM $BASE_IMAGE as base
 
 COPY ./full_usa.osm.pbf ./
 
-RUN java -Xmx115g -Ddw.graphhopper.datareader.file=full_usa.osm.pbf \
+RUN java -Xmx58g -Ddw.graphhopper.datareader.file=full_usa.osm.pbf \
   -Ddw.graphhopper.validation=false -classpath web/target/graphhopper-web-1.0-SNAPSHOT.jar \
   com.graphhopper.http.GraphHopperApplication validate-gtfs gtfs_validation_gh_config.yaml \
   && rm ./full_usa.osm.pbf

--- a/run_gtfs_validation.sh
+++ b/run_gtfs_validation.sh
@@ -3,6 +3,6 @@ set -o errexit
 
 # Assumes that folder containing gtfs files is mounted as volume at /gtfs/
 export GTFS_FILE_LIST=$(ls ./gtfs/ | awk '{print "./gtfs/"$1}' | paste -s -d, -)
-java -Xmx16g -Ddw.graphhopper.gtfs.file=$GTFS_FILE_LIST \
+java -Xmx32g -Ddw.graphhopper.gtfs.file=$GTFS_FILE_LIST \
   -Ddw.graphhopper.validation=true -classpath web/target/graphhopper-web-1.0-SNAPSHOT.jar \
   com.graphhopper.http.GraphHopperApplication validate-gtfs gtfs_validation_gh_config.yaml


### PR DESCRIPTION
[Tested and working in north atlantic](https://replicahq.slack.com/archives/C01EV65JZS6/p1638328039347600?thread_ts=1638218119.332300&cid=C01EV65JZS6)
Reverts the last commit I made where I doubled the incorrect value, and bumps the correct value
FYI @kaelgreco 