### PR TITLE
Update name + ref tag usage for street names in network link export

### DIFF
--- a/replica-common/src/main/java/com/graphhopper/CustomGraphHopperGtfs.java
+++ b/replica-common/src/main/java/com/graphhopper/CustomGraphHopperGtfs.java
@@ -191,6 +191,7 @@ public class CustomGraphHopperGtfs extends GraphHopperGtfs {
     }
 
     // todo: can we move this logic into CustomOsmReader?
+    // todo: not all of the info we parse here is relevant for the server - can we stop parsing it here?
     public void collectOsmInfo() {
         LOG.info("Creating custom OSM reader; reading file and parsing lane tag and street name info.");
         List<ReaderRelation> roadRelations = Lists.newArrayList();

--- a/replica-common/src/main/java/com/graphhopper/CustomGraphHopperGtfs.java
+++ b/replica-common/src/main/java/com/graphhopper/CustomGraphHopperGtfs.java
@@ -27,6 +27,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static com.graphhopper.OsmHelper.getConcatNameFromOsmElement;
+import static com.graphhopper.OsmHelper.getHighwayFromOsmWay;
 import static com.graphhopper.util.GHUtility.readCountries;
 import static com.graphhopper.util.Helper.createFormatter;
 import static com.graphhopper.util.Helper.isEmpty;
@@ -262,26 +264,6 @@ public class CustomGraphHopperGtfs extends GraphHopperGtfs {
         } catch (Exception e) {
             throw new RuntimeException("Can't open OSM file provided at " + osmPath + "!");
         }
-    }
-
-    private static String getHighwayFromOsmWay(ReaderWay way) {
-        if (way.hasTag("highway")) {
-            return way.getTag("highway");
-        } else {
-            return null;
-        }
-    }
-
-    // if only `name` or only `ref` tag exist, return that. if both exist, return "<ref>, <name>". else, return null
-    private static String getConcatNameFromOsmElement(ReaderElement wayOrRelation) {
-        String name = null;
-        if (wayOrRelation.hasTag("name")) {
-            name = wayOrRelation.getTag("name");
-        }
-        if (wayOrRelation.hasTag("ref")) {
-            name = name == null ? wayOrRelation.getTag("ref") : wayOrRelation.getTag("ref") + ", " + name;
-        }
-        return name;
     }
 
     public Map<Long, Map<String, String>> getOsmIdToLaneTags() {

--- a/replica-common/src/main/java/com/graphhopper/CustomGraphHopperOSM.java
+++ b/replica-common/src/main/java/com/graphhopper/CustomGraphHopperOSM.java
@@ -195,7 +195,7 @@ public class CustomGraphHopperOSM extends GraphHopper {
                     long osmId = ghReaderWay.getId();
 
                     // Parse street name from Way, if it exists
-                    String wayName = getNameFromOsmElement(ghReaderWay);
+                    String wayName = getConcatNameFromOsmElement(ghReaderWay);
                     if (wayName != null) {
                         osmIdToStreetName.put(osmId, wayName);
                     }
@@ -240,7 +240,7 @@ public class CustomGraphHopperOSM extends GraphHopper {
                             // If we haven't recorded a street name for a Way in this Relation,
                             // use the Relation's name instead, if it exists
                             if (!osmIdToStreetName.containsKey(member.getRef())) {
-                                String streetName = getNameFromOsmElement(relation);
+                                String streetName = getConcatNameFromOsmElement(relation);
                                 if (streetName != null) {
                                     osmIdToStreetName.put(member.getRef(), streetName);
                                 }
@@ -263,14 +263,16 @@ public class CustomGraphHopperOSM extends GraphHopper {
         }
     }
 
-    private static String getNameFromOsmElement(ReaderElement wayOrRelation) {
+    // if only `name` or only `ref` tag exist, return that. if both exist, return "<ref>, <name>". else, return null
+    private static String getConcatNameFromOsmElement(ReaderElement wayOrRelation) {
+        String name = null;
         if (wayOrRelation.hasTag("name")) {
-            return wayOrRelation.getTag("name");
-        } else if (wayOrRelation.hasTag("ref")) {
-            return wayOrRelation.getTag("ref");
-        } else {
-            return null;
+            name = wayOrRelation.getTag("name");
         }
+        if (wayOrRelation.hasTag("ref")) {
+            name = name == null ? wayOrRelation.getTag("ref") : wayOrRelation.getTag("ref") + ", " + name;
+        }
+        return name;
     }
 
     public Map<Long, Map<String, String>> getOsmIdToLaneTags() {

--- a/replica-common/src/main/java/com/graphhopper/CustomGraphHopperOSM.java
+++ b/replica-common/src/main/java/com/graphhopper/CustomGraphHopperOSM.java
@@ -26,6 +26,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static com.graphhopper.OsmHelper.getConcatNameFromOsmElement;
+import static com.graphhopper.OsmHelper.getHighwayFromOsmWay;
 import static com.graphhopper.util.GHUtility.readCountries;
 import static com.graphhopper.util.Helper.createFormatter;
 import static com.graphhopper.util.Helper.isEmpty;
@@ -253,26 +255,6 @@ public class CustomGraphHopperOSM extends GraphHopper {
         } catch (Exception e) {
             throw new RuntimeException("Can't open OSM file provided at " + osmPath + "!");
         }
-    }
-
-    private static String getHighwayFromOsmWay(ReaderWay way) {
-        if (way.hasTag("highway")) {
-            return way.getTag("highway");
-        } else {
-            return null;
-        }
-    }
-
-    // if only `name` or only `ref` tag exist, return that. if both exist, return "<ref>, <name>". else, return null
-    private static String getConcatNameFromOsmElement(ReaderElement wayOrRelation) {
-        String name = null;
-        if (wayOrRelation.hasTag("name")) {
-            name = wayOrRelation.getTag("name");
-        }
-        if (wayOrRelation.hasTag("ref")) {
-            name = name == null ? wayOrRelation.getTag("ref") : wayOrRelation.getTag("ref") + ", " + name;
-        }
-        return name;
     }
 
     public Map<Long, Map<String, String>> getOsmIdToLaneTags() {

--- a/replica-common/src/main/java/com/graphhopper/OsmHelper.java
+++ b/replica-common/src/main/java/com/graphhopper/OsmHelper.java
@@ -1,5 +1,7 @@
 package com.graphhopper;
 
+import com.graphhopper.reader.ReaderElement;
+import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.storage.DataAccess;
 import com.graphhopper.util.BitUtil;
 
@@ -38,5 +40,25 @@ public class OsmHelper {
 
     public static Map<String, String> getLanesTag(long osmId, Map<Long, Map<String, String>> osmIdToLaneTags) {
         return osmIdToLaneTags.getOrDefault(osmId, null);
+    }
+
+    public static String getHighwayFromOsmWay(ReaderWay way) {
+        if (way.hasTag("highway")) {
+            return way.getTag("highway");
+        } else {
+            return null;
+        }
+    }
+
+    // if only `name` or only `ref` tag exist, return that. if both exist, return "<ref>, <name>". else, return null
+    public static String getConcatNameFromOsmElement(ReaderElement wayOrRelation) {
+        String name = null;
+        if (wayOrRelation.hasTag("name")) {
+            name = wayOrRelation.getTag("name");
+        }
+        if (wayOrRelation.hasTag("ref")) {
+            name = name == null ? wayOrRelation.getTag("ref") : wayOrRelation.getTag("ref") + ", " + name;
+        }
+        return name;
     }
 }


### PR DESCRIPTION
A long time ago, [we made a change](https://github.com/replicahq/graphhopper/pull/93) that intended to improve how street names were parsed from OSM tags (for eventual output in network link exports). However, after the topic was brought up again in [slack](https://replicahq.slack.com/archives/C027YNRDV6Y/p1679592790421519?thread_ts=1679589680.458979&cid=C027YNRDV6Y) today, I realized that this change was undone accidentally during subsequent code refactoring.

Basically, we'd made the intended update - concating the values of the `ref` and `name` tags, in the case both tags are present - only in `CustomGraphHopperGTFS`, which at the time was used both for building routers and generating network link exports. When the class relevant for today's nationwide network link export - `CustomGraphHopperOSM` - was introduced at a later point, this concating logic wasn't ported over, meaning we were no longer getting the upgraded parsing behavior when generating network link exports.

This change fixes that. It also pulls the static methods in each of these custom classes relevant to OSM tag parsing out into a single shared location, so we can be guaranteed the logic in each case always matches.

[sidenote: we technically don't even use street names in the server at all, so the parsing logic here in `CustomGraphHopperGTFS` can probably be 🔪 , but I'm leaving that as a separate task - I've added a `todo` so we don't forget]

cc @bnaul @brookskinch 