### PR TITLE
RAD-5694 Return profile which created StreetPath to clients

### DIFF
--- a/grpc/src/main/java/com/replica/RouterImpl.java
+++ b/grpc/src/main/java/com/replica/RouterImpl.java
@@ -103,7 +103,7 @@ public class RouterImpl extends router.RouterGrpc.RouterImplBase {
                 if (!ghResponse.hasErrors()) {
                     anyPathsFound = true;
                     ghResponse.getAll().stream()
-                            .map(RouterConverters::toStreetPath)
+                            .map(responsePath -> RouterConverters.toStreetPath(responsePath, profile))
                             .forEach(replyBuilder::addPaths);
                 }
             } catch (Exception e) {
@@ -180,7 +180,7 @@ public class RouterImpl extends router.RouterGrpc.RouterImplBase {
             } else {
                 StreetRouteReply.Builder replyBuilder = StreetRouteReply.newBuilder();
                 ghResponse.getAll().stream()
-                        .map(RouterConverters::toStreetPath)
+                        .map(responsePath -> RouterConverters.toStreetPath(responsePath, request.getProfile()))
                         .forEach(replyBuilder::addPaths);
 
                 double durationSeconds = (System.currentTimeMillis() - startTime) / 1000.0;

--- a/grpc/src/main/java/com/replica/util/RouterConverters.java
+++ b/grpc/src/main/java/com/replica/util/RouterConverters.java
@@ -241,7 +241,7 @@ public final class RouterConverters {
         return ghPtRequest;
     }
 
-    public static StreetPath toStreetPath(ResponsePath responsePath) {
+    public static StreetPath toStreetPath(ResponsePath responsePath, String profile) {
         List<String> pathStableEdgeIds = responsePath.getPathDetails().get("stable_edge_ids").stream()
                 .map(pathDetail -> (String) pathDetail.getValue())
                 .collect(Collectors.toList());
@@ -256,6 +256,7 @@ public final class RouterConverters {
                 .addAllStableEdgeIds(pathStableEdgeIds)
                 .addAllEdgeDurationsMillis(edgeTimes)
                 .setPoints(responsePath.getPoints().toLineString(false).toString())
+                .setProfile(profile)
                 .build();
     }
 


### PR DESCRIPTION
https://replicahq.atlassian.net/browse/RAD-5694

Picks up the proto change from https://github.com/replicahq/idls/pull/107 and updates the server to return the profile which created each `StreetPath`.  

This PR also updates `RouterServerTest` to check the returned profiles and validate that the number of paths for each profile matches expectations. The test is now a little more thorough than it was before - for instance, when alternate routes are requested, we now ensure that each profile produces alternates rather than simply checking that more than one `ResponsePath` is returned.

