### PR TITLE
Fix stable edge ID list formation in walk legs of transit responses

### DIFF
--- a/grpc/src/main/java/com/replica/RouterImpl.java
+++ b/grpc/src/main/java/com/replica/RouterImpl.java
@@ -364,6 +364,7 @@ public class RouterImpl extends router.RouterGrpc.RouterImplBase {
             }
         }
 
+        // TODO: can we remove this clause? Or does the duplicate ID issue still exist for access/egress legs?
         if (accessExists && egressExists) {
             // ACCESS legs contains stable IDs for both ACCESS and EGRESS legs for some reason,
             // so we remove the EGRESS leg IDs from the ACCESS leg before storing the path

--- a/grpc/src/main/java/com/replica/util/RouterConverters.java
+++ b/grpc/src/main/java/com/replica/util/RouterConverters.java
@@ -262,7 +262,6 @@ public final class RouterConverters {
     private static List<String> fetchWalkLegStableIds(Trip.WalkLeg leg) {
         return leg.details.get("stable_edge_ids").stream()
                 .map(idPathDetail -> (String) idPathDetail.getValue())
-                .filter(id -> id.length() == 20)
                 .collect(toList());
     }
 

--- a/grpc/src/main/java/com/replica/util/RouterConverters.java
+++ b/grpc/src/main/java/com/replica/util/RouterConverters.java
@@ -262,6 +262,7 @@ public final class RouterConverters {
     private static List<String> fetchWalkLegStableIds(Trip.WalkLeg leg) {
         return leg.details.get("stable_edge_ids").stream()
                 .map(idPathDetail -> (String) idPathDetail.getValue())
+                .filter(id -> id.length() == 20)
                 .collect(toList());
     }
 

--- a/web/src/test/java/com/replica/RouterServerTest.java
+++ b/web/src/test/java/com/replica/RouterServerTest.java
@@ -232,6 +232,12 @@ public class RouterServerTest extends ReplicaGraphHopperTest {
             assertFalse(stop.getStopName().isEmpty());
             assertTrue(stop.hasPoint());
         }
+
+        // Check number of stable edge IDs for each leg is as-expected
+        List<Integer> expectedStableEdgeIdCount = Lists.newArrayList(8, 201, 3, 184, 15);
+        for (int i = 0; i < path.getLegsList().size(); i++) {
+            assertEquals(expectedStableEdgeIdCount.get(i), path.getLegsList().get(i).getStableEdgeIdsCount());
+        }
     }
 
     @Test
@@ -291,6 +297,12 @@ public class RouterServerTest extends ReplicaGraphHopperTest {
             assertEquals(1, TEST_GTFS_FILE_NAMES.stream().filter(f -> stop.getStopId().startsWith(f)).count());
             assertFalse(stop.getStopName().isEmpty());
             assertTrue(stop.hasPoint());
+        }
+
+        // Check number of stable edge IDs for each leg is as-expected
+        List<Integer> expectedStableEdgeIdCount = Lists.newArrayList(19, 59, 3, 164, 15);
+        for (int i = 0; i < path.getLegsList().size(); i++) {
+            assertEquals(expectedStableEdgeIdCount.get(i), path.getLegsList().get(i).getStableEdgeIdsCount());
         }
     }
 


### PR DESCRIPTION
While working on new schemes for stable edge IDs, I came across an unrelated bug in the code that forms transit responses in our GRPC server code. Specifically, an old clause from > a year ago is filtering out any stable edge IDs in walking legs of transit responses where the ID length isn't exactly 20.

I can't remember why this clause was ever included (seems like it was added [here](https://github.com/replicahq/graphhopper/commit/a16abda2e371ddb3ce70133298cd5a52b57040ce#diff-267115fa81fbfa77f290254a70b8013854fd1262c25bd622f67a125eea452982R141-R151) when we first set up the GRPC server code, thanks for finding this Bryan!), and it logically isn't right at face value - when checking our existing stable edge IDs (without any of the new ID changes, just w/ the core-updated router):
```
SELECT stableEdgeId
FROM street_export.street_export_usa_2022_Q4_734428cf12ae7c690634d7e8fb726643e988b35a
WHERE LENGTH(stableEdgeId) != 20
```
We get 115073679 results, which is ~54% of all stable edge IDs. This means our filter was removing quite a lot of potential IDs from these legs of transit responses.

I also added new unit tests to ensure "stability" in the number of IDs returned for test queries over time - not pretty, but gives us some guidepost moving forward. I tested that the unit test "made sense" by adding back the filter clause - this causes the test the fail, as expected (some IDs are filtered out vs. without the clause).