### PR TITLE
Add support for new small_truck vehicle

### DIFF
--- a/configs/custom_weight_gh_config.yaml
+++ b/configs/custom_weight_gh_config.yaml
@@ -6,7 +6,7 @@ graphhopper:
   graph.location: transit_data/graphhopper
   routing.ch.disabling_allowed: true
   routing.max_visited_nodes: 1500000
-  graph.flag_encoders: car,bike,foot,truck
+  graph.flag_encoders: car,bike,foot,truck,small_truck
 
   # Profiles specifying vehicle and weightings for each mode type.
   profiles:

--- a/configs/custom_weight_gh_config.yaml
+++ b/configs/custom_weight_gh_config.yaml
@@ -26,6 +26,10 @@ graphhopper:
       vehicle: truck
       weighting: custom
       custom_model_file: empty
+    - name: small_truck
+      vehicle: small_truck
+      weighting: custom
+      custom_model_file: empty
 
 server:
   min_threads: 4

--- a/configs/nationwide_gh_config.yaml
+++ b/configs/nationwide_gh_config.yaml
@@ -6,7 +6,7 @@ graphhopper:
   graph.location: transit_data/graphhopper
   routing.ch.disabling_allowed: true
   routing.max_visited_nodes: 1500000
-  graph.flag_encoders: car,bike,foot,truck
+  graph.flag_encoders: car,bike,foot,truck,small_truck
   prepare.ch.threads: 16
 
   # Profiles specifying vehicle and weightings for each mode type.

--- a/configs/nationwide_gh_config.yaml
+++ b/configs/nationwide_gh_config.yaml
@@ -24,6 +24,9 @@ graphhopper:
     - name: truck
       vehicle: truck
       weighting: fastest
+    - name: small_truck
+      vehicle: small_truck
+      weighting: fastest
 
 server:
   min_threads: 4

--- a/configs/run_local_server_gh_config.yaml
+++ b/configs/run_local_server_gh_config.yaml
@@ -8,7 +8,7 @@ graphhopper:
   graph.location: transit_data/graphhopper
   routing.ch.disabling_allowed: true
   routing.max_visited_nodes: 1500000
-  graph.flag_encoders: car,bike,foot,truck
+  graph.flag_encoders: car,bike,foot,truck,small_truck
   graph.encoded_values: road_class,road_class_link
   prepare.ch.threads: 16
 
@@ -40,6 +40,9 @@ graphhopper:
     - name: truck
       vehicle: truck
       weighting: fastest
+    - name: small_truck
+      vehicle: small_truck
+      weighting: fastest
 
   profiles_ch:
     - profile: gtfs_link_mapper
@@ -48,6 +51,7 @@ graphhopper:
     - profile: bike
     - profile: foot
     - profile: truck
+    - profile: small_truck
 
 server:
   min_threads: 4

--- a/configs/test_export_gh_config.yaml
+++ b/configs/test_export_gh_config.yaml
@@ -6,7 +6,7 @@ graphhopper:
   graph.location: transit_data/export_test/graphhopper
   routing.ch.disabling_allowed: true
   routing.max_visited_nodes: 1500000
-  graph.flag_encoders: car,bike,foot,truck
+  graph.flag_encoders: car,bike,foot,truck,small_truck
   prepare.ch.threads: 16
 
   # Profiles specifying vehicle and weightings for each mode type.

--- a/configs/test_export_gh_config.yaml
+++ b/configs/test_export_gh_config.yaml
@@ -24,6 +24,9 @@ graphhopper:
     - name: truck
       vehicle: truck
       weighting: fastest
+    - name: small_truck
+      vehicle: small_truck
+      weighting: fastest
 
 server:
   min_threads: 4

--- a/configs/test_gh_config.yaml
+++ b/configs/test_gh_config.yaml
@@ -40,6 +40,9 @@ graphhopper:
     - name: truck
       vehicle: truck
       weighting: fastest
+    - name: small_truck
+      vehicle: small_truck
+      weighting: fastest
 
   profiles_ch:
     - profile: gtfs_link_mapper
@@ -48,6 +51,7 @@ graphhopper:
     - profile: bike
     - profile: foot
     - profile: truck
+    - profile: small_truck
 
 server:
   min_threads: 4

