### PR TITLE
Update omniscale (map tile) api key to new paid token

### DIFF
--- a/grpc/src/main/resources/assets/js/config/options.js
+++ b/grpc/src/main/resources/assets/js/config/options.js
@@ -14,6 +14,6 @@ exports.options = {
     routing: {host: 'localhost:8998', api_key: '48531d4f4b6e70e2314489e3244c6c71fa8b984c5690af42'},
     geocoding: {host: '', api_key: ''},
     thunderforest: {api_key: ''},
-    omniscale: {api_key: 'graphhopper-k8s-f4f36693'},
+    omniscale: {api_key: 'graphhopper-34c9f6fd'},
     mapilion: {api_key: ''}
 };


### PR DESCRIPTION
Same deal as https://github.com/replicahq/graphhopper/pull/139, updating our omniscale API key, this time to a new key linked to a paid account to avoid losing access ([thread](https://replicahq.slack.com/archives/CK358RL0Z/p1683048932447059?thread_ts=1679933470.604989&cid=CK358RL0Z) for context)

Untested, but it can't make things worse 🤷 

cc @bnaul 