### PR TITLE
Move dev server image build into main CI workflow

### DIFF
--- a/.github/workflows/build_test_push.yaml
+++ b/.github/workflows/build_test_push.yaml
@@ -83,7 +83,7 @@ jobs:
             MININORCAL_OSM_PATH=${{ secrets.MININORCAL_OSM_PATH}}
             MININORCAL_GTFS_PATH=${{ secrets.MININORCAL_GTFS_PATH}}
 
-      # Build the dev server image used in unit + functional tests
+      # Build the dev server image used in functional tests
       - name: Build the server
         uses: docker/build-push-action@v2
         with:
@@ -101,5 +101,5 @@ jobs:
 
       - name: run unit tests
         run: |
-          docker run -t -d --name testrunner us.gcr.io/model-159019/gh:${{ github.sha }}-server-dev /bin/bash
+          docker run -t -d --name testrunner us.gcr.io/model-159019/gh:${{ github.sha }}-dev /bin/bash
           docker exec -i testrunner /bin/bash -c "mvn test"

--- a/.github/workflows/build_test_push.yaml
+++ b/.github/workflows/build_test_push.yaml
@@ -89,16 +89,12 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          push: false
+          push: true
           load: true
           file: Dockerfile.server
           tags: "us.gcr.io/model-159019/gh:${{ github.sha }}-server-dev"
           build-args: |
             BASE_IMAGE=us.gcr.io/model-159019/gh:${{ github.sha }}-dev
-
-      - name: Push server-dev image
-        run: |
-          docker push us.gcr.io/model-159019/gh:${{ github.sha }}-server-dev
 
       - name: run unit tests
         run: |

--- a/.github/workflows/build_test_push.yaml
+++ b/.github/workflows/build_test_push.yaml
@@ -83,7 +83,8 @@ jobs:
             MININORCAL_OSM_PATH=${{ secrets.MININORCAL_OSM_PATH}}
             MININORCAL_GTFS_PATH=${{ secrets.MININORCAL_GTFS_PATH}}
 
-      # Build the dev server image used in functional tests
+      # Build the dev server image used in functional tests ahead of time,
+      # so we can have it available for quick testing in the model repo ASAP
       - name: Build the server
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/build_test_push.yaml
+++ b/.github/workflows/build_test_push.yaml
@@ -80,6 +80,27 @@ jobs:
             MININORCAL_OSM_PATH=${{ secrets.MININORCAL_OSM_PATH}}
             MININORCAL_GTFS_PATH=${{ secrets.MININORCAL_GTFS_PATH}}
 
+      # Build the dev server + sandbox images used in functional test ahead of time
+      - name: build the server
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          file: Dockerfile.server
+          tags: "us.gcr.io/model-159019/gh:${{ github.sha }}-server-dev"
+          build-args: |
+            BASE_IMAGE=us.gcr.io/model-159019/gh:${{ github.sha }}-dev
+
+      - name: build the sandbox
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          file: Dockerfile.sandbox
+          tags: "us.gcr.io/model-159019/gh:${{ github.sha }}-server-sandbox"
+          build-args: |
+            BASE_IMAGE=us.gcr.io/model-159019/gh:${{ github.sha }}-dev
+
       - name: run unit tests
         run: |
           docker run -t -d --name testrunner us.gcr.io/model-159019/gh:${{ github.sha }}-dev /bin/bash

--- a/.github/workflows/build_test_push.yaml
+++ b/.github/workflows/build_test_push.yaml
@@ -89,12 +89,16 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          push: true
+          push: false
           load: true
           file: Dockerfile.server
           tags: "us.gcr.io/model-159019/gh:${{ github.sha }}-server-dev"
           build-args: |
             BASE_IMAGE=us.gcr.io/model-159019/gh:${{ github.sha }}-dev
+
+      - name: Push server-dev image
+        run: |
+          docker push us.gcr.io/model-159019/gh:${{ github.sha }}-server-dev
 
       - name: run unit tests
         run: |

--- a/.github/workflows/build_test_push.yaml
+++ b/.github/workflows/build_test_push.yaml
@@ -54,6 +54,8 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@master
+        with:
+          driver: docker
 
       - name: Cache Docker layers
         uses: actions/cache@v2

--- a/.github/workflows/build_test_push.yaml
+++ b/.github/workflows/build_test_push.yaml
@@ -70,6 +70,7 @@ jobs:
         with:
           context: .
           push: false
+          load: true
           file: Dockerfile.build
           tags: "us.gcr.io/model-159019/gh:${{ github.sha }}-dev"
           build-args: |

--- a/.github/workflows/build_test_push.yaml
+++ b/.github/workflows/build_test_push.yaml
@@ -64,8 +64,8 @@ jobs:
             ${{ runner.os }}-graphhopper-buildx
       # ---------------------
 
-        # Build image for unit tests
-      - name: Build test image
+        # Build base image for server + sandbox
+      - name: Build base image
         uses: docker/build-push-action@v2
         with:
           context: .
@@ -80,24 +80,14 @@ jobs:
             MININORCAL_OSM_PATH=${{ secrets.MININORCAL_OSM_PATH}}
             MININORCAL_GTFS_PATH=${{ secrets.MININORCAL_GTFS_PATH}}
 
-      # Build the dev server + sandbox images used in functional test ahead of time
-      - name: build the server
+      # Build the dev server image used in unit + functional tests
+      - name: Build the server
         uses: docker/build-push-action@v2
         with:
           context: .
           push: true
           file: Dockerfile.server
           tags: "us.gcr.io/model-159019/gh:${{ github.sha }}-server-dev"
