### PR TITLE
Use free walking config when starting server

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -30,4 +30,4 @@ CMD java -server -Xms${HEAP_XMS_GB:-6}g -Xmx${HEAP_XMX_GB:-13}g \
   -Djava.rmi.server.hostname=127.0.0.1 \
   -XX:+UseG1GC -XX:MetaspaceSize=100M \
   -classpath grpc/target/graphhopper-grpc-1.0-SNAPSHOT.jar \
-  com.replica.RouterServer default_gh_config.yaml
+  com.replica.RouterServer free_walk_gh_config.yaml


### PR DESCRIPTION
Enables free-walking mode at server start-up time (similar changes to be made on model repo side to ensure consistent use of this config for import/gtfs link mapper builds as well)