### PR TITLE
Update example custom profile in sandbox to newer JSON format

### DIFF
--- a/grpc/src/main/resources/assets/js/main-template.js
+++ b/grpc/src/main/resources/assets/js/main-template.js
@@ -84,9 +84,10 @@ $(document).ready(function (e) {
         mapLayer.adjustMapSize();
     });
     $("#flex-example").click(function() {
-         $("#flex-input-text").val("speed_factor:\n  road_class:\n    motorway: 0.8\npriority:\n  road_class:\n    residential: 0.7\n");
+         $("#flex-input-text").val("{\n  \"speed\": [\n    {\n      \"if\": \"road_class == SECONDARY\",\n      \"multiply_by\": \"0.9\"\n    }\n  ],\n  \"priority\": [\n    {\n      \"if\": \"road_class == SECONDARY\",\n      \"multiply_by\": \"0.9\"\n    }\n  ],\n  \"distance_influence\": \"70\"\n}");
          return false;
     });
+
 
     var sendCustomData = function() {
        mapLayer.clearElevation();


### PR DESCRIPTION
Finally updates the example custom profile in the sandbox to use the newer JSON format the core-updated graphhopper uses. The example is fairly simple but includes all the fields we care about: 
```
{
  "speed": [
    {
      "if": "road_class == SECONDARY",
      "multiply_by": "0.9"
    }
  ],
  "priority": [
    {
      "if": "road_class == SECONDARY",
      "multiply_by": "0.9"
    }
  ],
  "distance_influence": "70"
}
```
<img width="274" alt="Screen Shot 2023-03-28 at 5 49 41 PM" src="https://user-images.githubusercontent.com/13446427/228398349-1e0d34d6-fc71-4f5e-afcc-16a427728ba8.png">

cc @bryanwilliams1025 