### PR TITLE
Support custom speeds for truck and small_truck vehicles

### DIFF
--- a/configs/test_gh_config.yaml
+++ b/configs/test_gh_config.yaml
@@ -47,12 +47,22 @@ graphhopper:
     - name: foot
       vehicle: foot
       weighting: fastest
-    - name: truck
+    - name: truck_default # needed for comparison against Thurton Drive custom speeds profile
       vehicle: truck
       weighting: fastest
-    - name: small_truck
+    - name: truck_custom_fast_thurton_drive
+      vehicle: truck_custom_fast_thurton_drive
+      weighting: fastest
+      # sets a very high speed for Thurton Drive in Roseville (OSM way id 10485465)
+      custom_speed_file: test-data/custom_speeds/custom_fast_thurton_drive_speed.csv # mvn tests run from the /web folder
+    - name: small_truck_default # needed for comparison against Thurton Drive custom speeds profile
       vehicle: small_truck
       weighting: fastest
+    - name: small_truck_custom_fast_thurton_drive
+      vehicle: small_truck_custom_fast_thurton_drive
+      weighting: fastest
+      # sets a very high speed for Thurton Drive in Roseville (OSM way id 10485465)
+      custom_speed_file: test-data/custom_speeds/custom_fast_thurton_drive_speed.csv # mvn tests run from the /web folder
 
   profiles_ch:
     - profile: car_default
@@ -62,8 +72,10 @@ graphhopper:
     - profile: car_custom_closed_baseline_road
     - profile: bike
     - profile: foot
-    - profile: truck
-    - profile: small_truck
+    - profile: truck_default
+    - profile: truck_custom_fast_thurton_drive
+    - profile: small_truck_default
+    - profile: small_truck_custom_fast_thurton_drive
 
 server:
   min_threads: 4

--- a/grpc/src/main/java/com/replica/util/RouterConverters.java
+++ b/grpc/src/main/java/com/replica/util/RouterConverters.java
@@ -6,6 +6,7 @@ import com.google.common.collect.Sets;
 import com.google.protobuf.Timestamp;
 import com.graphhopper.GHRequest;
 import com.graphhopper.ResponsePath;
+import com.graphhopper.RouterConstants;
 import com.graphhopper.Trip;
 import com.graphhopper.gtfs.Request;
 import com.graphhopper.jackson.Jackson;

--- a/replica-common/src/main/java/com/graphhopper/RouterConstants.java
+++ b/replica-common/src/main/java/com/graphhopper/RouterConstants.java
@@ -1,4 +1,4 @@
-package com.replica.util;
+package com.graphhopper;
 
 import com.google.common.collect.Sets;
 
@@ -9,6 +9,10 @@ public final class RouterConstants {
     private RouterConstants() {
         // utility class
     }
+
+    public static final String CAR_VEHICLE_NAME = "car";
+    public static final String TRUCK_VEHICLE_NAME = "truck";
+    public static final String SMALL_TRUCK_VEHICLE_NAME = "small_truck";
 
     public static final Set<Integer> STREET_BASED_ROUTE_TYPES = Sets.newHashSet(0, 3, 5);
 }

