### PR TITLE
Enable beta access + egress parameters in PT requests

### DIFF
--- a/configs/custom_weight_gh_config.yaml
+++ b/configs/custom_weight_gh_config.yaml
@@ -13,23 +13,23 @@ graphhopper:
     - name: car
       vehicle: car
       weighting: custom
-      custom_model_file: empty
+      custom_model_files: []
     - name: bike
       vehicle: bike
       weighting: custom
-      custom_model_file: empty
+      custom_model_files: []
     - name: foot
       vehicle: foot
       weighting: custom
-      custom_model_file: empty
+      custom_model_files: []
     - name: truck
       vehicle: truck
       weighting: custom
-      custom_model_file: empty
+      custom_model_files: []
     - name: small_truck
       vehicle: small_truck
       weighting: custom
-      custom_model_file: empty
+      custom_model_files: []
 
 server:
   min_threads: 4

--- a/configs/run_local_server_gh_config.yaml
+++ b/configs/run_local_server_gh_config.yaml
@@ -23,11 +23,11 @@ graphhopper:
     - name: car
       vehicle: car
       weighting: custom
-      custom_model_file: local_car_custom_model.json
+      custom_model_files: [local_car_custom_model.json]
     - name: car_freeway
       vehicle: car
       weighting: custom
-      custom_model_file: freeway_car_custom_model.json
+      custom_model_files: [freeway_car_custom_model.json]
     - name: bike
       vehicle: bike
       weighting: fastest

--- a/configs/test_gh_config.yaml
+++ b/configs/test_gh_config.yaml
@@ -26,11 +26,11 @@ graphhopper:
     - name: car  # "car" profile name required for PT routing with custom access/egress mode
       vehicle: car
       weighting: custom
-      custom_model_file: local_car_custom_model.json
+      custom_model_files: [local_car_custom_model.json]
     - name: car_freeway
       vehicle: car
       weighting: custom
-      custom_model_file: freeway_car_custom_model.json
+      custom_model_files: [freeway_car_custom_model.json]
     - name: car_custom_fast_thurton_drive
       vehicle: car_custom_fast_thurton_drive
       weighting: fastest

--- a/grpc/pom.xml
+++ b/grpc/pom.xml
@@ -24,17 +24,17 @@
         <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-core</artifactId>
-            <version>2.0.8</version>
+            <version>2.1.6</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-assets</artifactId>
-            <version>2.0.8</version>
+            <version>2.1.6</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard-bundles</groupId>
             <artifactId>dropwizard-redirect-bundle</artifactId>
