### PR TITLE
Update GTFS link mapper to use its own unique profile

### DIFF
--- a/configs/test_gh_config.yaml
+++ b/configs/test_gh_config.yaml
@@ -19,6 +19,10 @@ graphhopper:
 
   # Profiles specifying vehicle and weightings for each mode type.
   profiles:
+    - name: gtfs_link_mapper
+      vehicle: car
+      weighting: custom
+      custom_model_file: ./test-data/local_car_custom_model.yaml # mvn tests run from the /web folder
     - name: car_local
       vehicle: car
       weighting: custom

--- a/configs/test_gh_config.yaml
+++ b/configs/test_gh_config.yaml
@@ -42,6 +42,7 @@ graphhopper:
       weighting: fastest
 
   profiles_ch:
+    - profile: gtfs_link_mapper
     - profile: car_local
     - profile: car_freeway
     - profile: bike

--- a/replica-common/src/main/java/com/graphhopper/CustomGraphHopperGtfs.java
+++ b/replica-common/src/main/java/com/graphhopper/CustomGraphHopperGtfs.java
@@ -38,6 +38,9 @@ import java.util.Set;
 public class CustomGraphHopperGtfs extends GraphHopperGtfs {
     private static final Logger LOG = LoggerFactory.getLogger(CustomGraphHopperGtfs.class);
 
+    // Name of profile (+ CH profile) necessary for GTFS link mapper to run properly
+    public static final String GTFS_LINK_MAPPER_PROFILE = "gtfs_link_mapper";
+
     // Tags considered by R5 when calculating the value of the `lanes` column
     private static final Set<String> LANE_TAGS = Sets.newHashSet("lanes", "lanes:forward", "lanes:backward");
     private String osmPath;
@@ -66,7 +69,7 @@ public class CustomGraphHopperGtfs extends GraphHopperGtfs {
         if (ghConfig.getProfiles().stream().noneMatch(p -> p.getName().equals(GTFS_LINK_MAPPER_PROFILE))) {
             throw new RuntimeException("Graphhopper config must include gtfs_link_mapper listed as a profile!");
         }
-        if (ghConfig.getCHProfiles().stream().noneMatch(p -> p.getProfile().equals("gtfs_link_mapper"))) {
+        if (ghConfig.getCHProfiles().stream().noneMatch(p -> p.getProfile().equals(GTFS_LINK_MAPPER_PROFILE))) {
             throw new RuntimeException("Graphhopper config must include gtfs_link_mapper listed as a CH profile!");
         }
     }

--- a/replica-common/src/main/java/com/graphhopper/CustomGraphHopperGtfs.java
+++ b/replica-common/src/main/java/com/graphhopper/CustomGraphHopperGtfs.java
@@ -61,6 +61,14 @@ public class CustomGraphHopperGtfs extends GraphHopperGtfs {
         this.osmIdToLaneTags = Maps.newHashMap();
         this.osmIdToStreetName = Maps.newHashMap();
         this.osmIdToHighwayTag = Maps.newHashMap();
+
+        // Error if gtfs_link_mapper profile wasn't properly included in GH config (link mapper step will fail in this case)
+        if (ghConfig.getProfiles().stream().noneMatch(p -> p.getName().equals(GTFS_LINK_MAPPER_PROFILE))) {
+            throw new RuntimeException("Graphhopper config must include gtfs_link_mapper listed as a profile!");
+        }
+        if (ghConfig.getCHProfiles().stream().noneMatch(p -> p.getProfile().equals("gtfs_link_mapper"))) {
+            throw new RuntimeException("Graphhopper config must include gtfs_link_mapper listed as a CH profile!");
+        }
     }
 
     @Override

--- a/web-bundle/src/main/java/com/graphhopper/http/GraphHopperManaged.java
+++ b/web-bundle/src/main/java/com/graphhopper/http/GraphHopperManaged.java
@@ -50,6 +50,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.graphhopper.util.Helper.UTF_CS;
 
@@ -121,6 +122,13 @@ public class GraphHopperManaged implements Managed {
                 }
         }
         configuration.setProfiles(newProfiles);
+
+        // Error if gtfs_link_mapper profile wasn't included in GH config (link mapper step will fail in this case)
+        if (newProfiles.stream()
+                .filter(p -> p.getName().equals("gtfs_link_mapper"))
+                .collect(Collectors.toSet()).size() == 0) {
+            throw new RuntimeException("Graphhopper config must include gtfs_link_mapper profile!");
+        }
 
         graphHopper.setFlagEncoderFactory(new FlagEncoderFactory() {
             private FlagEncoderFactory delegate = new DefaultFlagEncoderFactory();

--- a/web-bundle/src/main/java/com/graphhopper/http/GraphHopperManaged.java
+++ b/web-bundle/src/main/java/com/graphhopper/http/GraphHopperManaged.java
@@ -50,7 +50,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static com.graphhopper.util.Helper.UTF_CS;
 
@@ -122,15 +121,6 @@ public class GraphHopperManaged implements Managed {
                 }
         }
         configuration.setProfiles(newProfiles);
-
-        // Error if gtfs_link_mapper profile wasn't included in GH config (link mapper step will fail in this case)
-        if (configuration.has("gtfs.file")) {
-            if (newProfiles.stream()
-                    .filter(p -> p.getName().equals("gtfs_link_mapper"))
-                    .collect(Collectors.toSet()).size() == 0) {
-                throw new RuntimeException("Graphhopper config must include gtfs_link_mapper profile!");
-            }
-        }
 
         graphHopper.setFlagEncoderFactory(new FlagEncoderFactory() {
             private FlagEncoderFactory delegate = new DefaultFlagEncoderFactory();

--- a/web-bundle/src/main/java/com/graphhopper/http/GraphHopperManaged.java
+++ b/web-bundle/src/main/java/com/graphhopper/http/GraphHopperManaged.java
@@ -124,10 +124,12 @@ public class GraphHopperManaged implements Managed {
         configuration.setProfiles(newProfiles);
 
         // Error if gtfs_link_mapper profile wasn't included in GH config (link mapper step will fail in this case)
-        if (newProfiles.stream()
-                .filter(p -> p.getName().equals("gtfs_link_mapper"))
-                .collect(Collectors.toSet()).size() == 0) {
-            throw new RuntimeException("Graphhopper config must include gtfs_link_mapper profile!");
+        if (configuration.has("gtfs.file")) {
+            if (newProfiles.stream()
+                    .filter(p -> p.getName().equals("gtfs_link_mapper"))
+                    .collect(Collectors.toSet()).size() == 0) {
+                throw new RuntimeException("Graphhopper config must include gtfs_link_mapper profile!");
+            }
         }
 
         graphHopper.setFlagEncoderFactory(new FlagEncoderFactory() {

--- a/web-bundle/src/main/java/com/graphhopper/replica/GtfsLinkMapper.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/GtfsLinkMapper.java
@@ -116,7 +116,7 @@ public class GtfsLinkMapper {
                         stop.stop_lat, stop.stop_lon,
                         nextStop.stop_lat, nextStop.stop_lon
                 );
-                odRequest.setProfile("car_local");
+                odRequest.setProfile("gtfs_link_mapper");
                 odRequest.setPathDetails(Lists.newArrayList("stable_edge_ids"));
                 GHResponse response = graphHopper.route(odRequest);
 

--- a/web-bundle/src/main/java/com/graphhopper/replica/GtfsLinkMapper.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/GtfsLinkMapper.java
@@ -3,8 +3,8 @@ package com.graphhopper.replica;
 import com.conveyal.gtfs.GTFSFeed;
 import com.conveyal.gtfs.model.Route;
 import com.conveyal.gtfs.model.Stop;
-import com.conveyal.gtfs.model.StopTime;
 import com.google.common.collect.*;
+import com.graphhopper.CustomGraphHopperGtfs;
 import com.graphhopper.GHRequest;
 import com.graphhopper.GHResponse;
 import com.graphhopper.GraphHopper;
@@ -116,7 +116,7 @@ public class GtfsLinkMapper {
                         stop.stop_lat, stop.stop_lon,
                         nextStop.stop_lat, nextStop.stop_lon
                 );
-                odRequest.setProfile("gtfs_link_mapper");
+                odRequest.setProfile(CustomGraphHopperGtfs.GTFS_LINK_MAPPER_PROFILE);
                 odRequest.setPathDetails(Lists.newArrayList("stable_edge_ids"));
                 GHResponse response = graphHopper.route(odRequest);
 


### PR DESCRIPTION
Traditionally, the GTFS link mapper has been hardcoded to use a specific car routing mode internally - originally, it was just `car`, but was updated to `car_local` after the recent batch of custom profile changes were merged.

However, with https://replicahq.atlassian.net/browse/RAD-5578 meaning we're now handing over the power to create/change profiles at will to users in the model repo, we're no longer guaranteed that these specific car profiles will actually get included in the graphhopper configs used to build/run routers. This means that in cases where, say, `car_local` isn't included, the link mapper would fail to find any routes, which is bad.

---

The solution implemented here is to simply choose a special profile name, `gtfs_link_mapper`, that the link mapper is still hardcoded to expect, but is much clearer to other users how the profile is intended to be used (/why it's required). I also added a few clauses in `GraphHopperManaged` that check that the profile exists in cases where the GH profile includes GTFS (and therefore we'd expect the link mapper to run), and throws a runtime error if it does not.

I think this, plus some clear comments in the GH configs in the model repo / our notion docs about this special profile, should be enough guardrails for users to ensure the correct pattern is followed.

---

Didn't _really_ test this, but the unit tests pass after I updated `test_gh_config` accordingly, and I did accidentally test the clause I added when I pushed 094e72a without having defined `gtfs_link_mapper` as a contraction hierarchy profile.