### PR TITLE
Add unit test for setting custom speeds to zero

### DIFF
--- a/configs/test_gh_config.yaml
+++ b/configs/test_gh_config.yaml
@@ -36,6 +36,11 @@ graphhopper:
       weighting: fastest
       # sets a very high speed for Thurton Drive in Roseville (OSM way id 10485465)
       custom_speed_file: test-data/custom_speeds/custom_fast_thurton_drive_speed.csv # mvn tests run from the /web folder
+    - name: car_custom_closed_baseline_road
+      vehicle: car_custom_closed_baseline_road
+      weighting: fastest
+      # sets a zero speed for a section of Baseline Road in Roseville (OSM way id 76254223)
+      custom_speed_file: test-data/custom_speeds/baseline_road_zero_speed.csv # mvn tests run from the /web folder
     - name: bike
       vehicle: bike
       weighting: fastest
@@ -54,6 +59,7 @@ graphhopper:
     - profile: car
     - profile: car_freeway
     - profile: car_custom_fast_thurton_drive
+    - profile: car_custom_closed_baseline_road
     - profile: bike
     - profile: foot
     - profile: truck

--- a/web/test-data/custom_speeds/baseline_road_zero_speed.csv
+++ b/web/test-data/custom_speeds/baseline_road_zero_speed.csv
@@ -1,0 +1,2 @@
+osm_way_id,max_speed_kph
+76254223,0


### PR DESCRIPTION
Scenario sets custom speeds to zero to simulate road closures. As we mature and harden Scenario road closures, I wanted to add a unit test router-side to ensure we don't accidentally regress this behavior, especially during Graphhopper core updates. This PR creates a new profile which sets a custom speed to zero to close part of a road, and adds a unit test which routes from shortly before the closure to shortly after. The test ensures the road closure profile takes a non-direct route.

If you're curious, here's a screenshot of the way being closed:
<img width="778" alt="close baseline road custom speed zero" src="https://github.com/replicahq/graphhopper/assets/112983365/4b4219d8-7f6f-4da0-92de-f9e25b54e322">


To sanity check the routes generated in the unit test, I also plotted the the default car profile's route (red) and the closed road profile's route (green) in a [4sq map](https://studio.foursquare.com/map/67e08f59-4e68-44e4-8280-47ba13f49a76):
<img width="1128" alt="unit test routes" src="https://github.com/replicahq/graphhopper/assets/112983365/6cfced16-8276-474d-8fec-5cc16cb0ef0e">

(The default route and closed road route have the same start and end, but the red line is on top of the green line so you can't see that part unless you hide the default route)


cc @emling @rregue 
