### PR TITLE
Move from datadog distribution to histogram metric type

### DIFF
--- a/grpc/src/main/java/com/replica/util/MetricUtils.java
+++ b/grpc/src/main/java/com/replica/util/MetricUtils.java
@@ -15,7 +15,7 @@ public final class MetricUtils {
     public static void sendDatadogStats(StatsDClient statsDClient, String[] tags, double durationSeconds) {
         if (statsDClient != null) {
             statsDClient.incrementCounter("routers.num_requests", tags);
-            statsDClient.distribution("routers.request_seconds", durationSeconds, tags);
+            statsDClient.histogram("routers.request_seconds", durationSeconds, tags);
         }
     }
 


### PR DESCRIPTION
We recently made a move from using Datadog's distribution metric type to the histogram type in the model repo (see https://github.com/replicahq/model/pull/6369 and https://github.com/replicahq/model/pull/6425). I held off on transitioning the router-side metrics code to histograms until fully understanding their benefits/drawbacks, but after recent investigations I think we've settled on switching everything over to histogram, at least for the time being (with some known drawbacks that will be communicated more widely soon).

As I've been testing the new core update with real runs, I've [made this change](https://github.com/replicahq/graphhopper/pull/112/commits/cd78ed0ade9fccf5f1e528510bd2cfc23c2e3d95) in our core update branch, but it would be good to get it into "master" so I can get an even comparison of core updated vs. non-core updated performance.

cc @epotex @hardisty 