### PR TITLE
Display query time in transit routing GUI

### DIFF
--- a/grpc/src/main/resources/assets/pt/src/view/App.js
+++ b/grpc/src/main/resources/assets/pt/src/view/App.js
@@ -114,6 +114,7 @@ export default class App extends React.Component {
 
                     var component = this;
                     var router = new Router.RouterClient('/api');
+                    const startTime = Date.now();
                     router.routePt(ptRouteRequest, null, function(err, response) {
                         if (err) {
                             console.log(err);
@@ -130,13 +131,15 @@ export default class App extends React.Component {
                                 console.log(response.toObject());
                                 const paths = response.getPathsList().map(path => new Path(path));
                                 const selectedPath = component._selectPathOnReceive(paths);
+                                const queryTimeSeconds = (Date.now() - startTime) * 1.0 / 1000;
                                 return {
                                     routes: {
                                         query: query,
                                         paths: paths,
                                         isLastQuerySuccess: true,
                                         isFetching: false,
-                                        selectedRouteIndex: selectedPath
+                                        selectedRouteIndex: selectedPath,
+                                        queryTimeSeconds: queryTimeSeconds
                                     }
                                 };
                             });

--- a/grpc/src/main/resources/assets/pt/src/view/App.js
+++ b/grpc/src/main/resources/assets/pt/src/view/App.js
@@ -126,12 +126,12 @@ export default class App extends React.Component {
                                 }
                             });
                         } else {
+                            const queryTimeSeconds = (Date.now() - startTime) * 1.0 / 1000;
                             component.setState(prevState => {
                                 if (CreateQuery(new URL("/route", window.location), prevState) !== query) return {}; // This reply is not what we want to know anymore
                                 console.log(response.toObject());
                                 const paths = response.getPathsList().map(path => new Path(path));
                                 const selectedPath = component._selectPathOnReceive(paths);
-                                const queryTimeSeconds = (Date.now() - startTime) * 1.0 / 1000;
                                 return {
                                     routes: {
                                         query: query,

--- a/grpc/src/main/resources/assets/pt/src/view/sidebar/Sidebar.js
+++ b/grpc/src/main/resources/assets/pt/src/view/sidebar/Sidebar.js
@@ -45,7 +45,7 @@ export default (({
       }),
       React.createElement("div", {
         className: "searchInput"
-      }, React.createElement("span", null, `${routes.queryTimeSeconds != null ? `Query Time: ${routes.queryTimeSeconds}` : ""}`)),
+      }, React.createElement("span", null, `${routes.queryTimeSeconds != null ? `Query Time: ${routes.queryTimeSeconds} seconds` : ""}`)),
       getSidebarContent(routes)
   );
 });

--- a/grpc/src/main/resources/assets/pt/src/view/sidebar/Sidebar.js
+++ b/grpc/src/main/resources/assets/pt/src/view/sidebar/Sidebar.js
@@ -36,11 +36,18 @@ export default (({
   }
 
   return React.createElement("div", {
-    className: "sidebar"
-  }, React.createElement(Logo, null), React.createElement(SearchInput, {
-    search: search,
-    onSearchChange: onSearchChange
-  }), getSidebarContent(routes));
+        className: "sidebar"
+      },
+      React.createElement(Logo, null),
+      React.createElement(SearchInput, {
+        search: search,
+        onSearchChange: onSearchChange
+      }),
+      React.createElement("div", {
+        className: "searchInput"
+      }, React.createElement("span", null, `${routes.queryTimeSeconds != null ? `Query Time: ${routes.queryTimeSeconds}` : ""}`)),
+      getSidebarContent(routes)
+  );
 });
 
 const Logo = () => {


### PR DESCRIPTION
Updates the transit routing GUI to show a query time in seconds for routes that were found successfully. Tested locally, see how it works below!



https://github.com/replicahq/graphhopper/assets/13446427/214dfc7f-e376-44bd-81f5-77654978af6c




cc @alexeisw 