--- a/replica-common/src/main/java/com/graphhopper/customspeeds/CustomSpeedsVehicle.java
+++ b/replica-common/src/main/java/com/graphhopper/customspeeds/CustomSpeedsVehicle.java
@@ -7,6 +7,7 @@ import java.util.EnumSet;
 import java.util.Objects;
 
 public class CustomSpeedsVehicle {
+    // TODO support custom speeds for bikes and pedestrians (RAD-6445, RAD-6446)
     public enum VehicleType {
         CAR,
         TRUCK,

--- a/replica-common/src/main/java/com/graphhopper/customspeeds/CustomSpeedsVehicle.java
+++ b/replica-common/src/main/java/com/graphhopper/customspeeds/CustomSpeedsVehicle.java
@@ -1,0 +1,55 @@
+package com.graphhopper.customspeeds;
+
+import com.google.common.collect.ImmutableMap;
+import com.graphhopper.RouterConstants;
+
+import java.util.EnumSet;
+import java.util.Objects;
+
+public class CustomSpeedsVehicle {
+    public enum VehicleType {
+        CAR,
+        TRUCK,
+        SMALL_TRUCK,
+    }
+
+    public final VehicleType baseVehicleType;
+    public final String customVehicleName;
+    public final ImmutableMap<Long, Double> osmWayIdToCustomSpeed;
+
+    private CustomSpeedsVehicle(String customVehicleName, VehicleType baseVehicleType, ImmutableMap<Long, Double> osmWayIdToCustomSpeed) {
+        this.customVehicleName = customVehicleName;
+        this.baseVehicleType = baseVehicleType;
+        this.osmWayIdToCustomSpeed = osmWayIdToCustomSpeed;
+    }
+
+    public static CustomSpeedsVehicle create(String customVehicleName, ImmutableMap<Long, Double> osmWayIdToCustomSpeed) {
+        return new CustomSpeedsVehicle(customVehicleName, CustomSpeedsVehicle.getBaseVehicleType(customVehicleName), osmWayIdToCustomSpeed);
+    }
+
+    private static CustomSpeedsVehicle.VehicleType getBaseVehicleType(String customVehicleName) {
+        if (customVehicleName.startsWith(RouterConstants.CAR_VEHICLE_NAME)) {
+            return CustomSpeedsVehicle.VehicleType.CAR;
+        }
+        if (customVehicleName.startsWith(RouterConstants.TRUCK_VEHICLE_NAME)) {
+            return CustomSpeedsVehicle.VehicleType.TRUCK;
+        }
+        if (customVehicleName.startsWith(RouterConstants.SMALL_TRUCK_VEHICLE_NAME)) {
+            return CustomSpeedsVehicle.VehicleType.SMALL_TRUCK;
+        }
+        throw new IllegalArgumentException("Could not determine base vehicle type for custom speeds vehicle " + customVehicleName + ". Supported base vehicle types: " + EnumSet.allOf(CustomSpeedsVehicle.VehicleType.class));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CustomSpeedsVehicle that = (CustomSpeedsVehicle) o;
+        return baseVehicleType == that.baseVehicleType && customVehicleName.equals(that.customVehicleName) && osmWayIdToCustomSpeed.equals(that.osmWayIdToCustomSpeed);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(baseVehicleType, customVehicleName, osmWayIdToCustomSpeed);
+    }
+}

--- a/replica-common/src/test/java/com/graphhopper/customspeeds/CustomSpeedsUtilsTest.java
+++ b/replica-common/src/test/java/com/graphhopper/customspeeds/CustomSpeedsUtilsTest.java
@@ -12,32 +12,37 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 
 public class CustomSpeedsUtilsTest {
+    private static final ImmutableMap<Long, Double> TEST_CUSTOM_SPEEDS = ImmutableMap.of(1L, 2.0, 3L, 4.0, 123L, 456.789);
+    private static final ImmutableMap<Long, Double> FAST_THRUTON_DRIVE_SPEEDS = ImmutableMap.of(10485465L, 1000.0);
 
     @Test
-    public void testGetVehicleNameToCustomSpeeds() {
+    public void testGetCustomSpeedVehiclesByName() {
         List<Profile> profiles = ImmutableList.of(
                 createProfile("prof1", "car", null),
-                createProfile("prof2", "car_prof2", "../web/test-data/custom_speeds/test_custom_speeds.csv"),
-                createProfile("prof3", "car_prof3", "../web/test-data/custom_speeds/custom_fast_thurton_drive_speed.csv")
+                createProfile("prof2", "car_custom", "../web/test-data/custom_speeds/test_custom_speeds.csv"),
+                createProfile("prof3", "car_custom_2", "../web/test-data/custom_speeds/custom_fast_thurton_drive_speed.csv"),
+                createProfile("prof4", "truck", "../web/test-data/custom_speeds/custom_fast_thurton_drive_speed.csv"),
+                createProfile("prof5", "small_truck", "../web/test-data/custom_speeds/test_custom_speeds.csv")
         );
-        ImmutableMap<String, ImmutableMap<Long, Double>> vehicleNameToCustomSpeeds =
-                CustomSpeedsUtils.getVehicleNameToCustomSpeeds(profiles);
-        ImmutableMap<String, ImmutableMap<Long, Double>> expectedVehicleNameToCustomSpeeds = ImmutableMap.of(
-                "car_prof2", ImmutableMap.of(1L, 2.0, 3L, 4.0, 123L, 456.789),
-                "car_prof3", ImmutableMap.of(10485465L, 1000.0)
-        );
-        assertEquals(expectedVehicleNameToCustomSpeeds, vehicleNameToCustomSpeeds);
+        ImmutableMap<String, CustomSpeedsVehicle> customSpeedVehiclesByName =
+                CustomSpeedsUtils.getCustomSpeedVehiclesByName(profiles);
+        ImmutableMap<String, CustomSpeedsVehicle> expectedCustomSpeedVehiclesByName = ImmutableMap.of(
+                "car_custom", CustomSpeedsVehicle.create("car_custom", TEST_CUSTOM_SPEEDS),
+                "car_custom_2", CustomSpeedsVehicle.create("car_custom_2", FAST_THRUTON_DRIVE_SPEEDS),
+                "truck", CustomSpeedsVehicle.create("truck", FAST_THRUTON_DRIVE_SPEEDS),
+                "small_truck", CustomSpeedsVehicle.create("small_truck", TEST_CUSTOM_SPEEDS));
+        assertEquals(expectedCustomSpeedVehiclesByName, customSpeedVehiclesByName);
     }
 
     @Test
-    public void testGetVehicleNameToCustomSpeedsUniqueVehicleName() {
+    public void testGetCustomSpeedVehiclesByNameUniqueVehicleNames() {
         // each vehicle may only be associated with one custom speed file
         List<Profile> invalidProfiles = ImmutableList.of(
                 createProfile("prof1", "car_custom_speeds", "../web/test-data/custom_speeds/test_custom_speeds.csv"),
                 createProfile("prof2", "car_custom_speeds", "../web/test-data/custom_speeds/custom_fast_thurton_drive_speed.csv")
         );
         assertThrows(IllegalArgumentException.class, () ->
-                CustomSpeedsUtils.getVehicleNameToCustomSpeeds(invalidProfiles));
+                CustomSpeedsUtils.getCustomSpeedVehiclesByName(invalidProfiles));
 
         // vehicle/custom speed file pairing must be consistent
         List<Profile> invalidProfiles2 = ImmutableList.of(
@@ -45,19 +50,35 @@ public class CustomSpeedsUtilsTest {
                 createProfile("prof2", "car_custom_speeds", null)
         );
         assertThrows(IllegalArgumentException.class, () ->
-                CustomSpeedsUtils.getVehicleNameToCustomSpeeds(invalidProfiles2));
+                CustomSpeedsUtils.getCustomSpeedVehiclesByName(invalidProfiles2));
 
         // vehicle can be reused between profiles if it has the same custom speed file
         List<Profile> validProfiles = ImmutableList.of(
                 createProfile("prof1", "car_custom_speeds", "../web/test-data/custom_speeds/custom_fast_thurton_drive_speed.csv"),
                 createProfile("prof2", "car_custom_speeds", "../web/test-data/custom_speeds/custom_fast_thurton_drive_speed.csv")
         );
-        ImmutableMap<String, ImmutableMap<Long, Double>> vehicleNameToCustomSpeeds =
-                CustomSpeedsUtils.getVehicleNameToCustomSpeeds(validProfiles);
-        ImmutableMap<String, ImmutableMap<Long, Double>> expectedVehicleNameToCustomSpeeds = ImmutableMap.of(
-                "car_custom_speeds", ImmutableMap.of(10485465L, 1000.0)
+        ImmutableMap<String, CustomSpeedsVehicle> customSpeedVehiclesByName =
+                CustomSpeedsUtils.getCustomSpeedVehiclesByName(validProfiles);
+        ImmutableMap<String, CustomSpeedsVehicle> expectedCustomSpeedVehiclesByName = ImmutableMap.of(
+                "car_custom_speeds", CustomSpeedsVehicle.create("car_custom_speeds", FAST_THRUTON_DRIVE_SPEEDS));
+        assertEquals(expectedCustomSpeedVehiclesByName, customSpeedVehiclesByName);
+    }
+
+    @Test
+    public void testGetCustomSpeedVehiclesByNameUnsupportedBaseVehicle() {
+        // custom speeds only currently support cars/trucks/small_trucks
+        List<Profile> invalidProfiles = ImmutableList.of(
+                createProfile("prof1", "bike_custom", "../web/test-data/custom_speeds/test_custom_speeds.csv")
         );
-        assertEquals(expectedVehicleNameToCustomSpeeds, vehicleNameToCustomSpeeds);
+        assertThrows(IllegalArgumentException.class, () ->
+                CustomSpeedsUtils.getCustomSpeedVehiclesByName(invalidProfiles));
+
+        // custom vehicle name must have base vehicle as prefix
+        List<Profile> invalidProfiles2 = ImmutableList.of(
+                createProfile("prof1", "custom_car", "../web/test-data/custom_speeds/test_custom_speeds.csv")
+        );
+        assertThrows(IllegalArgumentException.class, () ->
+                CustomSpeedsUtils.getCustomSpeedVehiclesByName(invalidProfiles2));
     }
 
     private static Profile createProfile(String profileName, String vehicleName, @Nullable String customSpeedsFilePath) {

--- a/web-bundle/src/main/java/com/graphhopper/http/GraphHopperManaged.java
+++ b/web-bundle/src/main/java/com/graphhopper/http/GraphHopperManaged.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableMap;
 import com.graphhopper.*;
 import com.graphhopper.config.Profile;
 import com.graphhopper.customspeeds.CustomSpeedsUtils;
+import com.graphhopper.customspeeds.CustomSpeedsVehicle;
 import com.graphhopper.jackson.Jackson;
 import com.graphhopper.replica.ReplicaVehicleEncodedValuesFactory;
 import com.graphhopper.replica.ReplicaVehicleTagParserFactory;
@@ -62,13 +63,13 @@ public class GraphHopperManaged implements Managed {
 
         // we read all custom speeds mappings into memory so they can be efficiently applied during OSM import. each
         // custom speed file should be <= 250 MB (nationwide speed mapping file is 235MB)
-        ImmutableMap<String, ImmutableMap<Long, Double>> vehicleNameToCustomSpeeds =
-                CustomSpeedsUtils.getVehicleNameToCustomSpeeds(configuration.getProfiles());
+        ImmutableMap<String, CustomSpeedsVehicle> customSpeedsVehiclesByName =
+                CustomSpeedsUtils.getCustomSpeedVehiclesByName(configuration.getProfiles());
 
         graphHopper.setEncodedValueFactory(new EncodedValueFactoryWithStableId());
         graphHopper.setTagParserFactory(new TagParserFactoryWithOsmId());
-        graphHopper.setVehicleTagParserFactory(new ReplicaVehicleTagParserFactory(vehicleNameToCustomSpeeds));
-        graphHopper.setVehicleEncodedValuesFactory(new ReplicaVehicleEncodedValuesFactory(vehicleNameToCustomSpeeds.keySet()));
+        graphHopper.setVehicleTagParserFactory(new ReplicaVehicleTagParserFactory(customSpeedsVehiclesByName));
+        graphHopper.setVehicleEncodedValuesFactory(new ReplicaVehicleEncodedValuesFactory(customSpeedsVehiclesByName));
         graphHopper.init(configuration);
         graphHopper.setEncodedValuesString("osmid,stable_id_byte_0,stable_id_byte_1,stable_id_byte_2,stable_id_byte_3,stable_id_byte_4,stable_id_byte_5,stable_id_byte_6,stable_id_byte_7,reverse_stable_id_byte_0,reverse_stable_id_byte_1,reverse_stable_id_byte_2,reverse_stable_id_byte_3,reverse_stable_id_byte_4,reverse_stable_id_byte_5,reverse_stable_id_byte_6,reverse_stable_id_byte_7");
         graphHopper.setPathDetailsBuilderFactory(new PathDetailsBuilderFactoryWithStableId());

--- a/web-bundle/src/main/java/com/graphhopper/http/TruckFlagEncoder.java
+++ b/web-bundle/src/main/java/com/graphhopper/http/TruckFlagEncoder.java
@@ -6,32 +6,32 @@ import com.graphhopper.routing.util.VehicleEncodedValues;
 
 // adapted from prod GraphHopper code (not available in OSS GraphHopper)
 public class TruckFlagEncoder {
-    public static final String TRUCK_VEHICLE_NAME = "truck";
-    public static final String SMALL_TRUCK_VEHICLE_NAME = "small_truck";
     private static final int TRUCK_SPEED_BITS = 6;
     private static final int SMALL_TRUCK_SPEED_BITS = 7;
     private static final int TRUCK_SPEED_FACTOR = 2;  // truck and small_truck share this value
     private static final boolean ENABLE_TRUCK_TURN_RESTRICTIONS = false;
 
-    public static VehicleEncodedValues createTruck() {
+    // accept vehicleName as param rather than using TRUCK_VEHICLE_NAME to support custom speeds vehicles with nonstandard names
+    public static VehicleEncodedValues createTruck(String vehicleName) {
         // turn costs is binary -- restricted or unrestricted (1 is scaled to infinity further down the code)
         int maxTurnCosts = ENABLE_TRUCK_TURN_RESTRICTIONS ? 1 : 0;
         BooleanEncodedValue accessEnc = new SimpleBooleanEncodedValue(
-                EncodingManager.getKey(TRUCK_VEHICLE_NAME, "access"), true);
+                EncodingManager.getKey(vehicleName, "access"), true);
         DecimalEncodedValue speedEnc = new DecimalEncodedValueImpl(
-                EncodingManager.getKey(TRUCK_VEHICLE_NAME, "average_speed"), TRUCK_SPEED_BITS, TRUCK_SPEED_FACTOR, true);
-        DecimalEncodedValue turnCostEnc = maxTurnCosts > 0 ? TurnCost.create(TRUCK_VEHICLE_NAME, maxTurnCosts) : null;
-        return new VehicleEncodedValues(TRUCK_VEHICLE_NAME, accessEnc, speedEnc, null, turnCostEnc);
+                EncodingManager.getKey(vehicleName, "average_speed"), TRUCK_SPEED_BITS, TRUCK_SPEED_FACTOR, true);
+        DecimalEncodedValue turnCostEnc = maxTurnCosts > 0 ? TurnCost.create(vehicleName, maxTurnCosts) : null;
+        return new VehicleEncodedValues(vehicleName, accessEnc, speedEnc, null, turnCostEnc);
     }
 
-    public static VehicleEncodedValues createSmallTruck() {
+    // accept vehicleName as param rather than using SMALL_TRUCK_VEHICLE_NAME to support custom speeds vehicles with nonstandard names
+    public static VehicleEncodedValues createSmallTruck(String vehicleName) {
         // turn costs is binary -- restricted or unrestricted (1 is scaled to infinity further down the code)
         int maxTurnCosts = ENABLE_TRUCK_TURN_RESTRICTIONS ? 1 : 0;
         BooleanEncodedValue accessEnc = new SimpleBooleanEncodedValue(
-                EncodingManager.getKey(SMALL_TRUCK_VEHICLE_NAME, "access"), true);
+                EncodingManager.getKey(vehicleName, "access"), true);
         DecimalEncodedValue speedEnc = new DecimalEncodedValueImpl(
-                EncodingManager.getKey(SMALL_TRUCK_VEHICLE_NAME, "average_speed"), SMALL_TRUCK_SPEED_BITS, TRUCK_SPEED_FACTOR, true);
-        DecimalEncodedValue turnCostEnc = maxTurnCosts > 0 ? TurnCost.create(SMALL_TRUCK_VEHICLE_NAME, maxTurnCosts) : null;
-        return new VehicleEncodedValues(SMALL_TRUCK_VEHICLE_NAME, accessEnc, speedEnc, null, turnCostEnc);
+                EncodingManager.getKey(vehicleName, "average_speed"), SMALL_TRUCK_SPEED_BITS, TRUCK_SPEED_FACTOR, true);
+        DecimalEncodedValue turnCostEnc = maxTurnCosts > 0 ? TurnCost.create(vehicleName, maxTurnCosts) : null;
+        return new VehicleEncodedValues(vehicleName, accessEnc, speedEnc, null, turnCostEnc);
     }
 }

--- a/web-bundle/src/main/java/com/graphhopper/replica/ReplicaCustomSpeedsCarTagParser.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/ReplicaCustomSpeedsCarTagParser.java
@@ -11,7 +11,6 @@ import com.graphhopper.util.PMap;
 import java.util.Objects;
 
 public class ReplicaCustomSpeedsCarTagParser extends CarAverageSpeedParser {
-    // empty if no custom speeds were provided
     private final ImmutableMap<Long, Double> osmWayIdToMaxSpeed;
 
     public ReplicaCustomSpeedsCarTagParser(EncodedValueLookup lookup, PMap configuration, ImmutableMap<Long, Double> osmWayIdToMaxSpeed) {

--- a/web-bundle/src/main/java/com/graphhopper/replica/ReplicaCustomSpeedsCarTagParser.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/ReplicaCustomSpeedsCarTagParser.java
@@ -1,14 +1,17 @@
 package com.graphhopper.replica;
 
 import com.google.common.collect.ImmutableMap;
+import com.graphhopper.customspeeds.CustomSpeedsUtils;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.EncodedValueLookup;
 import com.graphhopper.routing.util.parsers.CarAverageSpeedParser;
+import com.graphhopper.routing.util.parsers.TagParser;
 import com.graphhopper.util.PMap;
 
 import java.util.Objects;
 
 public class ReplicaCustomSpeedsCarTagParser extends CarAverageSpeedParser {
+    // empty if no custom speeds were provided
     private final ImmutableMap<Long, Double> osmWayIdToMaxSpeed;
 
     public ReplicaCustomSpeedsCarTagParser(EncodedValueLookup lookup, PMap configuration, ImmutableMap<Long, Double> osmWayIdToMaxSpeed) {
@@ -18,20 +21,11 @@ public class ReplicaCustomSpeedsCarTagParser extends CarAverageSpeedParser {
 
     @Override
     protected double applyMaxSpeed(ReaderWay way, double speed, boolean bwd) {
-        // n.b. superclass logic sets max speed to be 90% of the OSM's max speed for the way, but we don't apply the 90%
-        // discount for the custom speeds we've been explicitly given
-        Double knownMaxSpeed = osmWayIdToMaxSpeed.get(way.getId());
-        return Objects.requireNonNullElseGet(knownMaxSpeed, () -> super.applyMaxSpeed(way, speed, bwd));
+        return CustomSpeedsUtils.getCustomMaxSpeed(way, osmWayIdToMaxSpeed).orElseGet(() -> super.applyMaxSpeed(way, speed, bwd));
     }
 
     @Override
     protected double applyBadSurfaceSpeed(ReaderWay way, double speed) {
-        // if we've been explicitly given a custom speed to use for the way, we should not apply any additional logic
-        // for bad road surfaces
-        if (osmWayIdToMaxSpeed.containsKey(way.getId())) {
-            return speed;
-        }
-
-        return super.applyBadSurfaceSpeed(way, speed);
+        return CustomSpeedsUtils.getCustomBadSurfaceSpeed(way, osmWayIdToMaxSpeed).orElseGet(() -> super.applyBadSurfaceSpeed(way, speed));
     }
 }

--- a/web-bundle/src/main/java/com/graphhopper/replica/ReplicaVehicleEncodedValuesFactory.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/ReplicaVehicleEncodedValuesFactory.java
@@ -29,7 +29,7 @@ public class ReplicaVehicleEncodedValuesFactory extends DefaultVehicleEncodedVal
             baseCustomSpeedsVehicleType = customSpeedsVehiclesByName.get(vehicleName).baseVehicleType;
         }
 
-        if (vehicleName.equals("car") || baseCustomSpeedsVehicleType == CustomSpeedsVehicle.VehicleType.CAR) {
+        if (vehicleName.equals(RouterConstants.CAR_VEHICLE_NAME) || baseCustomSpeedsVehicleType == CustomSpeedsVehicle.VehicleType.CAR) {
             return VehicleEncodedValues.car(configuration);
         } else if (vehicleName.equals(RouterConstants.TRUCK_VEHICLE_NAME) || baseCustomSpeedsVehicleType == CustomSpeedsVehicle.VehicleType.TRUCK) {
             return TruckFlagEncoder.createTruck(vehicleName);

--- a/web-bundle/src/main/java/com/graphhopper/replica/ReplicaVehicleTagParserFactory.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/ReplicaVehicleTagParserFactory.java
@@ -58,13 +58,15 @@ public class ReplicaVehicleTagParserFactory extends DefaultVehicleTagParserFacto
             configuration.putObject("name", vehicleName);
         }
 
-
-        if (vehicleName.equals("car") || baseCustomSpeedsVehicleType == CustomSpeedsVehicle.VehicleType.CAR) {
+        if (baseCustomSpeedsVehicleType == CustomSpeedsVehicle.VehicleType.CAR) {
             return new VehicleTagParsers(
                     new CarAccessParser(lookup, configuration).init(configuration.getObject("date_range_parser", new DateRangeParser())),
                     new ReplicaCustomSpeedsCarTagParser(lookup, configuration, osmWayIdToCustomSpeed),
                     null);
 
+        } else if (vehicleName.equals(RouterConstants.CAR_VEHICLE_NAME) ) {
+            // do nothing and carry through to superclass implementation. we could use pass an empty custom speeds mapping
+            // to ReplicaCustomSpeedsCarTagParser, but it's safer to use the default GraphHopper behavior directly
         } else if (vehicleName.equals(RouterConstants.TRUCK_VEHICLE_NAME) || baseCustomSpeedsVehicleType == CustomSpeedsVehicle.VehicleType.TRUCK) {
             configuration.putObject("block_fords", false);
             if (!configuration.has("name"))

--- a/web-bundle/src/main/java/com/graphhopper/replica/ReplicaVehicleTagParserFactory.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/ReplicaVehicleTagParserFactory.java
@@ -19,9 +19,10 @@
 package com.graphhopper.replica;
 
 import com.google.common.collect.ImmutableMap;
+import com.graphhopper.RouterConstants;
+import com.graphhopper.customspeeds.CustomSpeedsVehicle;
 import com.graphhopper.http.TruckAccessParser;
 import com.graphhopper.http.TruckAverageSpeedParser;
-import com.graphhopper.http.TruckFlagEncoder;
 import com.graphhopper.reader.osm.conditional.DateRangeParser;
 import com.graphhopper.routing.ev.EncodedValueLookup;
 import com.graphhopper.routing.util.DefaultVehicleTagParserFactory;
@@ -32,30 +33,39 @@ import com.graphhopper.util.PMap;
 import static com.graphhopper.http.TruckAverageSpeedParser.*;
 
 public class ReplicaVehicleTagParserFactory extends DefaultVehicleTagParserFactory {
-    private final ImmutableMap<String, ImmutableMap<Long, Double>> vehicleNameToCustomSpeeds;
+    private final ImmutableMap<String, CustomSpeedsVehicle> customSpeedsVehiclesByName;
 
     /**
      * @param vehicleNameToCustomSpeeds map of vehicle name to mapping from OSM way id to the custom speed to use for
      *                                  that way, in kph. vehicles without custom speeds may be omitted from the map.
      */
-    public ReplicaVehicleTagParserFactory(ImmutableMap<String, ImmutableMap<Long, Double>> vehicleNameToCustomSpeeds) {
-        this.vehicleNameToCustomSpeeds = vehicleNameToCustomSpeeds;
+    public ReplicaVehicleTagParserFactory(ImmutableMap<String, CustomSpeedsVehicle> customSpeedsVehiclesByName) {
+        this.customSpeedsVehiclesByName = customSpeedsVehiclesByName;
     }
 
     @Override
-    public VehicleTagParsers createParsers(EncodedValueLookup lookup, String name, PMap configuration) {
-        // TODO if we ever want to support custom speeds for vehicles other than car, we'll need to generalize
-        // ReplicaCustomSpeedsCarTagParser
-        if (vehicleNameToCustomSpeeds.containsKey(name)) {
+    public VehicleTagParsers createParsers(EncodedValueLookup lookup, String vehicleName, PMap configuration) {
+        // assume no custom speeds by default
+        ImmutableMap<Long, Double> osmWayIdToCustomSpeed = ImmutableMap.of();
+        CustomSpeedsVehicle.VehicleType baseCustomSpeedsVehicleType = null;
+
+        if (customSpeedsVehiclesByName.containsKey(vehicleName)) {
+            CustomSpeedsVehicle customSpeedsVehicle = customSpeedsVehiclesByName.get(vehicleName);
+            osmWayIdToCustomSpeed = customSpeedsVehicle.osmWayIdToCustomSpeed;
+            baseCustomSpeedsVehicleType = customSpeedsVehicle.baseVehicleType;
             // vehicles with custom speeds use nonstandard vehicle names which must be added to the config for the GH
             // internals to tolerate it
-            PMap configWithName = new PMap(configuration).putObject("name", name);
+            configuration.putObject("name", vehicleName);
+        }
+
+
+        if (vehicleName.equals("car") || baseCustomSpeedsVehicleType == CustomSpeedsVehicle.VehicleType.CAR) {
             return new VehicleTagParsers(
-                    new CarAccessParser(lookup, configWithName).init(configWithName.getObject("date_range_parser", new DateRangeParser())),
-                    new ReplicaCustomSpeedsCarTagParser(lookup, configWithName, vehicleNameToCustomSpeeds.get(name)),
-                    null
-            );
-        } else if (name.equals(TruckFlagEncoder.TRUCK_VEHICLE_NAME)) {
+                    new CarAccessParser(lookup, configuration).init(configuration.getObject("date_range_parser", new DateRangeParser())),
+                    new ReplicaCustomSpeedsCarTagParser(lookup, configuration, osmWayIdToCustomSpeed),
+                    null);
+
+        } else if (vehicleName.equals(RouterConstants.TRUCK_VEHICLE_NAME) || baseCustomSpeedsVehicleType == CustomSpeedsVehicle.VehicleType.TRUCK) {
             configuration.putObject("block_fords", false);
             if (!configuration.has("name"))
                 configuration = new PMap(configuration).putObject("name", "truck");
@@ -67,12 +77,12 @@ public class ReplicaVehicleTagParserFactory extends DefaultVehicleTagParserFacto
                             setWeight(13.0 + 13.0).setAxes(3).setIsHGV(true).
                             initProperties().
                             init(configuration.getObject("date_range_parser", new DateRangeParser())),
-                    new TruckAverageSpeedParser(lookup, configuration).
+                    new TruckAverageSpeedParser(lookup, configuration, osmWayIdToCustomSpeed).
                             setHeight(3.7).setWidth(2.6, 0.34).setLength(12).
                             setWeight(13.0 + 13.0).setAxes(3).setIsHGV(true).
                             initProperties(),
                     null);
-        } else if (name.equals(TruckFlagEncoder.SMALL_TRUCK_VEHICLE_NAME)) {
+        } else if (vehicleName.equals(RouterConstants.SMALL_TRUCK_VEHICLE_NAME) || baseCustomSpeedsVehicleType == CustomSpeedsVehicle.VehicleType.SMALL_TRUCK) {
             configuration.putObject("block_fords", false);
             if (!configuration.has("name"))
                 configuration = new PMap(configuration).putObject("name", "small_truck");
@@ -84,13 +94,13 @@ public class ReplicaVehicleTagParserFactory extends DefaultVehicleTagParserFacto
                             setWeight(SMALL_TRUCK_WEIGHT).
                             initProperties().
                             init(configuration.getObject("date_range_parser", new DateRangeParser())),
-                    new TruckAverageSpeedParser(lookup, configuration).
+                    new TruckAverageSpeedParser(lookup, configuration, osmWayIdToCustomSpeed).
                             setHeight(2.7).setWidth(2, 0.34).setLength(5.5).
                             setWeight(SMALL_TRUCK_WEIGHT)
                             .initProperties(),
                     null);
         }
 
-        return super.createParsers(lookup, name, configuration);
+        return super.createParsers(lookup, vehicleName, configuration);
     }
 }

--- a/web-bundle/src/main/java/com/graphhopper/replica/ReplicaVehicleTagParserFactory.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/ReplicaVehicleTagParserFactory.java
@@ -36,8 +36,9 @@ public class ReplicaVehicleTagParserFactory extends DefaultVehicleTagParserFacto
     private final ImmutableMap<String, CustomSpeedsVehicle> customSpeedsVehiclesByName;
 
     /**
-     * @param vehicleNameToCustomSpeeds map of vehicle name to mapping from OSM way id to the custom speed to use for
-     *                                  that way, in kph. vehicles without custom speeds may be omitted from the map.
+     * @param customSpeedsVehiclesByName map of custom vehicle name to CustomSpeedsVehicle object containing the custom
+     *                                   speeds mapping and the base vehicle type. the speeds mapping must be expressed
+     *                                   in kph. vehicles without custom speeds should be omitted from the map.
      */
     public ReplicaVehicleTagParserFactory(ImmutableMap<String, CustomSpeedsVehicle> customSpeedsVehiclesByName) {
         this.customSpeedsVehiclesByName = customSpeedsVehiclesByName;

--- a/web/src/test/java/com/replica/RouterServerTest.java
+++ b/web/src/test/java/com/replica/RouterServerTest.java
@@ -450,7 +450,6 @@ public class RouterServerTest extends ReplicaGraphHopperTest {
         for (Map.Entry<String, String> profileEntry : CUSTOM_THURTON_DRIVE_PROFILE_TO_DEFAULT_PROFILE.entrySet()) {
             String customProfile = profileEntry.getKey();
             String defaultProfile = profileEntry.getValue();
-            System.out.println("Querying profiles " + customProfile + " and " + defaultProfile);
 
             final RouterOuterClass.StreetRouteReply customSpeedsResponse = routerStub.routeStreetMode(
                     createStreetRequest(customProfile, false, origin, dest));

--- a/web/src/test/java/com/replica/RouterServerTest.java
+++ b/web/src/test/java/com/replica/RouterServerTest.java
@@ -17,10 +17,7 @@
  */
 package com.replica;
 
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
+import com.google.common.collect.*;
 import com.google.protobuf.Timestamp;
 import com.graphhopper.GraphHopper;
 import com.graphhopper.gtfs.GraphHopperGtfs;
@@ -78,6 +75,10 @@ public class RouterServerTest extends ReplicaGraphHopperTest {
     // Tests park-and-ride routing for a longer route (with a transfer)
     private static final RouterOuterClass.PtRouteRequest PT_REQUEST_PARK_N_RIDE_W_TRANSFER = createPtRequest(REQUEST_ORIGIN_3, REQUEST_DESTINATION_2, "car", "foot");
 
+    private static final String DEFAULT_CAR_PROFILE_NAME = "car_default";
+    private static final String DEFAULT_TRUCK_PROFILE_NAME = "truck_default";
+    private static final String DEFAULT_SMALL_TRUCK_PROFILE_NAME = "small_truck_default";
+
     private static final RouterOuterClass.StreetRouteRequest AUTO_REQUEST =
             createStreetRequest("car", false, REQUEST_ORIGIN_1, REQUEST_DESTINATION_1);
     private static final RouterOuterClass.StreetRouteRequest AUTO_REQUEST_WITH_ALTERNATIVES =
@@ -85,15 +86,16 @@ public class RouterServerTest extends ReplicaGraphHopperTest {
     private static final RouterOuterClass.StreetRouteRequest WALK_REQUEST =
             createStreetRequest("foot", false, REQUEST_ORIGIN_1, REQUEST_DESTINATION_1);
     private static final RouterOuterClass.StreetRouteRequest TRUCK_REQUEST =
-            createStreetRequest("truck", false, REQUEST_ORIGIN_1, REQUEST_DESTINATION_1);
+            createStreetRequest(DEFAULT_TRUCK_PROFILE_NAME, false, REQUEST_ORIGIN_1, REQUEST_DESTINATION_1);
     private static final RouterOuterClass.StreetRouteRequest SMALL_TRUCK_REQUEST =
-            createStreetRequest("small_truck", false, REQUEST_ORIGIN_1, REQUEST_DESTINATION_1);
+            createStreetRequest(DEFAULT_SMALL_TRUCK_PROFILE_NAME, false, REQUEST_ORIGIN_1, REQUEST_DESTINATION_1);
 
-    private static final String FAST_THURTON_DRIVE_CAR_PROFILE_NAME = "car_custom_fast_thurton_drive";
+    private static final String CUSTOM_THURTON_DRIVE_CAR_PROFILE_NAME = "car_custom_fast_thurton_drive";
     private static final String CLOSED_BASELINE_ROAD_CAR_PROFILE_NAME = "car_custom_closed_baseline_road";
-    private static final String DEFAULT_CAR_PROFILE_NAME = "car_default";
     private static final ImmutableSet<String> CAR_PROFILES =
-            ImmutableSet.of("car", "car_freeway", DEFAULT_CAR_PROFILE_NAME, FAST_THURTON_DRIVE_CAR_PROFILE_NAME, CLOSED_BASELINE_ROAD_CAR_PROFILE_NAME);
+            ImmutableSet.of("car", "car_freeway", DEFAULT_CAR_PROFILE_NAME, CUSTOM_THURTON_DRIVE_CAR_PROFILE_NAME, CLOSED_BASELINE_ROAD_CAR_PROFILE_NAME);
+
+    private static final ImmutableMap<String, String> CUSTOM_THURTON_DRIVE_PROFILE_TO_DEFAULT_PROFILE = ImmutableMap.of(CUSTOM_THURTON_DRIVE_CAR_PROFILE_NAME, DEFAULT_CAR_PROFILE_NAME, "truck_custom_fast_thurton_drive", DEFAULT_TRUCK_PROFILE_NAME, "small_truck_custom_fast_thurton_drive", DEFAULT_SMALL_TRUCK_PROFILE_NAME);
 
     private static router.RouterGrpc.RouterBlockingStub routerStub = null;
 
@@ -337,11 +339,11 @@ public class RouterServerTest extends ReplicaGraphHopperTest {
         Predicate<Long> perProfilePathCountPredicate = pathCount -> pathCount == 1L;
 
         final RouterOuterClass.StreetRouteReply truckResponse = routerStub.routeStreetMode(TRUCK_REQUEST);
-        Set<String> expectedTruckProfiles = ImmutableSet.of("truck");
+        Set<String> expectedTruckProfiles = ImmutableSet.of(DEFAULT_TRUCK_PROFILE_NAME);
         checkStreetBasedResponse(truckResponse, expectedTruckProfiles, perProfilePathCountPredicate);
 
         final RouterOuterClass.StreetRouteReply smallTruckResponse = routerStub.routeStreetMode(SMALL_TRUCK_REQUEST);
-        expectedTruckProfiles = ImmutableSet.of("small_truck");
+        expectedTruckProfiles = ImmutableSet.of(DEFAULT_SMALL_TRUCK_PROFILE_NAME);
         checkStreetBasedResponse(smallTruckResponse, expectedTruckProfiles, perProfilePathCountPredicate);
 
         // Check truck and small_truck return slightly different results
@@ -445,20 +447,26 @@ public class RouterServerTest extends ReplicaGraphHopperTest {
 
         Predicate<Long> onlyOnePathPredicate = pathCount -> pathCount == 1L;
 
-        final RouterOuterClass.StreetRouteReply customSpeedsResponse = routerStub.routeStreetMode(
-                createStreetRequest(FAST_THURTON_DRIVE_CAR_PROFILE_NAME, false, origin, dest));
-        checkStreetBasedResponse(customSpeedsResponse, ImmutableSet.of(FAST_THURTON_DRIVE_CAR_PROFILE_NAME), onlyOnePathPredicate);
+        for (Map.Entry<String, String> profileEntry : CUSTOM_THURTON_DRIVE_PROFILE_TO_DEFAULT_PROFILE.entrySet()) {
+            String customProfile = profileEntry.getKey();
+            String defaultProfile = profileEntry.getValue();
+            System.out.println("Querying profiles " + customProfile + " and " + defaultProfile);
 
-        final RouterOuterClass.StreetRouteReply defaultSpeedsResponse = routerStub.routeStreetMode(
-                createStreetRequest(DEFAULT_CAR_PROFILE_NAME, false, origin, dest));
-        checkStreetBasedResponse(defaultSpeedsResponse, ImmutableSet.of(DEFAULT_CAR_PROFILE_NAME), onlyOnePathPredicate);
+            final RouterOuterClass.StreetRouteReply customSpeedsResponse = routerStub.routeStreetMode(
+                    createStreetRequest(customProfile, false, origin, dest));
+            checkStreetBasedResponse(customSpeedsResponse, ImmutableSet.of(customProfile), onlyOnePathPredicate);
 
-        RouterOuterClass.StreetPath customSpeedsPath = Iterables.getOnlyElement(customSpeedsResponse.getPathsList());
-        RouterOuterClass.StreetPath defaultSpeedsPath = Iterables.getOnlyElement(defaultSpeedsResponse.getPathsList());
+            final RouterOuterClass.StreetRouteReply defaultSpeedsResponse = routerStub.routeStreetMode(
+                    createStreetRequest(defaultProfile, false, origin, dest));
+            checkStreetBasedResponse(defaultSpeedsResponse, ImmutableSet.of(defaultProfile), onlyOnePathPredicate);
 
-        // the custom speeds profile sets the Thurton Drive speed very high, so the travel time using this profile
-        // should be less than the default
-        assertTrue(customSpeedsPath.getDurationMillis() < defaultSpeedsPath.getDurationMillis());
+            RouterOuterClass.StreetPath customSpeedsPath = Iterables.getOnlyElement(customSpeedsResponse.getPathsList());
+            RouterOuterClass.StreetPath defaultSpeedsPath = Iterables.getOnlyElement(defaultSpeedsResponse.getPathsList());
+
+            // the custom speeds profile sets the Thurton Drive speed very high, so the travel time using this profile
+            // should be less than the default
+            assertTrue(customSpeedsPath.getDurationMillis() < defaultSpeedsPath.getDurationMillis());
+        }
     }
 
     // tests road closure simulation via setting a custom speed for an OSM way to 0


### PR DESCRIPTION
Addresses part of https://replicahq.atlassian.net/browse/RAD-6268 (just trucks; bikes and peds are still outstanding)

Adds custom speeds support for the `truck` and `small_truck` vehicles. Configuration is similar to what's currently in places for custom car speeds - just add a `custom_speed_file` to the profiles of interest!

The one tricky piece I encountered was with some limitations re: vehicles. You might recall from the original custom speeds implementation that Graphhopper only supports customizing speeds for each way on a per-vehicle basis, not a per-profile one (additional context at https://github.com/replicahq/graphhopper/pull/122#discussion_r1007372958. I looked at the current Graphhopper core master and confirmed this limitation still exists). So if you want both a standard car and a custom speeds car (or standard truck and custom speeds truck), the profile with custom speeds must use a different vehicle name (e.g. `car_custom`). `ReplicaVehicleTagParserFactory` and `ReplicaVehicleEncodedValuesFactory` apply the custom speeds to the relevant vehicles, but they need to know the "base" vehicle type for each custom speeds vehicle so they can apply the custom speeds to the right class. 

I chose to derive the base vehicle from the custom speeds vehicle by examining the custom speeds vehicle prefix (e.g. `car_custom` is assumed to have a base vehicle type of `car`). It's a little hacky, but in all our custom speeds use cases so far we apply the custom speeds to *all profiles* of a given vehicle type (e.g. close the road for all car profiles, or increase the speed for all car profiles), so we always just keep the standard vehicle names ([example config](https://github.com/replicahq/model/pull/7987/files#diff-07736554fdb0426f0b34b88bf83395d616b63a388b402a140c5a312ad4359fd8)). I considered adding a `base_vehicle_type` or something to the Profile configuration, but this would just add more complexity to the common case of setting speeds for all profiles of a given vehicle type. Plus, we use the prefixing approach when applying profiles to routing queries already, so there's some precedent. I kept this derivation logic specific to one place, so if we need something more robust in the future we can easily swap it out. If you're on board, I'll be sure to update the docs with this detail once this merges. But again, it's not relevant to our typical usage patterns. When we hook up custom speeds into the automated Scenario pipeline, I think we should only expose configuring custom speeds per-mode, not per-profile, at least to start. That keeps things simple and avoids all these details.

I created a new `CustomSpeedsVehicle` class to hold the custom speeds vehicle name, the base vehicle, and the custom speeds mapping. I updated the `CustomSpeedUtilsTest` and `RouterServerTest` to test custom speeds for small trucks/trucks (and test out some details of the base vehicle type logic). I moved common custom speeds logic to `CustomSpeedsUtils` and called it from `ReplicaCustomSpeedsCarTagParser` and `TruckAverageSpeedParser` (tried to handle it instead via inheritance first, but I think the cleanest way to do it is with multiple inheritance which Java doesn't support).

cc @rregue @rslassman 