-            <version>1.0.5</version>
+            <version>1.3.5</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/grpc/src/main/java/com/replica/RouterImpl.java
+++ b/grpc/src/main/java/com/replica/RouterImpl.java
@@ -223,16 +223,6 @@ public class RouterImpl extends router.RouterGrpc.RouterImplBase {
         Point toPoint = request.getPoints(1);
         Request ghPtRequest = RouterConverters.toGHPtRequest(request);
 
-        // Set access and egress leg modes if they've been explicitly provided.
-        // Note: even if modes other than walk are requested, Graphhopper will return these legs
-        // as Trip.WalkLeg objects
-        // Note: GraphHopper currently only accepts profiles with standard "base" names for
-        // access/egress modes. Therefore, "mode" and "profile" are somewhat interchangeable here
-        String accessMode = request.getAccessMode().equals("") ? "foot" : request.getAccessMode();
-        String egressMode = request.getEgressMode().equals("") ? "foot" : request.getEgressMode();
-        ghPtRequest.setAccessProfile(accessMode);
-        ghPtRequest.setEgressProfile(egressMode);
-
         try {
             long routeStartTime = System.currentTimeMillis();
             GHResponse ghResponse = ptRouter.route(ghPtRequest);

--- a/grpc/src/main/java/com/replica/util/RouterConverters.java
+++ b/grpc/src/main/java/com/replica/util/RouterConverters.java
@@ -224,6 +224,23 @@ public final class RouterConverters {
         ghPtRequest.setBetaTransfers(request.getBetaTransfers());
         ghPtRequest.setMaxVisitedNodes(request.getMaxVisitedNodes() == 0 ? DEFAULT_MAX_VISITED_NODES : request.getMaxVisitedNodes());
 
+        // Set access and egress leg modes if they've been explicitly provided.
+        // Note: even if modes other than walk are requested, Graphhopper will return these legs
+        // as Trip.WalkLeg objects
+        // Note: GraphHopper currently only accepts profiles with standard "base" names for
+        // access/egress modes. Therefore, "mode" and "profile" are somewhat interchangeable here
+        String accessMode = request.getAccessMode().equals("") ? "foot" : request.getAccessMode();
+        String egressMode = request.getEgressMode().equals("") ? "foot" : request.getEgressMode();
+        ghPtRequest.setAccessProfile(accessMode);
+        ghPtRequest.setEgressProfile(egressMode);
+
+        // If beta access/egress time hasn't been explicitly set, assume caller is using older protos
+        // where only one global beta walk time param is provided, and use that value
+        double betaAccessTime = request.getBetaAccessTime() == 0.0 ? request.getBetaWalkTime() : request.getBetaAccessTime();
+        double betaEgressTime = request.getBetaEgressTime() == 0.0 ? request.getBetaWalkTime() : request.getBetaEgressTime();
+        ghPtRequest.setBetaAccessTime(betaAccessTime);
+        ghPtRequest.setBetaEgressTime(betaEgressTime);
+
         return ghPtRequest;
     }
 

--- a/grpc/src/main/java/com/replica/util/RouterConverters.java
+++ b/grpc/src/main/java/com/replica/util/RouterConverters.java
@@ -218,7 +218,6 @@ public final class RouterConverters {
         ghPtRequest.setPathDetails(Lists.newArrayList("stable_edge_ids"));
         ghPtRequest.setProfileQuery(true);
         ghPtRequest.setMaxProfileDuration(Duration.ofMinutes(request.getMaxProfileDuration()));
-        ghPtRequest.setBetaStreetTime(request.getBetaWalkTime());
         ghPtRequest.setLimitStreetTime(Duration.ofSeconds(request.getLimitStreetTimeSeconds()));
         ghPtRequest.setIgnoreTransfers(!request.getUsePareto()); // ignoreTransfers=true means pareto queries are off
         ghPtRequest.setBetaTransfers(request.getBetaTransfers());

--- a/grpc/src/main/resources/assets/pt/src/data/Query.js
+++ b/grpc/src/main/resources/assets/pt/src/data/Query.js
@@ -24,12 +24,13 @@ const CreateQuery = (baseUrl, search) => {
     url.searchParams.set("profile", "pt");
     url.searchParams.set("pt.limit_solutions", search.limitSolutions);
     url.searchParams.set("pt.max_profile_duration", search.maxProfileDuration);
-    url.searchParams.set("pt.beta_walk_time", search.betaWalkTime);
     url.searchParams.set("pt.limit_street_time", search.limitStreetTimeSeconds);
     url.searchParams.set("pt.use_pareto", search.usePareto);
     url.searchParams.set("pt.beta_transfers", search.betaTransfers);
     url.searchParams.set("pt.access_mode", search.accessMode);
     url.searchParams.set("pt.egress_mode", search.egressMode);
+    url.searchParams.set("pt.beta_access_time", search.betaAccessTime);
+    url.searchParams.set("pt.beta_egress_time", search.betaEgressTime);
     url.searchParams.set("pt.max_visited_nodes", search.maxVisitedNodes);
     return url.toString();
 };
@@ -70,12 +71,13 @@ const ParseQuery = (search, searchParams) => {
     parse("pt.profile_duration", "rangeQueryDuration", searchParams);
     parse("pt.ignore_transfers", "ignoreTransfers", searchParams);
     parse("pt.max_profile_duration", "maxProfileDuration", searchParams);
-    parse("pt.beta_walk_time", "betaWalkTime", searchParams);
-    parse("pt.limit_street_time", "limitStreetTimeSeconds", searchParams)
+    parse("pt.limit_street_time", "limitStreetTimeSeconds", searchParams);
     parse("pt.use_pareto", "usePareto", searchParams);
     parse("pt.beta_transfers", "betaTransfers", searchParams);
     parse("pt.access_mode", "accessMode", searchParams);
     parse("pt.egress_mode", "egressMode", searchParams);
+    parse("pt.beta_access_time", "betaAccessTime", searchParams);
+    parse("pt.beta_egress_time", "betaEgressTime", searchParams);
     parse("pt.max_visited_nodes", "maxVisitedNodes", searchParams);
     return search;
 };

--- a/grpc/src/main/resources/assets/pt/src/view/App.js
+++ b/grpc/src/main/resources/assets/pt/src/view/App.js
@@ -33,11 +33,12 @@ export default class App extends React.Component {
             departureDateTime: new moment(),
             limitSolutions: 4,
             maxProfileDuration: 10,
-            betaWalkTime: 1.5,
             limitStreetTimeSeconds: 1440,
             usePareto: false,
             accessMode: "foot",
             egressMode: "foot",
+            betaAccessTime: 1.5,
+            betaEgressTime: 1.5,
             betaTransfers: 720000.0,
             maxVisitedNodes: 1000000,
             routes: {
@@ -90,12 +91,13 @@ export default class App extends React.Component {
                     ptRouteRequest.setEarliestDepartureTime(timestampFromDate);
                     ptRouteRequest.setLimitSolutions(this.state.limitSolutions);
                     ptRouteRequest.setMaxProfileDuration(this.state.maxProfileDuration);
-                    ptRouteRequest.setBetaWalkTime(this.state.betaWalkTime);
                     ptRouteRequest.setLimitStreetTimeSeconds(this.state.limitStreetTimeSeconds)
                     ptRouteRequest.setUsePareto(this.state.usePareto);
                     ptRouteRequest.setBetaTransfers(this.state.betaTransfers);
                     ptRouteRequest.setAccessMode(this.state.accessMode);
                     ptRouteRequest.setEgressMode(this.state.egressMode);
+                    ptRouteRequest.setBetaAccessTime(this.state.betaAccessTime);
+                    ptRouteRequest.setBetaEgressTime(this.state.betaEgressTime);
                     ptRouteRequest.setMaxVisitedNodes(this.state.maxVisitedNodes);
 
                     // log request object for debugging

--- a/grpc/src/main/resources/assets/pt/src/view/sidebar/SearchInput.js
+++ b/grpc/src/main/resources/assets/pt/src/view/sidebar/SearchInput.js
@@ -77,10 +77,16 @@ class SearchInput extends React.Component {
                 actionType: "maxProfileDuration"
             }),
             React.createElement(NumberInput, {
-                value: this.props.search.betaWalkTime,
-                label: "Beta walk time (values > 1.0 disincentivize walking)",
+                value: this.props.search.betaAccessTime,
+                label: "Beta access time (values > 1.0 disincentivize walking)",
                 onChange: this.handleInputChange,
-                actionType: "betaWalkTime"
+                actionType: "betaAccessTime"
+            }),
+            React.createElement(NumberInput, {
+                value: this.props.search.betaEgressTime,
+                label: "Beta egress time (values > 1.0 disincentivize walking)",
+                onChange: this.handleInputChange,
+                actionType: "betaEgressTime"
             }),
             React.createElement(NumberInput, {
                 value: this.props.search.limitStreetTimeSeconds,

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-testing</artifactId>
-            <version>2.0.16</version>
+            <version>2.1.5</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.mockito/mockito-core -->

--- a/replica-common/pom.xml
+++ b/replica-common/pom.xml
@@ -19,31 +19,31 @@
         <dependency>
             <groupId>com.graphhopper</groupId>
             <artifactId>graphhopper-core</artifactId>
-            <version>49b0dd189fddd751e5d170e7a741feaa81d4c486</version>
+            <version>547215973b5b66d082a6adb184f48ae71f790c9d</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.graphhopper</groupId>
             <artifactId>graphhopper-reader-gtfs</artifactId>
-            <version>49b0dd189fddd751e5d170e7a741feaa81d4c486</version>
+            <version>547215973b5b66d082a6adb184f48ae71f790c9d</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.graphhopper</groupId>
             <artifactId>graphhopper-web-bundle</artifactId>
-            <version>49b0dd189fddd751e5d170e7a741feaa81d4c486</version>
+            <version>547215973b5b66d082a6adb184f48ae71f790c9d</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.graphhopper</groupId>
             <artifactId>graphhopper-web</artifactId>
-            <version>49b0dd189fddd751e5d170e7a741feaa81d4c486</version>
+            <version>547215973b5b66d082a6adb184f48ae71f790c9d</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.graphhopper</groupId>
             <artifactId>graphhopper-tools</artifactId>
-            <version>49b0dd189fddd751e5d170e7a741feaa81d4c486</version>
+            <version>547215973b5b66d082a6adb184f48ae71f790c9d</version>
             <type>pom</type>
         </dependency>
         <dependency>

--- a/replica-common/src/main/java/com/graphhopper/CustomGraphHopperGtfs.java
+++ b/replica-common/src/main/java/com/graphhopper/CustomGraphHopperGtfs.java
@@ -136,7 +136,7 @@ public class CustomGraphHopperGtfs extends GraphHopperGtfs {
         }
 
         LOG.info("start creating graph from " + this.getOSMFile());
-        CustomOsmReader reader = new CustomOsmReader(this.getBaseGraph().getBaseGraph(), this.getEncodingManager(), this.getOSMParsers(), this.getReaderConfig())
+        CustomOsmReader reader = new CustomOsmReader(this.getBaseGraph().getBaseGraph(), this.getOSMParsers(), this.getReaderConfig())
                 .setFile(new File(this.getOSMFile())).
                 setAreaIndex(areaIndex).
                 setElevationProvider(this.getElevationProvider()).
@@ -199,7 +199,7 @@ public class CustomGraphHopperGtfs extends GraphHopperGtfs {
         try (OSMInput input = new OSMInputFile(new File(osmPath)).setWorkerThreads(2).open()) {
             ReaderElement next;
             while((next = input.getNext()) != null) {
-                if (next.isType(ReaderElement.Type.WAY)) {
+                if (next.getType().equals(ReaderElement.Type.WAY)) {
                     if (++readCount % 100_000 == 0) {
                         LOG.info("Parsing tag info from OSM ways. " + readCount + " read so far.");
                     }
@@ -232,7 +232,7 @@ public class CustomGraphHopperGtfs extends GraphHopperGtfs {
                             }
                         }
                     }
-                } else if (next.isType(ReaderElement.Type.RELATION)) {
+                } else if (next.getType().equals(ReaderElement.Type.RELATION)) {
                     if (next.hasTag("route", "road")) {
                         roadRelations.add((ReaderRelation) next);
                     }

--- a/replica-common/src/main/java/com/graphhopper/CustomGraphHopperOSM.java
+++ b/replica-common/src/main/java/com/graphhopper/CustomGraphHopperOSM.java
@@ -122,7 +122,7 @@ public class CustomGraphHopperOSM extends GraphHopper {
         }
 
         LOG.info("start creating graph from " + this.getOSMFile());
-        CustomOsmReader reader = new CustomOsmReader(this.getBaseGraph().getBaseGraph(), this.getEncodingManager(), this.getOSMParsers(), this.getReaderConfig())
+        CustomOsmReader reader = new CustomOsmReader(this.getBaseGraph().getBaseGraph(), this.getOSMParsers(), this.getReaderConfig())
                 .setFile(new File(this.getOSMFile()))
                 .setAreaIndex(areaIndex)
                 .setElevationProvider(this.getElevationProvider())
@@ -189,7 +189,7 @@ public class CustomGraphHopperOSM extends GraphHopper {
         try (OSMInput input = new OSMInputFile(new File(osmPath)).setWorkerThreads(2).open()) {
             ReaderElement next;
             while((next = input.getNext()) != null) {
-                if (next.isType(ReaderElement.Type.WAY)) {
+                if (next.getType().equals(ReaderElement.Type.WAY)) {
                     if (++readCount % 100_000 == 0) {
                         LOG.info("Parsing tag info from OSM ways. " + readCount + " read so far.");
                     }
@@ -222,7 +222,7 @@ public class CustomGraphHopperOSM extends GraphHopper {
                             }
                         }
                     }
-                } else if (next.isType(ReaderElement.Type.RELATION)) {
+                } else if (next.getType().equals(ReaderElement.Type.RELATION)) {
                     if (next.hasTag("route", "road")) {
                         roadRelations.add((ReaderRelation) next);
                     }

--- a/replica-common/src/main/java/com/graphhopper/OsmIdTagParser.java
+++ b/replica-common/src/main/java/com/graphhopper/OsmIdTagParser.java
@@ -1,6 +1,7 @@
 package com.graphhopper;
 
 import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.EdgeIntAccess;
 import com.graphhopper.routing.ev.IntEncodedValue;
 import com.graphhopper.routing.util.parsers.TagParser;
 import com.graphhopper.storage.IntsRef;
@@ -14,10 +15,9 @@ class OsmIdTagParser implements TagParser {
     }
 
     @Override
-    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay way, IntsRef intsRef1) {
+    public void handleWayTags(int edgeId, EdgeIntAccess edgeIntAccess, ReaderWay way, IntsRef relationFlags) {
         if (way.getId() > Integer.MAX_VALUE)
             throw new RuntimeException("Unexpectedly high way id.");
-        osmIdEnc.setInt(false, edgeFlags, (int) way.getId());
-        return edgeFlags;
+        osmIdEnc.setInt(false, edgeId, edgeIntAccess, (int) way.getId());
     }
 }

--- a/replica-common/src/main/java/com/graphhopper/TagParserFactoryWithOsmId.java
+++ b/replica-common/src/main/java/com/graphhopper/TagParserFactoryWithOsmId.java
@@ -4,18 +4,19 @@ import com.graphhopper.routing.ev.EncodedValueLookup;
 import com.graphhopper.routing.util.parsers.DefaultTagParserFactory;
 import com.graphhopper.routing.util.parsers.TagParser;
 import com.graphhopper.stableid.NoOpTagParser;
+import com.graphhopper.util.PMap;
 
 public class TagParserFactoryWithOsmId extends DefaultTagParserFactory {
 
     @Override
-    public TagParser create(EncodedValueLookup lookup, String name) {
+    public TagParser create(EncodedValueLookup lookup, String name, PMap properties) {
         if (name.equals("osmid")) {
             return new OsmIdTagParser(lookup.getIntEncodedValue("osmid"));
         } else if (name.startsWith("stable_id") || name.startsWith("reverse_stable_id")) {
             // We compute those values outside of GraphHopper's loop
             return new NoOpTagParser();
         } else {
-            return super.create(lookup, name);
+            return super.create(lookup, name, properties);
         }
     }
 }

--- a/replica-common/src/main/java/com/graphhopper/reader/osm/CustomOsmReader.java
+++ b/replica-common/src/main/java/com/graphhopper/reader/osm/CustomOsmReader.java
@@ -178,6 +178,7 @@ public class CustomOsmReader {
                 osmFile.getAbsolutePath(), nf(baseGraph.getNodes()), nf(baseGraph.getEdges()), nf(zeroCounter));
         this.ghNodeIdToOsmNodeIdMap = waySegmentParser.getGhNodeIdToOsmNodeIdMap();
         this.artificialIdToOsmNodeIds = waySegmentParser.getArtificialIdToOsmNodeIds();
+        waySegmentParser.releaseNodeData();
     }
 
     /**

--- a/replica-common/src/main/java/com/graphhopper/reader/osm/CustomWaySegmentParser.java
+++ b/replica-common/src/main/java/com/graphhopper/reader/osm/CustomWaySegmentParser.java
@@ -91,7 +91,10 @@ public class CustomWaySegmentParser {
         readOSM(osmFile, new Pass2Handler(), SkipOptions.none());
         LOGGER.info("pass2 - finished, took: {}", sw2.stop().getTimeString());
 
-        nodeData.release();
+        // Replica-specific: usually, node data would be cleared here. But, we want
+        // access to that data post-OSM-read. So, we removed the release() call here,
+        // and moved it into a helper below that we can call after fetching the
+        // data we care about from the read step
 
         LOGGER.info("Finished reading OSM file." +
                 " pass1: " + (int) sw1.getSeconds() + "s, " +
@@ -109,8 +112,18 @@ public class CustomWaySegmentParser {
         return nodeData.getGhIdToOsmIdMap();
     }
 
+    /**
+     * Replica-added helper to get access to internal mapping of GH artificial node IDs to OSM node ID
+     */
     public Map<Long, Long> getArtificialIdToOsmNodeIds() {
         return nodeData.getArtificialIdToOsmNodeIds();
+    }
+
+    /**
+     * Replica-added helper to clear node data object post-read (after we've grabbed info we care about)
+     */
+    public void releaseNodeData() {
+        nodeData.release();
     }
 
     /**

--- a/replica-common/src/main/java/com/graphhopper/stableid/EncodedValueFactoryWithStableId.java
+++ b/replica-common/src/main/java/com/graphhopper/stableid/EncodedValueFactoryWithStableId.java
@@ -21,46 +21,48 @@ package com.graphhopper.stableid;
 import com.graphhopper.routing.ev.DefaultEncodedValueFactory;
 import com.graphhopper.routing.ev.EncodedValue;
 import com.graphhopper.routing.ev.IntEncodedValueImpl;
+import com.graphhopper.util.PMap;
 
 public class EncodedValueFactoryWithStableId extends DefaultEncodedValueFactory {
+
     @Override
-    public EncodedValue create(String encodedValueString) {
-        if (encodedValueString.startsWith("stable_id_byte_0")) {
+    public EncodedValue create(String name, PMap properties) {
+        if (name.startsWith("stable_id_byte_0")) {
             return new IntEncodedValueImpl("stable_id_byte_0", 8, false);
-        } else if (encodedValueString.startsWith("stable_id_byte_1")) {
+        } else if (name.startsWith("stable_id_byte_1")) {
             return new IntEncodedValueImpl("stable_id_byte_1", 8, false);
-        } else if (encodedValueString.startsWith("stable_id_byte_2")) {
+        } else if (name.startsWith("stable_id_byte_2")) {
             return new IntEncodedValueImpl("stable_id_byte_2", 8, false);
-        } else if (encodedValueString.startsWith("stable_id_byte_3")) {
+        } else if (name.startsWith("stable_id_byte_3")) {
             return new IntEncodedValueImpl("stable_id_byte_3", 8, false);
-        } else if (encodedValueString.startsWith("stable_id_byte_4")) {
+        } else if (name.startsWith("stable_id_byte_4")) {
             return new IntEncodedValueImpl("stable_id_byte_4", 8, false);
-        } else if (encodedValueString.startsWith("stable_id_byte_5")) {
+        } else if (name.startsWith("stable_id_byte_5")) {
             return new IntEncodedValueImpl("stable_id_byte_5", 8, false);
-        } else if (encodedValueString.startsWith("stable_id_byte_6")) {
+        } else if (name.startsWith("stable_id_byte_6")) {
             return new IntEncodedValueImpl("stable_id_byte_6", 8, false);
-        } else if (encodedValueString.startsWith("stable_id_byte_7")) {
+        } else if (name.startsWith("stable_id_byte_7")) {
             return new IntEncodedValueImpl("stable_id_byte_7", 8, false);
-        } else if (encodedValueString.startsWith("reverse_stable_id_byte_0")) {
+        } else if (name.startsWith("reverse_stable_id_byte_0")) {
             return new IntEncodedValueImpl("reverse_stable_id_byte_0", 8, false);
-        } else if (encodedValueString.startsWith("reverse_stable_id_byte_1")) {
+        } else if (name.startsWith("reverse_stable_id_byte_1")) {
             return new IntEncodedValueImpl("reverse_stable_id_byte_1", 8, false);
-        } else if (encodedValueString.startsWith("reverse_stable_id_byte_2")) {
+        } else if (name.startsWith("reverse_stable_id_byte_2")) {
             return new IntEncodedValueImpl("reverse_stable_id_byte_2", 8, false);
-        } else if (encodedValueString.startsWith("reverse_stable_id_byte_3")) {
+        } else if (name.startsWith("reverse_stable_id_byte_3")) {
             return new IntEncodedValueImpl("reverse_stable_id_byte_3", 8, false);
-        } else if (encodedValueString.startsWith("reverse_stable_id_byte_4")) {
+        } else if (name.startsWith("reverse_stable_id_byte_4")) {
             return new IntEncodedValueImpl("reverse_stable_id_byte_4", 8, false);
-        } else if (encodedValueString.startsWith("reverse_stable_id_byte_5")) {
+        } else if (name.startsWith("reverse_stable_id_byte_5")) {
             return new IntEncodedValueImpl("reverse_stable_id_byte_5", 8, false);
-        } else if (encodedValueString.startsWith("reverse_stable_id_byte_6")) {
+        } else if (name.startsWith("reverse_stable_id_byte_6")) {
             return new IntEncodedValueImpl("reverse_stable_id_byte_6", 8, false);
-        } else if (encodedValueString.startsWith("reverse_stable_id_byte_7")) {
+        } else if (name.startsWith("reverse_stable_id_byte_7")) {
             return new IntEncodedValueImpl("reverse_stable_id_byte_7", 8, false);
-        } else if (encodedValueString.startsWith("osmid")) {
+        } else if (name.startsWith("osmid")) {
             return new IntEncodedValueImpl("osmid", 31, false);
         } else {
-            return super.create(encodedValueString);
+            return super.create(name, properties);
         }
     }
 }

--- a/replica-common/src/main/java/com/graphhopper/stableid/NoOpTagParser.java
+++ b/replica-common/src/main/java/com/graphhopper/stableid/NoOpTagParser.java
@@ -1,12 +1,13 @@
 package com.graphhopper.stableid;
 
 import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.EdgeIntAccess;
 import com.graphhopper.routing.util.parsers.TagParser;
 import com.graphhopper.storage.IntsRef;
 
 public class NoOpTagParser implements TagParser {
+
     @Override
-    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay way, IntsRef relationFlags) {
-        return edgeFlags;
-    }
+    public void handleWayTags(int edgeId, EdgeIntAccess edgeIntAccess, ReaderWay way, IntsRef relationFlags) {}
+
 }

--- a/replica-common/src/main/java/com/graphhopper/stableid/PathDetailsBuilderFactoryWithStableId.java
+++ b/replica-common/src/main/java/com/graphhopper/stableid/PathDetailsBuilderFactoryWithStableId.java
@@ -16,35 +16,49 @@ package com.graphhopper.stableid;/*
  *  limitations under the License.
  */
 
-import com.graphhopper.coll.MapEntry;
+import com.graphhopper.routing.Path;
 import com.graphhopper.routing.ev.*;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.Graph;
 import com.graphhopper.util.details.*;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 
-import static com.graphhopper.routing.util.EncodingManager.getKey;
 import static com.graphhopper.util.Parameters.Details.*;
 
 public class PathDetailsBuilderFactoryWithStableId extends PathDetailsBuilderFactory {
 
     @Override
-    public List<PathDetailsBuilder> createPathDetailsBuilders(List<String> requestedPathDetails, EncodedValueLookup evl, Weighting weighting, Graph graph) {
-        // request-scoped
+    public List<PathDetailsBuilder> createPathDetailsBuilders(List<String> requestedPathDetails, Path path, EncodedValueLookup evl, Weighting weighting, Graph graph) {
         List<PathDetailsBuilder> builders = new ArrayList<>();
+
+        if (requestedPathDetails.contains(LEG_TIME))
+            builders.add(new ConstantDetailsBuilder(LEG_TIME, path.getTime()));
+        if (requestedPathDetails.contains(LEG_DISTANCE))
+            builders.add(new ConstantDetailsBuilder(LEG_DISTANCE, path.getDistance()));
+        if (requestedPathDetails.contains(LEG_WEIGHT))
+            builders.add(new ConstantDetailsBuilder(LEG_WEIGHT, path.getWeight()));
+
+        if (requestedPathDetails.contains(STREET_NAME))
+            builders.add(new KVStringDetails(STREET_NAME));
+        if (requestedPathDetails.contains(STREET_REF))
+            builders.add(new KVStringDetails(STREET_REF));
+        if (requestedPathDetails.contains(STREET_DESTINATION))
+            builders.add(new KVStringDetails(STREET_DESTINATION));
 
         if (requestedPathDetails.contains(AVERAGE_SPEED))
             builders.add(new AverageSpeedDetails(weighting));
 
-        if (requestedPathDetails.contains("street_name"))
-            builders.add(new KVStringDetails("street_name"));
-
         if (requestedPathDetails.contains(EDGE_ID))
             builders.add(new EdgeIdDetails());
+
+        if (requestedPathDetails.contains(EDGE_KEY))
+            builders.add(new EdgeKeyDetails());
+
+        if (requestedPathDetails.contains("stable_edge_ids")) {
+            builders.add(new StableIdPathDetailsBuilder(evl));
+        }
 
         if (requestedPathDetails.contains(TIME))
             builders.add(new TimeDetails(weighting));
@@ -55,39 +69,32 @@ public class PathDetailsBuilderFactoryWithStableId extends PathDetailsBuilderFac
         if (requestedPathDetails.contains(DISTANCE))
             builders.add(new DistanceDetails());
 
-        for (String checkSuffix : requestedPathDetails) {
-            if (checkSuffix.contains(getKey("", "priority")) && evl.hasEncodedValue(checkSuffix))
-                builders.add(new DecimalDetails(checkSuffix, evl.getDecimalEncodedValue(checkSuffix)));
+        if (requestedPathDetails.contains(INTERSECTION))
+            builders.add(new IntersectionDetails(graph, weighting));
+
+        for (String pathDetail : requestedPathDetails) {
+            if (!evl.hasEncodedValue(pathDetail)) continue; // path details like "time" won't be found
+
+            EncodedValue ev = evl.getEncodedValue(pathDetail, EncodedValue.class);
+            if (ev instanceof DecimalEncodedValue)
+                builders.add(new DecimalDetails(pathDetail, (DecimalEncodedValue) ev));
+            else if (ev instanceof BooleanEncodedValue)
+                builders.add(new BooleanDetails(pathDetail, (BooleanEncodedValue) ev));
+            else if (ev instanceof EnumEncodedValue)
+                builders.add(new EnumDetails<>(pathDetail, (EnumEncodedValue) ev));
+            else if (ev instanceof StringEncodedValue)
+                builders.add(new StringDetails(pathDetail, (StringEncodedValue) ev));
+            else if (ev instanceof IntEncodedValue)
+                builders.add(new IntDetails(pathDetail, (IntEncodedValue) ev));
+            else throw new IllegalArgumentException("unknown EncodedValue class " + ev.getClass().getName());
         }
 
-        for (String key : Arrays.asList(MaxSpeed.KEY, MaxWidth.KEY, MaxHeight.KEY, MaxWeight.KEY,
-                MaxAxleLoad.KEY, MaxLength.KEY)) {
-            if (requestedPathDetails.contains(key) && evl.hasEncodedValue(key))
-                builders.add(new DecimalDetails(key, evl.getDecimalEncodedValue(key)));
-        }
-
-        if (requestedPathDetails.contains("edge_key")) {
-            builders.add(new EdgeKeyDetails());
-        }
-
-        if (requestedPathDetails.contains("stable_edge_ids")) {
-            builders.add(new StableIdPathDetailsBuilder(evl));
-        }
-
-        for (Map.Entry entry : Arrays.asList(new MapEntry<>(RoadClass.KEY, RoadClass.class),
-                new MapEntry<>(RoadEnvironment.KEY, RoadEnvironment.class), new MapEntry<>(Surface.KEY, Surface.class),
-                new MapEntry<>(RoadAccess.KEY, RoadAccess.class), new MapEntry<>(Toll.KEY, Toll.class),
-                new MapEntry<>(TrackType.KEY, TrackType.class), new MapEntry<>(Hazmat.KEY, Hazmat.class),
-                new MapEntry<>(HazmatTunnel.KEY, HazmatTunnel.class), new MapEntry<>(HazmatWater.KEY, HazmatWater.class),
-                new MapEntry<>(Country.KEY, Country.class))) {
-            String key = (String) entry.getKey();
-            if (requestedPathDetails.contains(key) && evl.hasEncodedValue(key))
-                builders.add(new EnumDetails(key, evl.getEnumEncodedValue(key, (Class<Enum>) entry.getValue())));
-        }
-
-        if (requestedPathDetails.size() != builders.size()) {
-            throw new IllegalArgumentException("You requested the details " + requestedPathDetails + " but we could only find " + builders);
-        }
+        if (requestedPathDetails.size() > builders.size()) {
+            ArrayList<String> clonedArr = new ArrayList<>(requestedPathDetails); // avoid changing request parameter
+            for (PathDetailsBuilder pdb : builders) clonedArr.remove(pdb.getName());
+            throw new IllegalArgumentException("Cannot find the path details: " + clonedArr);
+        } else if (requestedPathDetails.size() < builders.size())
+            throw new IllegalStateException("It should not happen that there are more path details added " + builders + " than requested " + requestedPathDetails);
 
         return builders;
     }

--- a/web-bundle/src/main/java/com/graphhopper/http/GraphHopperManaged.java
+++ b/web-bundle/src/main/java/com/graphhopper/http/GraphHopperManaged.java
@@ -39,6 +39,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class GraphHopperManaged implements Managed {
@@ -75,7 +76,7 @@ public class GraphHopperManaged implements Managed {
     }
 
     // MUST UPDATE EVERY TIME A "GRAPHHOPPER CORE UPDATE" OCCURS
-    // Copied directly from GraphHopperManaged.java on commit 49b0dd189fddd751e5d170e7a741feaa81d4c486
+    // Copied directly from GraphHopperManaged.java on commit 547215973b5b66d082a6adb184f48ae71f790c9d
     public static List<Profile> resolveCustomModelFiles(String customModelFolder, List<Profile> profiles) {
         ObjectMapper jsonOM = Jackson.newObjectMapper();
         List<Profile> newProfiles = new ArrayList<>();
@@ -85,35 +86,45 @@ public class GraphHopperManaged implements Managed {
                 continue;
             }
             Object cm = profile.getHints().getObject("custom_model", null);
+            CustomModel customModel;
             if (cm != null) {
+                if (!profile.getHints().getObject("custom_model_files", Collections.emptyList()).isEmpty())
+                    throw new IllegalArgumentException("Do not use custom_model_files and custom_model together");
                 try {
                     // custom_model can be an object tree (read from config) or an object (e.g. from tests)
-                    CustomModel customModel = jsonOM.readValue(jsonOM.writeValueAsBytes(cm), CustomModel.class);
+                    customModel = jsonOM.readValue(jsonOM.writeValueAsBytes(cm), CustomModel.class);
                     newProfiles.add(new CustomProfile(profile).setCustomModel(customModel));
-                    continue;
                 } catch (Exception ex) {
                     throw new RuntimeException("Cannot load custom_model from " + cm + " for profile " + profile.getName()
-                            + ". If you are trying to load from a file, use 'custom_model_file' instead.", ex);
+                            + ". If you are trying to load from a file, use 'custom_model_files' instead.", ex);
                 }
-            }
-            String customModelFileName = profile.getHints().getString("custom_model_file", "");
-            if (customModelFileName.isEmpty())
-                throw new IllegalArgumentException("Missing 'custom_model' or 'custom_model_file' field in profile '"
-                        + profile.getName() + "'. To use default specify custom_model_file: empty");
-            if ("empty".equals(customModelFileName))
-                newProfiles.add(new CustomProfile(profile).setCustomModel(new CustomModel()));
-            else {
-                if (customModelFileName.contains(File.separator))
-                    throw new IllegalArgumentException("Use custom_model_folder for the custom_model_file parent");
-                if (!customModelFileName.endsWith(".json"))
-                    throw new IllegalArgumentException("Yaml is no longer supported, see #2672. Use JSON with optional comments //");
-                try {
-                    // Somehow dropwizard makes it very hard to find out the folder of config.yml -> use an extra parameter for the folder
-                    String string = Helper.readJSONFileWithoutComments(Paths.get(customModelFolder).resolve(customModelFileName).toFile().getAbsolutePath());
-                    CustomModel customModel = jsonOM.readValue(string, CustomModel.class);
+            } else {
+                if (!profile.getHints().getString("custom_model_file", "").isEmpty())
+                    throw new IllegalArgumentException("Since 8.0 you must use a custom_model_files array instead of custom_model_file string");
+                List<String> customModelFileNames = profile.getHints().getObject("custom_model_files", null);
+                if (customModelFileNames == null)
+                    throw new IllegalArgumentException("Missing 'custom_model' or 'custom_model_files' field in profile '"
+                            + profile.getName() + "'. To use default specify custom_model_files: []");
+                if (customModelFileNames.isEmpty()) {
+                    newProfiles.add(new CustomProfile(profile).setCustomModel(customModel = new CustomModel()));
+                } else {
+                    customModel = new CustomModel();
+                    for (String file : customModelFileNames) {
+                        if (file.contains(File.separator))
+                            throw new IllegalArgumentException("Use custom_models.directory for the custom_model_files parent");
+                        if (!file.endsWith(".json"))
+                            throw new IllegalArgumentException("Yaml is no longer supported, see #2672. Use JSON with optional comments //");
+                        try {
+                            // Somehow dropwizard makes it very hard to find out the folder of config.yml -> use an extra parameter for the folder
+                            String string = Helper.readJSONFileWithoutComments(Paths.get(customModelFolder).
+                                    resolve(file).toFile().getAbsolutePath());
+                            customModel = CustomModel.merge(customModel, jsonOM.readValue(string, CustomModel.class));
+                        } catch (Exception ex) {
+                            throw new RuntimeException("Cannot load custom_model from location " + file + " for profile " + profile.getName(), ex);
+                        }
+                    }
+
                     newProfiles.add(new CustomProfile(profile).setCustomModel(customModel));
-                } catch (Exception ex) {
-                    throw new RuntimeException("Cannot load custom_model from location " + customModelFileName + " for profile " + profile.getName(), ex);
                 }
             }
         }

--- a/web-bundle/src/main/java/com/graphhopper/http/TruckAverageSpeedParser.java
+++ b/web-bundle/src/main/java/com/graphhopper/http/TruckAverageSpeedParser.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright 2014-2023 GraphHopper GmbH.
+ *
+ * NOTICE:  All information contained herein is, and remains the property of
+ * GraphHopper GmbH. The intellectual and technical concepts contained herein
+ * are proprietary to GraphHopper GmbH, and are protected by trade secret
+ * or copyright law. Dissemination of this information or reproduction of
+ * this material is strictly forbidden unless prior written permission
+ * is obtained from GraphHopper GmbH.
+ */
+package com.graphhopper.http;
+
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.DecimalEncodedValue;
+import com.graphhopper.routing.ev.EncodedValueLookup;
+import com.graphhopper.routing.ev.VehicleSpeed;
+import com.graphhopper.routing.util.parsers.CarAverageSpeedParser;
+import com.graphhopper.util.PMap;
+
+import java.util.Map;
+
+
+/**
+ * Truck speed parser with various properties. See truck limits bugs in OSM e.g.
+ * maxheights etc: http://maxheight.bplaced.net/overpass/map.html
+ * <p>
+ *
+ * @author Peter Karich
+ */
+public class TruckAverageSpeedParser extends CarAverageSpeedParser {
+    public static final double EE_CAR_MAX_SPEED = 140;
+    public static final double EE_SMALL_TRUCK_MAX_SPEED = 106;
+    public static final double EE_TRUCK_MAX_SPEED = 96;
+    // Assume 50 for scooter. This is a bit faster than Germany and Austria with 45, but other countries have higher limits...
+    public static final double EE_SCOOTER_SPEED = 50;
+
+    public static final double SMALL_TRUCK_WEIGHT = 2.08 + 1.4;
+
+    // default settings "isCarLike == true"
+    private boolean isHGV = false;
+    private boolean carriesGoods = true;
+    private boolean carriesHazard = false;
+    private boolean isAgricultural = false;
+    private boolean isTaxi = false;
+    private boolean isPSV = false;
+    private double length = 4.5;
+    private double width = 2;
+    private double mirrorWidth = 0;
+    private double height = 2;
+    private double weight = 2.5;
+    private double excludeMaxSpeed;
+    private int axes = 2;
+
+    public TruckAverageSpeedParser(EncodedValueLookup lookup, PMap properties) {
+        this(
+                lookup.getDecimalEncodedValue(VehicleSpeed.key(properties.getString("name", "car"))),
+                properties
+        );
+    }
+
+    public TruckAverageSpeedParser(DecimalEncodedValue speedEnc, PMap properties) {
+        super(speedEnc, speedEnc.getNextStorableValue(properties.getDouble("max_speed", EE_CAR_MAX_SPEED)));
+    }
+
+    public TruckAverageSpeedParser setHeight(double height) {
+        this.height = height;
+        return this;
+    }
+
+    public TruckAverageSpeedParser setLength(double length) {
+        this.length = length;
+        return this;
+    }
+
+    public TruckAverageSpeedParser setWidth(double width, double mirrorWidth) {
+        this.width = width;
+        this.mirrorWidth = mirrorWidth;
+        return this;
+    }
+
+    public TruckAverageSpeedParser setAxes(int axes) {
+        this.axes = axes;
+        return this;
+    }
+
+    /**
+     * Sets the weight of the vehicle including people, equipment and payload in tons
+     */
+    public TruckAverageSpeedParser setWeight(double weight) {
+        this.weight = weight;
+        return this;
+    }
+
+    /**
+     * Sets if this vehicle should be a heavy goods vehicle
+     */
+    public TruckAverageSpeedParser setIsHGV(boolean isHGV) {
+        this.isHGV = isHGV;
+        return this;
+    }
+
+    public boolean isHGV() {
+        return isHGV;
+    }
+
+    public TruckAverageSpeedParser setCarriesGoods(boolean carriesGoods) {
+        this.carriesGoods = carriesGoods;
+        return this;
+    }
+
+    public TruckAverageSpeedParser setCarriesHazard(boolean carriesHazard) {
+        this.carriesHazard = carriesHazard;
+        return this;
+    }
+
+    public TruckAverageSpeedParser setIsAgricultural(boolean isAgricultural) {
+        this.isAgricultural = isAgricultural;
+        return this;
+    }
+
+    public TruckAverageSpeedParser setIsTaxi(boolean isTaxi) {
+        this.isTaxi = isTaxi;
+        this.isPSV = isTaxi;
+        return this;
+    }
+
+    public TruckAverageSpeedParser setExcludeMaxSpeed(double maxSpeed) {
+        excludeMaxSpeed = maxSpeed;
+        return this;
+    }
+
+    public TruckAverageSpeedParser initProperties() {
+        // TODO merge with init somehow?
+        return initProperties(null);
+    }
+
+    /**
+     * This method initialized the speed and the specified speedMap or car
+     * speeds will be used for default speeds. Maps highway tags to speeds.
+     */
+    public TruckAverageSpeedParser initProperties(Map<String, Integer> speedMap) {
+        if (isCarLike()) {
+            trackTypeSpeedMap.clear();
+            trackTypeSpeedMap.put("grade2", 12);
+            trackTypeSpeedMap.put("grade1", 14);
+            trackTypeSpeedMap.put(null, 8);
+
+        } else if (isAgricultural) {
+            defaultSpeedMap.put("forestry", 15);
+            defaultSpeedMap.remove("track");
+        } else {
+            defaultSpeedMap.remove("track");
+        }
+
+        // make width and weight dependent (currently three categories)
+        if (isCarLike()) {
+            // keep values
+        } else if (weight <= 10.0 && width <= 2.7) {
+            // small truck
+            defaultSpeedMap.put("motorway", 90);
+            defaultSpeedMap.put("motorway_link", 75);
+            defaultSpeedMap.put("trunk", 70);
+            defaultSpeedMap.put("trunk_link", 60);
+            defaultSpeedMap.put("primary", 65);
+            defaultSpeedMap.put("primary_link", 60);
+            defaultSpeedMap.put("secondary", 55);
+            defaultSpeedMap.put("secondary_link", 50);
+            defaultSpeedMap.put("tertiary", 30);
+            defaultSpeedMap.put("tertiary_link", 25);
+            defaultSpeedMap.put("unclassified", 25);
+            defaultSpeedMap.put("residential", 20);
+            defaultSpeedMap.put("living_street", 5);
+            defaultSpeedMap.put("service", 15);
+            defaultSpeedMap.put("road", 15);
+        } else {
+            // truck / bus
+            defaultSpeedMap.put("motorway", 80);
+            defaultSpeedMap.put("motorway_link", 75);
+            defaultSpeedMap.put("trunk", 70);
+            defaultSpeedMap.put("trunk_link", 60);
+            defaultSpeedMap.put("primary", 60);
+            defaultSpeedMap.put("primary_link", 55);
+            defaultSpeedMap.put("secondary", 55);
+            defaultSpeedMap.put("secondary_link", 55);
+            defaultSpeedMap.put("tertiary", 20);
+            defaultSpeedMap.put("tertiary_link", 20);
+            defaultSpeedMap.put("unclassified", 20);
+            defaultSpeedMap.put("residential", 15);
+            defaultSpeedMap.put("living_street", 5);
+            defaultSpeedMap.put("service", 10);
+            defaultSpeedMap.put("road", 10);
+        }
+
+        if (speedMap != null) {
+            for (Map.Entry<String, Integer> entry : speedMap.entrySet()) {
+                if (entry.getValue() < 0) {
+                    defaultSpeedMap.remove(entry.getKey());
+                } else {
+                    defaultSpeedMap.put(entry.getKey(), entry.getValue());
+                }
+            }
+        } else {
+            // use car defaults
+        }
+
+        return this;
+    }
+
+    boolean isCarLike() {
+        return weight <= 3.0 && width <= 2 && length < 6;
+    }
+
+    double getDefaultSpeed(String key) {
+        return defaultSpeedMap.get(key);
+    }
+
+    @Override
+    protected double getSpeed(ReaderWay way) {
+        double speed = super.getSpeed(way);
+
+        double boost = 0;
+        if (isPSV) {
+            if (way.hasTag("lanes:psv")) {
+                boost = 4;
+            }
+
+            if (isTaxi && way.hasTag("lanes:taxi")) {
+                boost = 4;
+            }
+        }
+
+        return speed + boost;
+    }
+
+    @Override
+    protected double applyMaxSpeed(ReaderWay way, double speed, boolean bwd) {
+        // pick max speed as it is. reduce it in SpeedModel and not by a constant factor of 0.9 like done in CarFlagEncoder
+        double maxSpeed = getMaxSpeed(way, bwd);
+        if (maxSpeed >= 0) {
+            return Math.max(5, Math.min(maxPossibleSpeed, maxSpeed));
+        }
+        return speed;
+    }
+}

--- a/web-bundle/src/main/java/com/graphhopper/http/TruckFlagEncoder.java
+++ b/web-bundle/src/main/java/com/graphhopper/http/TruckFlagEncoder.java
@@ -19,7 +19,7 @@ public class TruckFlagEncoder {
         BooleanEncodedValue accessEnc = new SimpleBooleanEncodedValue(
                 EncodingManager.getKey(TRUCK_VEHICLE_NAME, "access"), true);
         DecimalEncodedValue speedEnc = new DecimalEncodedValueImpl(
-                EncodingManager.getKey(TRUCK_VEHICLE_NAME, "average_speed"), TRUCK_SPEED_BITS, TRUCK_SPEED_FACTOR, false);
+                EncodingManager.getKey(TRUCK_VEHICLE_NAME, "average_speed"), TRUCK_SPEED_BITS, TRUCK_SPEED_FACTOR, true);
         DecimalEncodedValue turnCostEnc = maxTurnCosts > 0 ? TurnCost.create(TRUCK_VEHICLE_NAME, maxTurnCosts) : null;
         return new VehicleEncodedValues(TRUCK_VEHICLE_NAME, accessEnc, speedEnc, null, turnCostEnc);
     }
@@ -30,7 +30,7 @@ public class TruckFlagEncoder {
         BooleanEncodedValue accessEnc = new SimpleBooleanEncodedValue(
                 EncodingManager.getKey(SMALL_TRUCK_VEHICLE_NAME, "access"), true);
         DecimalEncodedValue speedEnc = new DecimalEncodedValueImpl(
-                EncodingManager.getKey(SMALL_TRUCK_VEHICLE_NAME, "average_speed"), SMALL_TRUCK_SPEED_BITS, TRUCK_SPEED_FACTOR, false);
+                EncodingManager.getKey(SMALL_TRUCK_VEHICLE_NAME, "average_speed"), SMALL_TRUCK_SPEED_BITS, TRUCK_SPEED_FACTOR, true);
         DecimalEncodedValue turnCostEnc = maxTurnCosts > 0 ? TurnCost.create(SMALL_TRUCK_VEHICLE_NAME, maxTurnCosts) : null;
         return new VehicleEncodedValues(SMALL_TRUCK_VEHICLE_NAME, accessEnc, speedEnc, null, turnCostEnc);
     }

--- a/web-bundle/src/main/java/com/graphhopper/replica/ReplicaCustomSpeedsCarTagParser.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/ReplicaCustomSpeedsCarTagParser.java
@@ -3,12 +3,12 @@ package com.graphhopper.replica;
 import com.google.common.collect.ImmutableMap;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.EncodedValueLookup;
-import com.graphhopper.routing.util.CarTagParser;
+import com.graphhopper.routing.util.parsers.CarAverageSpeedParser;
 import com.graphhopper.util.PMap;
 
 import java.util.Objects;
 
-public class ReplicaCustomSpeedsCarTagParser extends CarTagParser {
+public class ReplicaCustomSpeedsCarTagParser extends CarAverageSpeedParser {
     private final ImmutableMap<Long, Double> osmWayIdToMaxSpeed;
 
     public ReplicaCustomSpeedsCarTagParser(EncodedValueLookup lookup, PMap configuration, ImmutableMap<Long, Double> osmWayIdToMaxSpeed) {
@@ -17,11 +17,11 @@ public class ReplicaCustomSpeedsCarTagParser extends CarTagParser {
     }
 
     @Override
-    protected double applyMaxSpeed(ReaderWay way, double speed) {
+    protected double applyMaxSpeed(ReaderWay way, double speed, boolean bwd) {
         // n.b. superclass logic sets max speed to be 90% of the OSM's max speed for the way, but we don't apply the 90%
         // discount for the custom speeds we've been explicitly given
         Double knownMaxSpeed = osmWayIdToMaxSpeed.get(way.getId());
-        return Objects.requireNonNullElseGet(knownMaxSpeed, () -> super.applyMaxSpeed(way, speed));
+        return Objects.requireNonNullElseGet(knownMaxSpeed, () -> super.applyMaxSpeed(way, speed, bwd));
     }
 
     @Override

--- a/web-bundle/src/main/java/com/graphhopper/replica/ReplicaVehicleTagParserFactory.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/ReplicaVehicleTagParserFactory.java
@@ -51,7 +51,7 @@ public class ReplicaVehicleTagParserFactory extends DefaultVehicleTagParserFacto
             // internals to tolerate it
             PMap configWithName = new PMap(configuration).putObject("name", name);
             return new VehicleTagParsers(
-                    new CarAccessParser(lookup, configuration).init(configuration.getObject("date_range_parser", new DateRangeParser())),
+                    new CarAccessParser(lookup, configWithName).init(configWithName.getObject("date_range_parser", new DateRangeParser())),
                     new ReplicaCustomSpeedsCarTagParser(lookup, configWithName, vehicleNameToCustomSpeeds.get(name)),
                     null
             );

--- a/web-bundle/src/main/java/com/graphhopper/replica/ReplicaVehicleTagParserFactory.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/ReplicaVehicleTagParserFactory.java
@@ -19,12 +19,17 @@
 package com.graphhopper.replica;
 
 import com.google.common.collect.ImmutableMap;
+import com.graphhopper.http.TruckAccessParser;
+import com.graphhopper.http.TruckAverageSpeedParser;
 import com.graphhopper.http.TruckFlagEncoder;
-import com.graphhopper.http.TruckTagParser;
+import com.graphhopper.reader.osm.conditional.DateRangeParser;
 import com.graphhopper.routing.ev.EncodedValueLookup;
 import com.graphhopper.routing.util.DefaultVehicleTagParserFactory;
-import com.graphhopper.routing.util.VehicleTagParser;
+import com.graphhopper.routing.util.VehicleTagParsers;
+import com.graphhopper.routing.util.parsers.CarAccessParser;
 import com.graphhopper.util.PMap;
+
+import static com.graphhopper.http.TruckAverageSpeedParser.*;
 
 public class ReplicaVehicleTagParserFactory extends DefaultVehicleTagParserFactory {
     private final ImmutableMap<String, ImmutableMap<Long, Double>> vehicleNameToCustomSpeeds;
@@ -38,22 +43,54 @@ public class ReplicaVehicleTagParserFactory extends DefaultVehicleTagParserFacto
     }
 
     @Override
-    public VehicleTagParser createParser(EncodedValueLookup lookup, String name, PMap configuration) {
+    public VehicleTagParsers createParsers(EncodedValueLookup lookup, String name, PMap configuration) {
         // TODO if we ever want to support custom speeds for vehicles other than car, we'll need to generalize
         // ReplicaCustomSpeedsCarTagParser
         if (vehicleNameToCustomSpeeds.containsKey(name)) {
             // vehicles with custom speeds use nonstandard vehicle names which must be added to the config for the GH
             // internals to tolerate it
             PMap configWithName = new PMap(configuration).putObject("name", name);
-            return new ReplicaCustomSpeedsCarTagParser(lookup, configWithName, vehicleNameToCustomSpeeds.get(name));
+            return new VehicleTagParsers(
+                    new CarAccessParser(lookup, configuration).init(configuration.getObject("date_range_parser", new DateRangeParser())),
+                    new ReplicaCustomSpeedsCarTagParser(lookup, configWithName, vehicleNameToCustomSpeeds.get(name)),
+                    null
+            );
         } else if (name.equals(TruckFlagEncoder.TRUCK_VEHICLE_NAME)) {
             configuration.putObject("block_fords", false);
-            return TruckTagParser.createTruck(lookup, configuration);
+            if (!configuration.has("name"))
+                configuration = new PMap(configuration).putObject("name", "truck");
+            if (!configuration.has("max_speed"))
+                configuration = new PMap(configuration).putObject("max_speed", EE_TRUCK_MAX_SPEED);
+            return new VehicleTagParsers(
+                    new TruckAccessParser(lookup, configuration).
+                            setHeight(3.7).setWidth(2.6, 0.34).setLength(12).
+                            setWeight(13.0 + 13.0).setAxes(3).setIsHGV(true).
+                            initProperties().
+                            init(configuration.getObject("date_range_parser", new DateRangeParser())),
+                    new TruckAverageSpeedParser(lookup, configuration).
+                            setHeight(3.7).setWidth(2.6, 0.34).setLength(12).
+                            setWeight(13.0 + 13.0).setAxes(3).setIsHGV(true).
+                            initProperties(),
+                    null);
         } else if (name.equals(TruckFlagEncoder.SMALL_TRUCK_VEHICLE_NAME)) {
             configuration.putObject("block_fords", false);
-            return TruckTagParser.createSmallTruck(lookup, configuration);
+            if (!configuration.has("name"))
+                configuration = new PMap(configuration).putObject("name", "small_truck");
+            if (!configuration.has("max_speed"))
+                configuration = new PMap(configuration).putObject("max_speed", EE_SMALL_TRUCK_MAX_SPEED);
+            return new VehicleTagParsers(
+                    new TruckAccessParser(lookup, configuration).
+                            setHeight(2.7).setWidth(2, 0.34).setLength(5.5).
+                            setWeight(SMALL_TRUCK_WEIGHT).
+                            initProperties().
+                            init(configuration.getObject("date_range_parser", new DateRangeParser())),
+                    new TruckAverageSpeedParser(lookup, configuration).
+                            setHeight(2.7).setWidth(2, 0.34).setLength(5.5).
+                            setWeight(SMALL_TRUCK_WEIGHT)
+                            .initProperties(),
+                    null);
         }
 
-        return super.createParser(lookup, name, configuration);
+        return super.createParsers(lookup, name, configuration);
     }
 }

--- a/web-bundle/src/main/java/com/graphhopper/replica/StreetEdgeExporter.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/StreetEdgeExporter.java
@@ -145,10 +145,10 @@ public class StreetEdgeExporter {
             String mode = ACCESSIBILITY_MODE_MAP.getOrDefault(vehicle, null);
             if (mode != null) {
                 BooleanEncodedValue access = encodingManager.getBooleanEncodedValue(VehicleAccess.key(vehicle));
-                if (access.getBool(false, edgeFlags)) {
+                if (access.getBool(false, ghEdgeId, new IntsRefEdgeIntAccess(edgeFlags))) {
                     forwardFlags.add("ALLOWS_" + mode);
                 }
-                if (access.getBool(true, edgeFlags)) {
+                if (access.getBool(true, ghEdgeId, new IntsRefEdgeIntAccess(edgeFlags))) {
                     backwardFlags.add("ALLOWS_" + mode);
                 }
             }

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-core</artifactId>
-            <version>2.0.8</version>
+            <version>2.1.6</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard-bundles</groupId>

--- a/web/src/test/java/com/replica/RouterServerTest.java
+++ b/web/src/test/java/com/replica/RouterServerTest.java
@@ -67,7 +67,7 @@ public class RouterServerTest extends ReplicaGraphHopperTest {
     private static final double[] REQUEST_ORIGIN_2 = {38.59337420024281,-121.48746937746185}; // Sacramento area
     private static final double[] REQUEST_ORIGIN_3 = {38.508810062393245,-121.5085223084316}; // South of Sacramento area
     private static final double[] REQUEST_DESTINATION_1 = {38.55518457319914,-121.43714698730038}; // Sacramento area
-    private static final double[] REQUEST_DESTINATION_2 = {38.64478548196401,-121.34168802760543}; // North of Sacramento area
+    private static final double[] REQUEST_DESTINATION_2 = {38.62099864518184,-121.51902571320535}; // North of Sacramento area
 
     // Should force a transfer between routes from 2 distinct feeds
     private static final RouterOuterClass.PtRouteRequest PT_REQUEST_DIFF_FEEDS = createPtRequest(REQUEST_ORIGIN_1, REQUEST_DESTINATION_1);
@@ -174,13 +174,14 @@ public class RouterServerTest extends ReplicaGraphHopperTest {
                 .setEarliestDepartureTime(EARLIEST_DEPARTURE_TIME)
                 .setLimitSolutions(4)
                 .setMaxProfileDuration(10)
-                .setBetaWalkTime(1.5)
                 .setLimitStreetTimeSeconds(1440)
                 .setUsePareto(false)
                 .setBetaTransfers(1440000)
                 .setMaxVisitedNodes(1000000)
                 .setAccessMode(accessMode)
                 .setEgressMode(egressMode)
+                .setBetaAccessTime(1.5)
+                .setBetaEgressTime(1.5)
                 .build();
     }
 
@@ -237,11 +238,11 @@ public class RouterServerTest extends ReplicaGraphHopperTest {
         expectedModeCounts.put("car", 1);
         expectedModeCounts.put("foot", 2);
 
-        // Expected route is [car access -> transit -> transfer -> transit -> transit (no transfer) -> walk egress]
-        checkTransitQuery(response, 3, 3,
+        // Expected route is [car access -> transit -> transfer -> transit -> walk egress]
+        checkTransitQuery(response, 2, 3,
                 Lists.newArrayList("ACCESS", "TRANSFER", "EGRESS"),
                 expectedModeCounts,
-                Lists.newArrayList(60, 102, 4, 243, 83, 11)
+                Lists.newArrayList(60, 161, 2, 19, 18)
         );
     }
 
@@ -251,7 +252,7 @@ public class RouterServerTest extends ReplicaGraphHopperTest {
                                    Map<String, Integer> expectedModeCounts,
                                    List<Integer> expectedStableEdgeIdCount) {
         // Check details of Path are set correctly
-        assertEquals(1, response.getPathsList().size());
+        assertTrue(response.getPathsList().size() >= 1);
         RouterOuterClass.PtPath path = response.getPaths(0);
         List<RouterOuterClass.PtLeg> streetLegs = path.getLegsList().stream()
                 .filter(l -> !l.hasTransitMetadata()).collect(Collectors.toList());


### PR DESCRIPTION
https://replicahq.atlassian.net/browse/RAD-6244

Updates our GH version in order to pull in the new beta access/egress transit routing parameters, and updates all replica-specific server + GUI code to accommodate the new knobs.

Most of the edits to files in the `replica-common` submodule came from copy/pasting relevant sections of files from graphhopper master @ 547215973b5b66d082a6adb184f48ae71f790c9d (the new commit we're pointing to). I did my best to go through and comment explanations for most of the other relevant edits as well.

----

Example of new parameters working, via the GUI: 

Before:
![Screen Shot 2023-05-22 at 2 36 54 PM](https://github.com/replicahq/graphhopper/assets/13446427/4d4823e4-1b28-4cda-a0fd-ddb45a6fbf3b)

After:
![Screen Shot 2023-05-22 at 2 37 22 PM](https://github.com/replicahq/graphhopper/assets/13446427/baffb3ec-1b4b-49e1-8243-571360886aee)


cc @alexeisw @bnaul