### PR TITLE
Publish stamped version of router sandbox image on functional test success

### DIFF
--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -257,3 +257,7 @@ jobs:
         docker pull us.gcr.io/model-159019/gh:${{ github.sha }}-server-dev
         docker tag us.gcr.io/model-159019/gh:${{ github.sha }}-server-dev us.gcr.io/model-159019/gh:${{ steps.compute_new_tag.outputs.tag }}
         docker push us.gcr.io/model-159019/gh:${{ steps.compute_new_tag.outputs.tag }}
+
+        docker pull us.gcr.io/model-159019/gh:${{ github.sha }}-server-sandbox
+        docker tag us.gcr.io/model-159019/gh:${{ github.sha }}-server-sandbox us.gcr.io/model-159019/gh:${{ steps.compute_new_tag.outputs.tag }}-sandbox
+        docker push us.gcr.io/model-159019/gh:${{ steps.compute_new_tag.outputs.tag }}-sandbox


### PR DESCRIPTION
In https://github.com/replicahq/model/pull/6277, it was noted that we've fallen off a bit on using the auto-generated "stamped" router docker image tags generated by CI upon a successful running of the functional test post-merge. We'd like to get back to using that pattern, but I realized that we've recently added the building of a sandbox image into the CI build process, and we don't yet generate an autostamped version of that image that can be referenced in the model repo.

This PR simply duplicates the existing "stamping" step for the sandbox image, tagging it with something of the form `v__-sandbox`

Not tested 🙈 