### PR TITLE
Update GH actions to fix CI workflow

### DIFF
--- a/.github/workflows/build_gtfs_validator.yaml
+++ b/.github/workflows/build_gtfs_validator.yaml
@@ -10,13 +10,20 @@ jobs:
       - name: Code Checkout
         uses: actions/checkout@v2
 
+      - name: Auth GCP
+        id: 'auth'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: '${{ secrets.GOOGLE_CREDENTIALS }}'
+          create_credentials_file: true
+
       - name: Login to GCP
         # Setup gcloud CLI
-        uses: google-github-actions/setup-gcloud@v0.2.0
+        uses: google-github-actions/setup-gcloud@v1
         with:
           project_id: ${{ env.PROJECT_ID }}
           service_account_key: ${{ secrets.GOOGLE_CREDENTIALS }}
-          version: "297.0.1" # Fix https://github.com/google-github-actions/setup-gcloud/issues/128
+          version: "410.0.0"
 
       - name: Download USA OSM cutout and build GTFS validator image
         run: |-

--- a/.github/workflows/build_test_push.yaml
+++ b/.github/workflows/build_test_push.yaml
@@ -21,6 +21,13 @@ jobs:
         run: |
           mkdir -p /home/runner/.ssh && touch /home/runner/.ssh/id_rsa && echo "$SSH_KEY_FOR_SUBMODULE" > $HOME/.ssh/id_rsa && chmod 600 $HOME/.ssh/id_rsa &&  git submodule sync && git submodule --quiet update --init && echo `git rev-parse --short=8 HEAD ` > TAG.txt
 
+      - name: Auth GCP
+        id: 'auth'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: '${{ secrets.GOOGLE_CREDENTIALS }}'
+          create_credentials_file: true
+
       - name: Login to GCP
         # Setup gcloud CLI
         uses: google-github-actions/setup-gcloud@v1
@@ -37,7 +44,6 @@ jobs:
 
       - run: |-
           echo "GOOGLE_CREDENTIALS_FILE=$(basename $GOOGLE_APPLICATION_CREDENTIALS)" >> $GITHUB_ENV
-
 
       - name: Login to GCR
         uses: docker/login-action@v1

--- a/.github/workflows/build_test_push.yaml
+++ b/.github/workflows/build_test_push.yaml
@@ -23,11 +23,11 @@ jobs:
 
       - name: Login to GCP
         # Setup gcloud CLI
-        uses: google-github-actions/setup-gcloud@v0.2.0
+        uses: google-github-actions/setup-gcloud@v1
         with:
           project_id: ${{ env.PROJECT_ID }}
           service_account_key: ${{ secrets.GOOGLE_CREDENTIALS }}
-          version: "297.0.1" # Fix https://github.com/google-github-actions/setup-gcloud/issues/128
+          version: "410.0.0" # Fix https://github.com/google-github-actions/setup-gcloud/issues/128
           export_default_credentials: true
 
       # Configure Docker to use the gcloud command-line tool as a credential

--- a/.github/workflows/build_test_push.yaml
+++ b/.github/workflows/build_test_push.yaml
@@ -35,7 +35,6 @@ jobs:
           project_id: ${{ env.PROJECT_ID }}
           service_account_key: ${{ secrets.GOOGLE_CREDENTIALS }}
           version: "410.0.0" # Fix https://github.com/google-github-actions/setup-gcloud/issues/128
-          export_default_credentials: true
 
       # Configure Docker to use the gcloud command-line tool as a credential
       # helper for authentication

--- a/.github/workflows/build_test_push.yaml
+++ b/.github/workflows/build_test_push.yaml
@@ -34,8 +34,8 @@ jobs:
         with:
           project_id: ${{ env.PROJECT_ID }}
           service_account_key: ${{ secrets.GOOGLE_CREDENTIALS }}
-          version: "410.0.0" # Fix https://github.com/google-github-actions/setup-gcloud/issues/128
-
+          version: "410.0.0"
+      
       # Configure Docker to use the gcloud command-line tool as a credential
       # helper for authentication
       - run: |-

--- a/.github/workflows/build_test_push.yaml
+++ b/.github/workflows/build_test_push.yaml
@@ -38,6 +38,7 @@ jobs:
       - run: |-
           echo "GOOGLE_CREDENTIALS_FILE=$(basename $GOOGLE_APPLICATION_CREDENTIALS)" >> $GITHUB_ENV
 
+
       - name: Login to GCR
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -42,14 +42,20 @@ jobs:
         run: |
           mkdir -p /home/runner/.ssh && touch /home/runner/.ssh/id_rsa && echo "$SSH_KEY_FOR_SUBMODULE" > $HOME/.ssh/id_rsa && chmod 600 $HOME/.ssh/id_rsa &&  git submodule sync && git submodule --quiet update --init && echo `git rev-parse --short=8 HEAD ` > TAG.txt
 
+      - name: Auth GCP
+        id: 'auth'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: '${{ secrets.GOOGLE_CREDENTIALS }}'
+          create_credentials_file: true
+
       - name: Login to GCP
         # Setup gcloud CLI
-        uses: google-github-actions/setup-gcloud@v0.2.0
+        uses: google-github-actions/setup-gcloud@v1
         with:
           project_id: ${{ env.PROJECT_ID }}
           service_account_key: ${{ secrets.GOOGLE_CREDENTIALS }}
-          version: "297.0.1" # Fix https://github.com/google-github-actions/setup-gcloud/issues/128
-          export_default_credentials: true
+          version: "410.0.0"
 
       # Configure Docker to use the gcloud command-line tool as a credential
       # helper for authentication

--- a/.github/workflows/generate-golden-response-set.yaml
+++ b/.github/workflows/generate-golden-response-set.yaml
@@ -19,14 +19,20 @@ jobs:
         run: |
           mkdir -p /home/runner/.ssh && touch /home/runner/.ssh/id_rsa && echo "$SSH_KEY_FOR_SUBMODULE" > $HOME/.ssh/id_rsa && chmod 600 $HOME/.ssh/id_rsa &&  git submodule sync && git submodule --quiet update --init && echo `git rev-parse --short=8 HEAD ` > TAG.txt
 
+      - name: Auth GCP
+        id: 'auth'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: '${{ secrets.GOOGLE_CREDENTIALS }}'
+          create_credentials_file: true
+
       - name: Login to GCP
         # Setup gcloud CLI
-        uses: google-github-actions/setup-gcloud@v0.2.0
+        uses: google-github-actions/setup-gcloud@v1
         with:
           project_id: ${{ env.PROJECT_ID }}
           service_account_key: ${{ secrets.GOOGLE_CREDENTIALS }}
-          version: "297.0.1" # Fix https://github.com/google-github-actions/setup-gcloud/issues/128
-          export_default_credentials: true
+          version: "410.0.0"
 
       # Configure Docker to use the gcloud command-line tool as a credential
       # helper for authentication


### PR DESCRIPTION
It seems as though a few of the GH action versions we're using have broken in the background (haven't tracked down the error 100%); I replicated the error in my first commit here, where I added a `/n` to test the CI.

I fixed that error by bumping the version of the `setup-gcloud` action, but then that broke something else: the older version would automatically write out a file containing google creds and set an env var `$GOOGLE_APPLICATION_CREDENTIALS`, but the new version doesn't. Now, that functionality is done by a separate GH action called `auth`. Adding that in before `setup-gcloud` fixed things 🚀 

I've only tested the main unit test CI + functional test flows, but made the updates in the other workflows as well. The `auth` step might (?) be overkill for some of the flows, but it doesn't seem harmful to include it (I'm kinda rushing due to LIRR as well :D )