-          build-args: |
-            BASE_IMAGE=us.gcr.io/model-159019/gh:${{ github.sha }}-dev
-
-      - name: build the sandbox
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          push: true
-          file: Dockerfile.sandbox
-          tags: "us.gcr.io/model-159019/gh:${{ github.sha }}-server-sandbox"
           build-args: |
             BASE_IMAGE=us.gcr.io/model-159019/gh:${{ github.sha }}-dev
 

--- a/.github/workflows/build_test_push.yaml
+++ b/.github/workflows/build_test_push.yaml
@@ -69,7 +69,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          push: true
+          push: false
           file: Dockerfile.build
           tags: "us.gcr.io/model-159019/gh:${{ github.sha }}-dev"
           build-args: |
@@ -103,5 +103,5 @@ jobs:
 
       - name: run unit tests
         run: |
-          docker run -t -d --name testrunner us.gcr.io/model-159019/gh:${{ github.sha }}-dev /bin/bash
+          docker run -t -d --name testrunner us.gcr.io/model-159019/gh:${{ github.sha }}-server-dev /bin/bash
           docker exec -i testrunner /bin/bash -c "mvn test"

--- a/.github/workflows/build_test_push.yaml
+++ b/.github/workflows/build_test_push.yaml
@@ -86,11 +86,16 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          push: true
+          push: false
+          load: true
           file: Dockerfile.server
           tags: "us.gcr.io/model-159019/gh:${{ github.sha }}-server-dev"
           build-args: |
             BASE_IMAGE=us.gcr.io/model-159019/gh:${{ github.sha }}-dev
+
+      - name: Push server-dev image
+        run: |
+          docker push us.gcr.io/model-159019/gh:${{ github.sha }}-server-dev
 
       - name: run unit tests
         run: |

--- a/.github/workflows/build_test_push.yaml
+++ b/.github/workflows/build_test_push.yaml
@@ -66,7 +66,7 @@ jobs:
             ${{ runner.os }}-graphhopper-buildx
       # ---------------------
 
-        # Build base image for server + sandbox
+      # Build base image for unit tests
       - name: Build base image
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -1,6 +1,6 @@
 name: Functional Test
 # This test does the following:
-# * Builds the "server" docker image that is used by the model repo
+# * Builds the sandbox docker image used for the router sandbox
 # * Runs functional tests queries against micro nor cal golden OD set
 # * Analyzes results of functional test queries, comparing against golden result set
 # * If tests pass, updates git and docker tags
@@ -23,7 +23,7 @@ jobs:
           GITHUB_CONTEXT: ${{ toJSON(github) }}
         run: echo "$GITHUB_CONTEXT"
   functional-test-queries:
-    name: "Build server image and run functional test queries"
+    name: "Build sandbox image and run functional test queries"
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -85,6 +85,16 @@ jobs:
       - name: Set temp directory env variable
         run: echo "TMPDIR=$(mktemp -d)" >> $GITHUB_ENV
 
+      - name: Build the sandbox
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          file: Dockerfile.sandbox
+          tags: "us.gcr.io/model-159019/gh:${{ github.sha }}-server-sandbox"
+          build-args: |
+            BASE_IMAGE=us.gcr.io/model-159019/gh:${{ github.sha }}-dev
+
       - name: Install golang
         uses: actions/setup-go@v2
         with:

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -85,26 +85,6 @@ jobs:
       - name: Set temp directory env variable
         run: echo "TMPDIR=$(mktemp -d)" >> $GITHUB_ENV
 
-      - name: build the server
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          push: true
-          file: Dockerfile.server
-          tags: "us.gcr.io/model-159019/gh:${{ github.sha }}-server-dev"
-          build-args: |
-            BASE_IMAGE=us.gcr.io/model-159019/gh:${{ github.sha }}-dev
-
-      - name: build the sandbox
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          push: true
-          file: Dockerfile.sandbox
-          tags: "us.gcr.io/model-159019/gh:${{ github.sha }}-server-sandbox"
-          build-args: |
-            BASE_IMAGE=us.gcr.io/model-159019/gh:${{ github.sha }}-dev
-
       - name: Install golang
         uses: actions/setup-go@v2
         with:

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -93,7 +93,7 @@ jobs:
           file: Dockerfile.sandbox
           tags: "us.gcr.io/model-159019/gh:${{ github.sha }}-server-sandbox"
           build-args: |
-            BASE_IMAGE=us.gcr.io/model-159019/gh:${{ github.sha }}-dev
+            BASE_IMAGE=us.gcr.io/model-159019/gh:${{ github.sha }}-server-dev
 
       - name: Install golang
         uses: actions/setup-go@v2


### PR DESCRIPTION
https://replicahq.atlassian.net/browse/RAD-6212

Currently, our CI setup doesn’t build a docker image that can be used to spin up routing servers in the model repo - this step happens only when you kick off a functional test CI flow manually. In theory, this separation is intended, as we technically don’t want to “stamp” a runnable server image with dev before we’ve even run unit tests.

However, in practice, I basically never sit and wait for all unit tests to pass when I’m iterating quickly and need a runnable image to use ASAP. Instead, I wait until the “unit test” image finished building (the first part of the docker build process), then right away kick off a functional test build to get a working server image I can plug into the model repo.

This change moves that server dev image building step to the main CI flow. The change technically goes against the intended pattern of our existing CI/functional test flow, but in practice would save me loads of time that’s currently wasted waiting for CI to pass a particular step and then manually kicking off another flow