### PR TITLE
Resize map window around existing route upon refresh

### DIFF
--- a/grpc/src/main/resources/assets/pt/src/view/App.js
+++ b/grpc/src/main/resources/assets/pt/src/view/App.js
@@ -52,14 +52,21 @@ export default class App extends React.Component {
     componentDidMount() {
         var router = new Router.RouterClient('/api');
         var component = this;
+
+        // Set bounds of bbox based on start/end of current route,
+        // or result of info() endpoint if no route is currently requested
         router.info(new Router.InfoRequest(), null, function(err, response) {
             if (err) {
-                console.log("Error in Webrequest. Code: " + err.code)
+                console.log("Error in Webrequest. Code: " + err.code);
+            } else if (component.state.from != null && component.state.to != null) {
+                component.setState({info: {
+                    bbox: [component.state.from.long, component.state.from.lat, component.state.to.long, component.state.to.lat]
+                }});
             } else {
-                console.log(response.toObject())
+                console.log(response.toObject());
                 component.setState({info: {
                     bbox: response.getBboxList()
-                }})
+                }});
             }
         });
     }

--- a/grpc/src/main/resources/assets/pt/src/view/App.js
+++ b/grpc/src/main/resources/assets/pt/src/view/App.js
@@ -55,20 +55,22 @@ export default class App extends React.Component {
 
         // Set bounds of bbox based on start/end of current route,
         // or result of info() endpoint if no route is currently requested
-        router.info(new Router.InfoRequest(), null, function(err, response) {
-            if (err) {
-                console.log("Error in Webrequest. Code: " + err.code);
-            } else if (component.state.from != null && component.state.to != null) {
-                component.setState({info: {
-                    bbox: [component.state.from.long, component.state.from.lat, component.state.to.long, component.state.to.lat]
-                }});
-            } else {
-                console.log(response.toObject());
-                component.setState({info: {
-                    bbox: response.getBboxList()
-                }});
-            }
-        });
+        if (component.state.from != null && component.state.to != null) {
+            component.setState({info: {
+                bbox: [component.state.from.long, component.state.from.lat, component.state.to.long, component.state.to.lat]
+            }});
+        } else {
+            router.info(new Router.InfoRequest(), null, function(err, response) {
+                if (err) {
+                    console.log("Error in Webrequest. Code: " + err.code);
+                } else {
+                    console.log(response.toObject());
+                    component.setState({info: {
+                        bbox: response.getBboxList()
+                    }});
+                }
+            });
+        }
     }
 
     componentDidUpdate(prevProps, prevState) {

--- a/grpc/src/main/resources/assets/pt/src/view/map/Map.js
+++ b/grpc/src/main/resources/assets/pt/src/view/map/Map.js
@@ -61,9 +61,6 @@ class LeafletComponent extends React.Component {
       iconSize: 10
     }));
     let bbox = this.props.info.bbox;
-    if (this.props.from != null && this.props.to != null) {
-        bbox = [this.props.from.long, this.props.from.lat, this.props.to.long, this.props.to.lat];
-    }
     console.log(bbox);
     this.map.fitBounds(Leaflet.latLngBounds(Leaflet.latLng(bbox[1], bbox[0]), Leaflet.latLng(bbox[3], bbox[2])), {padding: [50, 50]});
     this.map.on('click', e => this.props.onSubmit((prevState) => {

--- a/grpc/src/main/resources/assets/pt/src/view/map/Map.js
+++ b/grpc/src/main/resources/assets/pt/src/view/map/Map.js
@@ -61,8 +61,11 @@ class LeafletComponent extends React.Component {
       iconSize: 10
     }));
     let bbox = this.props.info.bbox;
-    console.log(bbox)
-    this.map.fitBounds(Leaflet.latLngBounds(Leaflet.latLng(bbox[1], bbox[0]), Leaflet.latLng(bbox[3], bbox[2])));
+    if (this.props.from != null && this.props.to != null) {
+        bbox = [this.props.from.long, this.props.from.lat, this.props.to.long, this.props.to.lat];
+    }
+    console.log(bbox);
+    this.map.fitBounds(Leaflet.latLngBounds(Leaflet.latLng(bbox[1], bbox[0]), Leaflet.latLng(bbox[3], bbox[2])), {padding: [50, 50]});
     this.map.on('click', e => this.props.onSubmit((prevState) => {
       if (prevState.from === null) return {from: Point.createFromArray([e.latlng.lat, e.latlng.lng])};
       else if (prevState.to === null) return {to: Point.createFromArray([e.latlng.lat, e.latlng.lng])};


### PR DESCRIPTION
When working on the side-by-side router GUI tool, I found that when you refresh the transit routing GUI with a route already plugged in, the zoom for the map resets to the complete region, instead of focusing in on the area around the route.

This updates the logic in the GUI to do just that. Upon creation of the map layer, the new logic detects if a route start/end point has been selected, and if so, centers the bbox of the map around that route (with a small padding).

I tested this in action in my branch for the side-by-side GUI tool. 

The old behavior:

https://github.com/replicahq/graphhopper/assets/13446427/20f6fd1f-88c6-427b-9d90-aaa429fc75ec

The new behavior:


https://github.com/replicahq/graphhopper/assets/13446427/d720d5b3-c41d-4198-843a-1fa59f423aa3
