### PR TITLE
Correct path to config used in GTFS validator

### DIFF
--- a/run_gtfs_validation.sh
+++ b/run_gtfs_validation.sh
@@ -5,4 +5,4 @@ set -o errexit
 export GTFS_FILE_LIST=$(ls ./gtfs/ | awk '{print "./gtfs/"$1}' | paste -s -d, -)
 java -Xmx58g -Ddw.graphhopper.gtfs.file=$GTFS_FILE_LIST \
   -Ddw.graphhopper.validation=true -classpath web/target/graphhopper-web-1.0-SNAPSHOT.jar \
-  com.graphhopper.http.GraphHopperApplication validate-gtfs gtfs_validation_gh_config.yaml
+  com.graphhopper.http.GraphHopperApplication validate-gtfs ./configs/gtfs_validation_gh_config.yaml


### PR DESCRIPTION
https://replicahq.slack.com/archives/C03T2S7TN85/p1675984033213399?thread_ts=1675981620.431949&cid=C03T2S7TN85

The configs live in `./configs` now...oops