### PR TITLE
Ensure stable edge id / edge duration lists are same length

### DIFF
--- a/analyze_functional_test_results.py
+++ b/analyze_functional_test_results.py
@@ -186,6 +186,13 @@ def transit_ratio_mean_percent_change(
     return (1 / matched_count) * sum_of_changes
 
 
+# Check that for each response, stable_edge_ids and edge_durations_millis lists are equal length
+def validate_edge_ids_and_durations(response_set: dict):
+    for r in response_set.values():
+        for p in r["paths"]:
+            assert len(p["stable_edge_ids"]) == len(p["edge_durations_millis"])
+
+
 def run_all_validations(
     golden_response_set: dict, responses_to_validate: dict, is_transit: bool
 ):
@@ -253,6 +260,8 @@ def run_all_validations(
             validation_results["90th_percentile_query_time"]
             <= STREET_90TH_PERCENTILE_QUERY_TIME_THRESHOLD_MS
         )
+        # For street responses, check that stable edge ID + edge durations lists are equal length
+        validate_edge_ids_and_durations(responses_to_validate)
 
 
 if __name__ == "__main__":

--- a/replica-common/src/main/java/com/graphhopper/stableid/StableIdPathDetailsBuilder.java
+++ b/replica-common/src/main/java/com/graphhopper/stableid/StableIdPathDetailsBuilder.java
@@ -21,24 +21,23 @@ package com.graphhopper.stableid;
 import com.graphhopper.routing.ev.EncodedValueLookup;
 import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.util.EdgeIteratorState;
-import com.graphhopper.util.GHUtility;
 import com.graphhopper.util.details.AbstractPathDetailsBuilder;
 
 public class StableIdPathDetailsBuilder extends AbstractPathDetailsBuilder {
     private final StableIdEncodedValues originalDirectionFlagEncoder;
     private int prevEdgeId = -1;
-    private String edgeId;
+    private String currentValue;
 
     public StableIdPathDetailsBuilder(EncodedValueLookup originalDirectionFlagEncoder) {
         super("stable_edge_ids");
         this.originalDirectionFlagEncoder = StableIdEncodedValues.fromEncodingManager((EncodingManager) originalDirectionFlagEncoder);
-        edgeId = "";
+        currentValue = "";
     }
 
     @Override
     public boolean isEdgeDifferentToLastEdge(EdgeIteratorState edge) {
         if (edge.getEdge() != this.prevEdgeId) {
-            edgeId = getStableId(edge);
+            currentValue = getStableId(edge);
             this.prevEdgeId = edge.getEdge();
             return true;
         } else {
@@ -53,6 +52,6 @@ public class StableIdPathDetailsBuilder extends AbstractPathDetailsBuilder {
 
     @Override
     public Object getCurrentValue() {
-        return this.edgeId;
+        return this.currentValue;
     }
 }

--- a/replica-common/src/main/java/com/graphhopper/stableid/StableIdPathDetailsBuilder.java
+++ b/replica-common/src/main/java/com/graphhopper/stableid/StableIdPathDetailsBuilder.java
@@ -21,10 +21,12 @@ package com.graphhopper.stableid;
 import com.graphhopper.routing.ev.EncodedValueLookup;
 import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.util.EdgeIteratorState;
+import com.graphhopper.util.GHUtility;
 import com.graphhopper.util.details.AbstractPathDetailsBuilder;
 
 public class StableIdPathDetailsBuilder extends AbstractPathDetailsBuilder {
     private final StableIdEncodedValues originalDirectionFlagEncoder;
+    private int prevEdgeId = -1;
     private String edgeId;
 
     public StableIdPathDetailsBuilder(EncodedValueLookup originalDirectionFlagEncoder) {
@@ -35,12 +37,13 @@ public class StableIdPathDetailsBuilder extends AbstractPathDetailsBuilder {
 
     @Override
     public boolean isEdgeDifferentToLastEdge(EdgeIteratorState edge) {
-        String newEdgeId = getStableId(edge);
-        if (newEdgeId.equals(edgeId)) {
+        if (edge.getEdge() != this.prevEdgeId) {
+            edgeId = getStableId(edge);
+            this.prevEdgeId = edge.getEdge();
+            return true;
+        } else {
             return false;
         }
-        edgeId = newEdgeId;
-        return true;
     }
 
     private String getStableId(EdgeIteratorState edge) {


### PR DESCRIPTION
Leaving open what _exactly_ may be going on (are beginning/ending "virtual edges" lost because they have the same internal edge number? were "logical" edges without a stable edge id lost if two of them came in direct succession?), we now use the same exact logic for "starting a new value" in either list (time vs. stable-id), so the off-by-one-error should be gone?