### PR TITLE
Update base image for server docker build

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -2,7 +2,7 @@ ARG BASE_IMAGE
 FROM $BASE_IMAGE as base
 
 # copy over JARs + web assets + config YAMLs for running server
-FROM openjdk:14.0.2-jdk-slim-buster
+FROM sapmachine:17.0.9-ubuntu-jammy
 
 RUN mkdir -p /data
 WORKDIR /graphhopper


### PR DESCRIPTION
More background at https://replicahq.slack.com/archives/C03AMSR3SCA/p1698246482296919

The street export task in TN CDP builds starting failing recently due to an incompatible Python version ([example logs](https://console.cloud.google.com/cloud-build/builds;region=global/54569beb-4d05-4f60-9d66-d9b332db5cee?project=model-159019)). The build installed Python 3.7, but the gcloud installation step couldn't find the Python install. The last successful build before we started getting these failures [warned](https://cloudlogging.app.goo.gl/AgcY2mmjx42EY1D98) `Python 3.7.x is no longer officially supported by the Google Cloud CLI and may not function correctly. Please use Python version 3.8 and up.`. 

I tried updating the street export's Dockerfile to explicitly install Python 3.8 or 3.10, but these versions can't be installed via apt on the docker container's linux OS. The OS version is too old. I also tried to have the build install Python manually rather than via apt against this old OS following some [Stackoverflow instructions](https://stackoverflow.com/questions/62830862/how-to-install-python3-8-on-debian-10), but I hit compilation issues while trying these out in a docker container I ran locally from the same image. I then tried bumping the [`remote-builder` docker image that we use to perform the docker build](https://github.com/replicahq/model/blob/deb57ae52d61d073972c5e096bec1102c7cf3eae/routerbuilder/graphhopper_street_edge_export_build.yaml#L2), but this didn't work either. The `remote-builder` docker container runs the build, but the build itself uses the [Graphhopper server docker image](https://github.com/replicahq/model/blob/6dd4a7e4d5e504fc9e6b5097c76335827d36b49c/routerbuilder/graphhopper_builder.py#L314) as the [base image](https://github.com/replicahq/model/blob/6dd4a7e4d5e504fc9e6b5097c76335827d36b49c/routerbuilder/Dockerfile.export#L1-L2). We need to make this Graphhopper server docker image compatible with Python 3.8+.

This PR bumps the base image we use for the Graphhopper server docker image, since this base image ultimately determines the OS and Python compatibility of the Graphhopper image. The `openjdk` base image we used previously is three years old, and all versions of `openjdk` have since been [deprecated](https://hub.docker.com/_/openjdk), so it's not surprising we're hitting issues. The deprecation notice recommends several replacements. I tried a couple and selected `sapmachine` since it appears actively maintained and I was able to locally confirm the new image is compatible with Python 3.8+ (even better, it installs Python 3.10 by default). None of the alternatives had Java 14 images available (I think because Java 17 is a Long-Term Support Java version whereas Java 14 is not), so we are now using a Java 17 JVM instead of a Java 14 JVM. I don't think this should change anything, though - we still [compile with Java 14](https://github.com/replicahq/graphhopper/blob/d07daaa2dc61d3d93d24c1f8207866111c1dc56f/pom.xml#L13), but we now run against Java 17. [Java supports this sort of backwards-compatibility.](https://stackoverflow.com/a/75977557)

I plugged in this new Graphhoper server image into the TN CDP on my testing branch at https://github.com/replicahq/model/pull/7946, and the FT now passes. I also ran the GH functional test against this branch, and it [passed](https://github.com/replicahq/graphhopper/actions/runs/6657162920). After this merges and gets tagged, I think we should update `graphhopper_runner_image_tag` and `graphhopper_builder_image_tag` for all seasons to use this new version.

Strangely, the TN CDP FT builds off master started succeeding this morning ([example gcloud builds link](https://console.cloud.google.com/cloud-build/builds;region=global/16d88f0b-80a0-4667-9dc4-a390bb2dd2a5?project=model-159019)). The `Python 3.7.x is no longer officially supported by the Google Cloud CLI and may not function correctly. Please use Python version 3.8 and up.` is back, but the build now succeeds - I think Google changed something on their side to give Python 3.7 a little more time? Either way, continuing to use Python 3.7 for these builds seems fragile and could easily break, so I still think we should proceed with this change. The 3.7 warnings no longer appear for the FT I ran using this newer server container ([gcloud build logs](https://console.cloud.google.com/cloud-build/builds;region=global/f1234b4b-d282-4d6f-bfde-b6a5c199c5d9?project=model-159019)).