### PR TITLE
Increase memory for GTFS validator build

### DIFF
--- a/Dockerfile.validate
+++ b/Dockerfile.validate
@@ -3,7 +3,7 @@ FROM $BASE_IMAGE as base
 
 COPY ./full_usa.osm.pbf ./
 
-RUN java -Xmx58g -Ddw.graphhopper.datareader.file=full_usa.osm.pbf \
+RUN java -Xmx30g -Ddw.graphhopper.datareader.file=full_usa.osm.pbf \
   -Ddw.graphhopper.validation=false -classpath web/target/graphhopper-web-1.0-SNAPSHOT.jar \
   com.graphhopper.http.GraphHopperApplication validate-gtfs ./configs/gtfs_validation_gh_config_phase_1.yaml \
   && rm ./full_usa.osm.pbf

--- a/gtfs_validator_build.yaml
+++ b/gtfs_validator_build.yaml
@@ -4,4 +4,4 @@ steps:
     args: ['build', '-f', 'Dockerfile.validate', '-t', '${_IMAGE_TAG}', '--build-arg', 'BASE_IMAGE=${_BASE_IMAGE}', '.']
 images: ['${_IMAGE_TAG}']
 options:
-  machineType: 'N1_HIGHCPU_32'
+  machineType: 'N1_STANDARD_16'

--- a/gtfs_validator_build.yaml
+++ b/gtfs_validator_build.yaml
@@ -4,4 +4,4 @@ steps:
     args: ['build', '-f', 'Dockerfile.validate', '-t', '${_IMAGE_TAG}', '--build-arg', 'BASE_IMAGE=${_BASE_IMAGE}', '.']
 images: ['${_IMAGE_TAG}']
 options:
-  machineType: 'N1_STANDARD_16'
+  machineType: 'E2_HIGHCPU_32'


### PR DESCRIPTION
When I tried building a fresh GTFS validator image off of `original-direction` after merging the new transit algorithm, the gcloud build responsible for creating the image [failed](https://github.com/replicahq/graphhopper/actions/runs/7051298798/job/19195424795) with a docker 137 (OOM).

It turns out, a few things were wrong:
- cloud build only allows [a few machine types](https://cloud.google.com/build/docs/api/reference/rest/v1/projects.builds#machinetype); we weren't using the one with the most memory (`E2_HIGHCPU_32`)
- We were mistakingly giving java way more heap memory than actually existed on the build machine

As a fix, I moved the build to `E2_HIGHCPU_32` machines (w/ 32gb ram), and lowered the java heap to 30gb. Running with this configuration was [successful](https://github.com/replicahq/graphhopper/actions/runs/7052781632/job/19198582820).