### PR TITLE
Measure time spent interacting with MapDB maps

### DIFF
--- a/grpc/src/main/java/com/replica/RouterImpl.java
+++ b/grpc/src/main/java/com/replica/RouterImpl.java
@@ -331,10 +331,10 @@ public class RouterImpl extends router.RouterGrpc.RouterImplBase {
                 long startTime = System.currentTimeMillis();
                 CustomPtLeg customPtLeg = RouterConverters.toCustomPtLeg(thisLeg, gtfsFeedIdMapping, gtfsLinkMappings, gtfsRouteInfo);
                 double durationSeconds = (System.currentTimeMillis() - startTime) / 1000.0;
+                String[] tags = MetricUtils.applyCustomTags(new String[0], customTags);
                 if (statsDClient != null) {
-                    statsDClient.histogram("routers.to_custom_pt_leg_seconds", durationSeconds);
+                    statsDClient.histogram("routers.to_custom_pt_leg_seconds", durationSeconds, tags);
                 }
-                logger.info("routers.to_custom_pt_leg_seconds: " + durationSeconds);
 
                 path.getLegs().add(customPtLeg);
             }

--- a/grpc/src/main/java/com/replica/RouterImpl.java
+++ b/grpc/src/main/java/com/replica/RouterImpl.java
@@ -327,8 +327,16 @@ public class RouterImpl extends router.RouterGrpc.RouterImplBase {
                 path.getLegs().add(RouterConverters.toCustomWalkLeg(thisLeg, travelSegmentType));
             } else if (leg instanceof Trip.PtLeg) {
                 Trip.PtLeg thisLeg = (Trip.PtLeg) leg;
-                path.getLegs().add(
-                        RouterConverters.toCustomPtLeg(thisLeg, gtfsFeedIdMapping, gtfsLinkMappings, gtfsRouteInfo));
+
+                long startTime = System.currentTimeMillis();
+                CustomPtLeg customPtLeg = RouterConverters.toCustomPtLeg(thisLeg, gtfsFeedIdMapping, gtfsLinkMappings, gtfsRouteInfo);
+                double durationSeconds = (System.currentTimeMillis() - startTime) / 1000.0;
+                if (statsDClient != null) {
+                    statsDClient.histogram("routers.to_custom_pt_leg_seconds", durationSeconds);
+                }
+                logger.info("routers.to_custom_pt_leg_seconds: " + durationSeconds);
+
+                path.getLegs().add(customPtLeg);
             }
         }
 


### PR DESCRIPTION
During discussion with @michaz today, it was discovered that the PT requests in particular seem to suffer from low CPU util (see https://replicahq.slack.com/archives/CK358RL0Z/p1671722270605119 and the several subsequent messages). One theory as to why PT has low util is due to its usage of several gtfs-related, MapDB-backed hashmaps. Perhaps the low util is caused by a good amount of I/O wait time when interacting with these maps.

Michael gave us some ideas for how to speed up these MapDB interactions, but I wanted to start by just measuring the time we spend interacting with MapDB maps to see how big an issue it is. The only spot we use these maps is within `RouterConverters.toCustomPtLeg`, and the method doesn't appear to do anything potentially expensive besides the various interactions with the maps, so I added some timing around the entire call to `toCustomPtLeg`.