--- a/configs/test_gh_config.yaml
+++ b/configs/test_gh_config.yaml
@@ -2,13 +2,13 @@
 # 1 profile loaded with default speeds is defined for each vehicle type
 
 graphhopper:
-  datareader.file: {{ TEST_OSM }}
-  gtfs.file: {{ TEST_GTFS }}
+  datareader.file: ./test-data/micro_nor_cal.osm.pbf
+  gtfs.file: ./test-data/gtfs/f-9qc-fairfield~ca~us.zip,./test-data/gtfs/rosevill.zip,./test-data/gtfs/srtd.zip,./test-data/gtfs/vacaville.zip
   gtfs.max_transfer_interpolation_walk_time_seconds: 300
   graph.location: transit_data/graphhopper
   routing.ch.disabling_allowed: true
   routing.max_visited_nodes: 1500000
-  graph.flag_encoders: car,bike,foot,truck
+  graph.flag_encoders: car,bike,foot,truck,small_truck
   graph.encoded_values: road_class,road_class_link
   prepare.ch.threads: 16
 

--- a/configs/test_gh_config.yaml
+++ b/configs/test_gh_config.yaml
@@ -2,8 +2,8 @@
 # 1 profile loaded with default speeds is defined for each vehicle type
 
 graphhopper:
-  datareader.file: ./test-data/micro_nor_cal.osm.pbf
-  gtfs.file: ./test-data/gtfs/f-9qc-fairfield~ca~us.zip,./test-data/gtfs/rosevill.zip,./test-data/gtfs/srtd.zip,./test-data/gtfs/vacaville.zip
+  datareader.file: {{ TEST_OSM }}
+  gtfs.file: {{ TEST_GTFS }}
   gtfs.max_transfer_interpolation_walk_time_seconds: 300
   graph.location: transit_data/graphhopper
   routing.ch.disabling_allowed: true

--- a/grpc/src/main/resources/assets/js/main-template.js
+++ b/grpc/src/main/resources/assets/js/main-template.js
@@ -361,11 +361,11 @@ $(document).ready(function (e) {
            }
 
 
-           var profiles = ["car", "foot", "bike", "truck"];
+           var profiles = ["car", "foot", "bike", "truck", "small_truck"];
            ghRequest.profiles = profiles;
            var showAllProfiles = true;
 
-           var numVehiclesWhenCollapsed = 4;
+           var numVehiclesWhenCollapsed = 5;
            var hiddenVehicles = [];
            for (var i = 0; i < profiles.length; ++i) {
                var btn = createButton(profiles[i], !showAllProfiles && i >= numVehiclesWhenCollapsed);

--- a/web-bundle/src/main/java/com/graphhopper/http/GraphHopperManaged.java
+++ b/web-bundle/src/main/java/com/graphhopper/http/GraphHopperManaged.java
@@ -131,6 +131,8 @@ public class GraphHopperManaged implements Managed {
                     return new CustomCarFlagEncoder(configuration, name);
                 } else if (name.equals("truck")) {
                     return TruckFlagEncoder.createTruck(configuration, "truck");
+                } else if (name.equals("small_truck")) {
+                    return TruckFlagEncoder.createSmallTruck(configuration, "small_truck");
                 } else {
                     return delegate.createFlagEncoder(name, configuration);
                 }


### PR DESCRIPTION
Adds support for the `small_truck` vehicle type, which we'd like to add to fix issues with our current "normal large truck" routing mode not allowing vehicles over certain important bridges [[thread](https://replicahq.slack.com/archives/C027YNRDV6Y/p1669832211379369)].

The main fix is just a few lines in `GraphHopperManaged`, but just to be safe, I also added the new vehicle type to a few of the fixed configs we store in this repo. I also updated the GUI to include a new button for routing with small_truck mode

### Testing

Built a router locally + tested the new mode via the GUI. There's a difference in routes returned for our standard truck mode vs. the new `small_truck` mode:

<img width="1158" alt="Screen Shot 2022-12-06 at 1 11 31 PM" src="https://user-images.githubusercontent.com/13446427/206023822-a265e2df-74ed-46e0-b39e-2bd362617f6b.png">


<img width="1214" alt="Screen Shot 2022-12-06 at 1 10 58 PM" src="https://user-images.githubusercontent.com/13446427/206023732-45a48ac4-41b2-46b2-83a2-83867463c72c.png">

### cc
@bnaul 
