### PR TITLE
Skip functional test response comparisons when PT ratio == 0

### DIFF
--- a/analyze_functional_test_results.py
+++ b/analyze_functional_test_results.py
@@ -179,6 +179,16 @@ def transit_ratio_mean_percent_change(
             matched_count += 1
             golden_ratio = calculate_transit_ratio(golden_response)
             to_compare_ratio = calculate_transit_ratio(to_compare)
+
+            # In some cases, transit paths contain stop-stop sections where stops
+            # are very closely spaced, and arrival/departure times for those stops
+            # are equal; in these cases, transit ratios will be 0, which cause issues
+            # in the calculations below. So, we skip these cases when they're identified.
+            if golden_ratio == 0:
+                assert to_compare_ratio == 0
+                matched_count -= 1  # consider these responses as "not matched"
+                continue
+
             if absolute:
                 sum_of_changes += abs((to_compare_ratio - golden_ratio) / golden_ratio)
             else:


### PR DESCRIPTION
I found a funny edge case in the part of our functional test that compares a "golden response set" to a new set of responses generated during the functional test, that this change is meant to address.

The setup:
- Some transit requests contain transit legs where two stops are very close together, and therefore the departure time recorded from one stop is equal to the arrival time recorded for the next stop (this situation isn't new, and has occurred with older versions of our code as well)
- The above situation happens, but with a transit response where the PT leg is very short - only 2 stops
- This means that the total travel time for the PT legs on that trip is calculated as 0 in the `calculate_transit_ratio()` method of the functional test analysis script, resulting in a divide by zero error when the analysis script runs ([eg](https://github.com/replicahq/graphhopper/actions/runs/3998899430/jobs/6862260437))

The proposed fix here:
- If we identify this situation, we assert that the route we're comparing to in this case also exhibits similar behavior (ie, the two routes "match")
- Then, we simply skip including this pair of routes in the overall metric being calculated here, to avoid the division by zero