### PR TITLE
[RAD-6448] Print OSM IDs and speeds along routes in router GUI

### DIFF
--- a/grpc/src/main/java/com/replica/RouterImpl.java
+++ b/grpc/src/main/java/com/replica/RouterImpl.java
@@ -98,7 +98,7 @@ public class RouterImpl extends router.RouterGrpc.RouterImplBase {
                 if (!ghResponse.hasErrors()) {
                     anyPathsFound = true;
                     ghResponse.getAll().stream()
-                            .map(responsePath -> RouterConverters.toStreetPath(responsePath, profile))
+                            .map(responsePath -> RouterConverters.toStreetPath(responsePath, profile, request.getReturnFullPathDetails()))
                             .forEach(replyBuilder::addPaths);
                 }
             } catch (Exception e) {
@@ -175,7 +175,7 @@ public class RouterImpl extends router.RouterGrpc.RouterImplBase {
             } else {
                 StreetRouteReply.Builder replyBuilder = StreetRouteReply.newBuilder();
                 ghResponse.getAll().stream()
-                        .map(responsePath -> RouterConverters.toStreetPath(responsePath, request.getProfile()))
+                        .map(responsePath -> RouterConverters.toStreetPath(responsePath, request.getProfile(), request.getReturnFullPathDetails()))
                         .forEach(replyBuilder::addPaths);
 
                 double durationSeconds = (System.currentTimeMillis() - startTime) / 1000.0;

--- a/grpc/src/main/resources/assets/js/main-template.js
+++ b/grpc/src/main/resources/assets/js/main-template.js
@@ -138,6 +138,7 @@ $(document).ready(function (e) {
        customRouteRequest.setAlternateRouteMaxPaths($('#alt_route_max_paths').val());
        customRouteRequest.setAlternateRouteMaxWeightFactor($('#alt_route_max_weight_factor').val());
        customRouteRequest.setAlternateRouteMaxShareFactor($('#alt_route_max_share_factor').val());
+       customRouteRequest.setReturnFullPathDetails(true);
        console.log(customRouteRequest.toObject());
 
         var router = new Router.RouterClient('/api');
@@ -979,6 +980,7 @@ function routeLatLng(request, doQuery) {
     streetRouteRequest.setAlternateRouteMaxPaths($('#alt_route_max_paths').val());
     streetRouteRequest.setAlternateRouteMaxWeightFactor($('#alt_route_max_weight_factor').val());
     streetRouteRequest.setAlternateRouteMaxShareFactor($('#alt_route_max_share_factor').val());
+    streetRouteRequest.setReturnFullPathDetails(true);
     console.log(streetRouteRequest.toObject());
 
     var router = new Router.RouterClient('/api');

--- a/replica-common/src/main/java/com/graphhopper/ReplicaPathDetails.java
+++ b/replica-common/src/main/java/com/graphhopper/ReplicaPathDetails.java
@@ -1,0 +1,17 @@
+package com.graphhopper;
+
+import com.graphhopper.RouterConstants;
+import com.graphhopper.util.Parameters;
+
+
+public final class ReplicaPathDetails {
+    private ReplicaPathDetails() {
+        // utility class
+    }
+
+    public static final String SPEED = Parameters.Details.AVERAGE_SPEED;
+    public static final String TIME = Parameters.Details.TIME;
+    public static final String STABLE_EDGE_IDS = "stable_edge_ids";
+    // detail is derived from the encoded value (see PathDetailsBuilderFactoryWithStableId), so the two should be kept in sync
+    public static final String OSM_ID = RouterConstants.OSM_ID_ENCODED_VALUE;
+}

--- a/replica-common/src/main/java/com/graphhopper/RouterConstants.java
+++ b/replica-common/src/main/java/com/graphhopper/RouterConstants.java
@@ -15,4 +15,7 @@ public final class RouterConstants {
     public static final String SMALL_TRUCK_VEHICLE_NAME = "small_truck";
 
     public static final Set<Integer> STREET_BASED_ROUTE_TYPES = Sets.newHashSet(0, 3, 5);
+
+    public static final String OSM_ID_ENCODED_VALUE = "osmid";
+    public static final String OSM_ID_PATH_DETAIL = OSM_ID_ENCODED_VALUE;
 }

--- a/replica-common/src/main/java/com/graphhopper/RouterConstants.java
+++ b/replica-common/src/main/java/com/graphhopper/RouterConstants.java
@@ -17,5 +17,4 @@ public final class RouterConstants {
     public static final Set<Integer> STREET_BASED_ROUTE_TYPES = Sets.newHashSet(0, 3, 5);
 
     public static final String OSM_ID_ENCODED_VALUE = "osmid";
-    public static final String OSM_ID_PATH_DETAIL = OSM_ID_ENCODED_VALUE;
 }

--- a/replica-common/src/main/java/com/graphhopper/TagParserFactoryWithOsmId.java
+++ b/replica-common/src/main/java/com/graphhopper/TagParserFactoryWithOsmId.java
@@ -10,8 +10,8 @@ public class TagParserFactoryWithOsmId extends DefaultTagParserFactory {
 
     @Override
     public TagParser create(EncodedValueLookup lookup, String name, PMap properties) {
-        if (name.equals("osmid")) {
-            return new OsmIdTagParser(lookup.getIntEncodedValue("osmid"));
+        if (name.equals(RouterConstants.OSM_ID_ENCODED_VALUE)) {
+            return new OsmIdTagParser(lookup.getIntEncodedValue(RouterConstants.OSM_ID_ENCODED_VALUE));
         } else if (name.startsWith("stable_id") || name.startsWith("reverse_stable_id")) {
             // We compute those values outside of GraphHopper's loop
             return new NoOpTagParser();

--- a/replica-common/src/main/java/com/graphhopper/stableid/PathDetailsBuilderFactoryWithStableId.java
+++ b/replica-common/src/main/java/com/graphhopper/stableid/PathDetailsBuilderFactoryWithStableId.java
@@ -25,6 +25,7 @@ import com.graphhopper.util.details.*;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.graphhopper.stableid.StableIdPathDetailsBuilder.STABLE_EDGE_IDS_PATH_DETAIL;
 import static com.graphhopper.util.Parameters.Details.*;
 
 public class PathDetailsBuilderFactoryWithStableId extends PathDetailsBuilderFactory {
@@ -56,7 +57,7 @@ public class PathDetailsBuilderFactoryWithStableId extends PathDetailsBuilderFac
         if (requestedPathDetails.contains(EDGE_KEY))
             builders.add(new EdgeKeyDetails());
 
-        if (requestedPathDetails.contains("stable_edge_ids")) {
+        if (requestedPathDetails.contains(STABLE_EDGE_IDS_PATH_DETAIL)) {
             builders.add(new StableIdPathDetailsBuilder(evl));
         }
 

--- a/replica-common/src/main/java/com/graphhopper/stableid/PathDetailsBuilderFactoryWithStableId.java
+++ b/replica-common/src/main/java/com/graphhopper/stableid/PathDetailsBuilderFactoryWithStableId.java
@@ -16,6 +16,7 @@ package com.graphhopper.stableid;/*
  *  limitations under the License.
  */
 
+import com.graphhopper.ReplicaPathDetails;
 import com.graphhopper.routing.Path;
 import com.graphhopper.routing.ev.*;
 import com.graphhopper.routing.weighting.Weighting;
@@ -25,7 +26,6 @@ import com.graphhopper.util.details.*;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.graphhopper.stableid.StableIdPathDetailsBuilder.STABLE_EDGE_IDS_PATH_DETAIL;
 import static com.graphhopper.util.Parameters.Details.*;
 
 public class PathDetailsBuilderFactoryWithStableId extends PathDetailsBuilderFactory {
@@ -57,7 +57,7 @@ public class PathDetailsBuilderFactoryWithStableId extends PathDetailsBuilderFac
         if (requestedPathDetails.contains(EDGE_KEY))
             builders.add(new EdgeKeyDetails());
 
-        if (requestedPathDetails.contains(STABLE_EDGE_IDS_PATH_DETAIL)) {
+        if (requestedPathDetails.contains(ReplicaPathDetails.STABLE_EDGE_IDS)) {
             builders.add(new StableIdPathDetailsBuilder(evl));
         }
 

--- a/replica-common/src/main/java/com/graphhopper/stableid/StableIdEncodedValues.java
+++ b/replica-common/src/main/java/com/graphhopper/stableid/StableIdEncodedValues.java
@@ -5,6 +5,7 @@ import com.google.common.hash.HashCode;
 import com.google.common.hash.Hashing;
 import com.google.common.primitives.Longs;
 import com.graphhopper.OsmHelper;
+import com.graphhopper.RouterConstants;
 import com.graphhopper.routing.ev.IntEncodedValue;
 import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.util.EdgeIteratorState;
@@ -18,7 +19,7 @@ public class StableIdEncodedValues {
 
     private StableIdEncodedValues(EncodingManager encodingManager, OsmHelper osmHelper) {
         this.osmHelper = osmHelper;
-        this.osmWayIdEnc = encodingManager.getIntEncodedValue("osmid");
+        this.osmWayIdEnc = encodingManager.getIntEncodedValue(RouterConstants.OSM_ID_ENCODED_VALUE);
 
         for (int i=0; i<8; i++) {
             stableIdEnc[i] = encodingManager.getIntEncodedValue("stable_id_byte_"+i);

--- a/replica-common/src/main/java/com/graphhopper/stableid/StableIdPathDetailsBuilder.java
+++ b/replica-common/src/main/java/com/graphhopper/stableid/StableIdPathDetailsBuilder.java
@@ -24,12 +24,13 @@ import com.graphhopper.util.EdgeIteratorState;
 import com.graphhopper.util.details.AbstractPathDetailsBuilder;
 
 public class StableIdPathDetailsBuilder extends AbstractPathDetailsBuilder {
+    public static final String STABLE_EDGE_IDS_PATH_DETAIL = "stable_edge_ids";
     private final StableIdEncodedValues originalDirectionFlagEncoder;
     private int prevEdgeId = -1;
     private String currentValue;
 
     public StableIdPathDetailsBuilder(EncodedValueLookup originalDirectionFlagEncoder) {
-        super("stable_edge_ids");
+        super(STABLE_EDGE_IDS_PATH_DETAIL);
         this.originalDirectionFlagEncoder = StableIdEncodedValues.fromEncodingManager((EncodingManager) originalDirectionFlagEncoder);
         currentValue = "";
     }

--- a/replica-common/src/main/java/com/graphhopper/stableid/StableIdPathDetailsBuilder.java
+++ b/replica-common/src/main/java/com/graphhopper/stableid/StableIdPathDetailsBuilder.java
@@ -18,19 +18,19 @@
 
 package com.graphhopper.stableid;
 
+import com.graphhopper.ReplicaPathDetails;
 import com.graphhopper.routing.ev.EncodedValueLookup;
 import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.util.EdgeIteratorState;
 import com.graphhopper.util.details.AbstractPathDetailsBuilder;
 
 public class StableIdPathDetailsBuilder extends AbstractPathDetailsBuilder {
-    public static final String STABLE_EDGE_IDS_PATH_DETAIL = "stable_edge_ids";
     private final StableIdEncodedValues originalDirectionFlagEncoder;
     private int prevEdgeId = -1;
     private String currentValue;
 
     public StableIdPathDetailsBuilder(EncodedValueLookup originalDirectionFlagEncoder) {
-        super(STABLE_EDGE_IDS_PATH_DETAIL);
+        super(ReplicaPathDetails.STABLE_EDGE_IDS);
         this.originalDirectionFlagEncoder = StableIdEncodedValues.fromEncodingManager((EncodingManager) originalDirectionFlagEncoder);
         currentValue = "";
     }

--- a/replica-common/src/test/java/com/graphhopper/customspeeds/CustomSpeedsUtilsTest.java
+++ b/replica-common/src/test/java/com/graphhopper/customspeeds/CustomSpeedsUtilsTest.java
@@ -13,7 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class CustomSpeedsUtilsTest {
     private static final ImmutableMap<Long, Double> TEST_CUSTOM_SPEEDS = ImmutableMap.of(1L, 2.0, 3L, 4.0, 123L, 456.789);
-    private static final ImmutableMap<Long, Double> FAST_THRUTON_DRIVE_SPEEDS = ImmutableMap.of(10485465L, 1000.0);
+    private static final ImmutableMap<Long, Double> FAST_THRUTON_DRIVE_SPEEDS = ImmutableMap.of(10485465L, 90.0);
 
     @Test
     public void testGetCustomSpeedVehiclesByName() {

--- a/web/src/test/java/com/replica/RouterServerTest.java
+++ b/web/src/test/java/com/replica/RouterServerTest.java
@@ -526,6 +526,7 @@ public class RouterServerTest extends ReplicaGraphHopperTest {
         }
     }
 
+    // requires streetPath to only have one value for the given detailName
     private static String getOnlyPathDetailValue(String detailName, RouterOuterClass.StreetPath streetPath) {
         Map<String, List<RouterOuterClass.StreetPathDetailValue>> customPathDetailsByName = getPathDetailsByName(streetPath);
         return Iterables.getOnlyElement(customPathDetailsByName.get(detailName)).getValue();

--- a/web/src/test/java/com/replica/RouterServerTest.java
+++ b/web/src/test/java/com/replica/RouterServerTest.java
@@ -20,7 +20,10 @@ package com.replica;
 import com.google.common.collect.*;
 import com.google.protobuf.Timestamp;
 import com.graphhopper.GraphHopper;
+import com.graphhopper.RouterConstants;
 import com.graphhopper.gtfs.*;
+import com.graphhopper.stableid.StableIdPathDetailsBuilder;
+import com.graphhopper.util.Parameters;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import io.grpc.ManagedChannel;
 import io.grpc.Status;
@@ -37,6 +40,7 @@ import router.RouterOuterClass;
 
 import java.io.File;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -86,6 +90,11 @@ public class RouterServerTest extends ReplicaGraphHopperTest {
     private static final RouterOuterClass.StreetRouteRequest SMALL_TRUCK_REQUEST =
             createStreetRequest(DEFAULT_SMALL_TRUCK_PROFILE_NAME, false, REQUEST_ORIGIN_1, REQUEST_DESTINATION_1);
 
+    private static final long THURTON_DRIVE_OSM_ID = 10485465;
+    // n.b. graphhopper internally rounds car speeds to the nearest multiple of 5 and truck speeds to the nearest multiple
+    // of 2 (see speed_factor property in VehicleEncodedValues#car and TruckFlagEncoder.TRUCK_SPEED_FACTOR), so we choose
+    // a custom speed that's a multiple of both to allow for straightforward equality comparisons
+    private static final double THURTON_DRIVE_CUSTOM_SPEED = 90;
     private static final String CUSTOM_THURTON_DRIVE_CAR_PROFILE_NAME = "car_custom_fast_thurton_drive";
     private static final String CLOSED_BASELINE_ROAD_CAR_PROFILE_NAME = "car_custom_closed_baseline_road";
     private static final ImmutableSet<String> CAR_PROFILES =
@@ -138,6 +147,11 @@ public class RouterServerTest extends ReplicaGraphHopperTest {
 
     private static RouterOuterClass.StreetRouteRequest createStreetRequest(String mode, boolean alternatives,
                                                                            double[] from, double[] to) {
+        return createStreetRequest(mode, alternatives, from, to, true);
+    }
+
+    private static RouterOuterClass.StreetRouteRequest createStreetRequest(String mode, boolean alternatives,
+                                                                           double[] from, double[] to, boolean returnFullPathDetails) {
         return RouterOuterClass.StreetRouteRequest.newBuilder()
                 .addPoints(0, RouterOuterClass.Point.newBuilder()
                         .setLat(from[0])
@@ -152,6 +166,7 @@ public class RouterServerTest extends ReplicaGraphHopperTest {
                 // below factors allow for long or very similar alternate routes for the sake of testing
                 .setAlternateRouteMaxWeightFactor(3.0)
                 .setAlternateRouteMaxShareFactor(0.9)
+                .setReturnFullPathDetails(returnFullPathDetails)
                 .build();
     }
 
@@ -384,7 +399,42 @@ public class RouterServerTest extends ReplicaGraphHopperTest {
             assertEquals(path.getStableEdgeIdsCount(), path.getEdgeDurationsMillisCount());
             int totalDurationMillis = path.getEdgeDurationsMillisList().stream().mapToInt(Long::intValue).sum();
             assertEquals(path.getDurationMillis(), totalDurationMillis);
+
+            Map<String, List<RouterOuterClass.StreetPathDetailValue>> pathDetailsByName = getPathDetailsByName(path);
+
+
+            // when the full path details are returned, stable edge ids and edge duration millis should also be present
+            // there (with higher fidelity, since the path details contain the mapping to GH edges). the top-level and
+            // path details values should match
+            if (!pathDetailsByName.isEmpty()) {
+                assertTrue(pathDetailsByName.containsKey(Parameters.Details.AVERAGE_SPEED));
+                assertTrue(pathDetailsByName.containsKey(RouterConstants.OSM_ID_PATH_DETAIL));
+                List<RouterOuterClass.StreetPathDetailValue> stableEdgeIdPathDetails = pathDetailsByName.get(StableIdPathDetailsBuilder.STABLE_EDGE_IDS_PATH_DETAIL);
+                List<RouterOuterClass.StreetPathDetailValue> timePathDetails = pathDetailsByName.get(Parameters.Details.TIME);
+
+                // the time and stable edge id details should align with the top-level fields and with each other
+                assertEquals(stableEdgeIdPathDetails.size(), timePathDetails.size());
+                assertEquals(stableEdgeIdPathDetails.size(), path.getStableEdgeIdsCount());
+                assertEquals(timePathDetails.size(), path.getEdgeDurationsMillisCount());
+
+                for (int i = 0; i < stableEdgeIdPathDetails.size(); i++) {
+                    RouterOuterClass.StreetPathDetailValue stableEdgeIdPathDetail = stableEdgeIdPathDetails.get(i);
+                    RouterOuterClass.StreetPathDetailValue timePathDetail = timePathDetails.get(i);
+
+                    assertEquals(stableEdgeIdPathDetail.getValue(), path.getStableEdgeIds(i));
+                    assertEquals(Long.parseLong(timePathDetail.getValue()), path.getEdgeDurationsMillis(i));
+
+                    assertEquals(stableEdgeIdPathDetail.getGhEdgeStartIndex(), timePathDetail.getGhEdgeStartIndex());
+                    assertEquals(stableEdgeIdPathDetail.getGhEdgeEndIndex(), timePathDetail.getGhEdgeEndIndex());
+                }
+            }
         }
+    }
+
+    private static Map<String, List<RouterOuterClass.StreetPathDetailValue>> getPathDetailsByName(RouterOuterClass.StreetPath path) {
+        return path.getPathDetailsList().stream()
+                .collect(Collectors.toMap(RouterOuterClass.StreetPathDetail::getDetail,
+                        RouterOuterClass.StreetPathDetail::getValuesList));
     }
 
     private static void checkStreetBasedResponseProfiles(RouterOuterClass.StreetRouteReply response,
@@ -437,7 +487,7 @@ public class RouterServerTest extends ReplicaGraphHopperTest {
 
     @Test
     public void testAutoQueryCustomSpeeds() {
-        // two nearby points in Roseville along Thurton Drive (OSM way ID 10485465)
+        // two nearby points in Roseville along Thurton Drive
         double[] origin = {38.75610459830836, -121.31971682573254};
         double[] dest = {38.75276653167277, -121.32034746128646};
 
@@ -448,20 +498,36 @@ public class RouterServerTest extends ReplicaGraphHopperTest {
             String defaultProfile = profileEntry.getValue();
 
             final RouterOuterClass.StreetRouteReply customSpeedsResponse = routerStub.routeStreetMode(
-                    createStreetRequest(customProfile, false, origin, dest));
+                    createStreetRequest(customProfile, false, origin, dest, true));
             checkStreetBasedResponse(customSpeedsResponse, ImmutableSet.of(customProfile), onlyOnePathPredicate);
 
             final RouterOuterClass.StreetRouteReply defaultSpeedsResponse = routerStub.routeStreetMode(
-                    createStreetRequest(defaultProfile, false, origin, dest));
+                    createStreetRequest(defaultProfile, false, origin, dest, true));
             checkStreetBasedResponse(defaultSpeedsResponse, ImmutableSet.of(defaultProfile), onlyOnePathPredicate);
 
             RouterOuterClass.StreetPath customSpeedsPath = Iterables.getOnlyElement(customSpeedsResponse.getPathsList());
             RouterOuterClass.StreetPath defaultSpeedsPath = Iterables.getOnlyElement(defaultSpeedsResponse.getPathsList());
 
+            double customSpeed = Double.parseDouble(getOnlyPathDetailValue(Parameters.Details.AVERAGE_SPEED, customSpeedsPath));
+            assertEquals(THURTON_DRIVE_CUSTOM_SPEED, customSpeed);
+
+            double defaultSpeed = Double.parseDouble(getOnlyPathDetailValue(Parameters.Details.AVERAGE_SPEED, defaultSpeedsPath));
+            assertTrue(defaultSpeed < customSpeed);
             // the custom speeds profile sets the Thurton Drive speed very high, so the travel time using this profile
             // should be less than the default
             assertTrue(customSpeedsPath.getDurationMillis() < defaultSpeedsPath.getDurationMillis());
+
+            // both paths should only involve the Thurton drive OSM way
+            for (RouterOuterClass.StreetPath path : Arrays.asList(customSpeedsPath, defaultSpeedsPath)) {
+                int osmId = Integer.parseInt(getOnlyPathDetailValue(RouterConstants.OSM_ID_PATH_DETAIL, path));
+                assertEquals(THURTON_DRIVE_OSM_ID, osmId);
+            }
         }
+    }
+
+    private static String getOnlyPathDetailValue(String detailName, RouterOuterClass.StreetPath streetPath) {
+        Map<String, List<RouterOuterClass.StreetPathDetailValue>> customPathDetailsByName = getPathDetailsByName(streetPath);
+        return Iterables.getOnlyElement(customPathDetailsByName.get(detailName)).getValue();
     }
 
     // tests road closure simulation via setting a custom speed for an OSM way to 0
@@ -488,5 +554,18 @@ public class RouterServerTest extends ReplicaGraphHopperTest {
         // should be greater than the default
         assertTrue(customSpeedsPath.getDistanceMeters() > defaultSpeedsPath.getDistanceMeters());
         assertTrue(customSpeedsPath.getDurationMillis() > defaultSpeedsPath.getDurationMillis());
+    }
+
+    @Test
+    public void testPathDetailsReturnedWhenRequested() {
+        final RouterOuterClass.StreetRouteReply responseWithoutDetails = routerStub.routeStreetMode(createStreetRequest("car", false, REQUEST_ORIGIN_1, REQUEST_DESTINATION_1, false));
+        assertTrue(responseWithoutDetails.getPathsList().stream().allMatch(path -> path.getPathDetailsCount() == 0));
+
+        final RouterOuterClass.StreetRouteReply responseWithDetails = routerStub.routeStreetMode(createStreetRequest("car", false, REQUEST_ORIGIN_1, REQUEST_DESTINATION_1, true));
+        assertTrue(responseWithDetails.getPathsList().stream()
+                .map(RouterServerTest::getPathDetailsByName)
+                .map(Map::keySet)
+                .allMatch(details -> details.containsAll(List.of(
+                        StableIdPathDetailsBuilder.STABLE_EDGE_IDS_PATH_DETAIL, Parameters.Details.TIME, RouterConstants.OSM_ID_PATH_DETAIL, Parameters.Details.AVERAGE_SPEED))));
     }
 }

--- a/web/test-data/custom_speeds/custom_fast_thurton_drive_speed.csv
+++ b/web/test-data/custom_speeds/custom_fast_thurton_drive_speed.csv
@@ -1,2 +1,2 @@
 osm_way_id,max_speed_kph
-10485465,1000
+10485465,90


### PR DESCRIPTION
https://replicahq.atlassian.net/browse/RAD-6448

This PR updates the router to return the full path details for each returned `StreetPath` when requested. As described in https://github.com/replicahq/idls/pull/111:

> Path details are additional metadata useful for debugging. To start, path details will contain the OSM IDs, internal Graphhopper speeds, stable edge ids, and edge durations along each path, but more details may be added in the future. The stable edge ids and edge durations are also returned as top-level fields in the StreetPath, but they are repeated in the path details in higher fidelity since the path details contain the exact mapping of each detail value to the corresponding GH edge indexes. Clients can request the full path details to be returned by setting the new return_full_path_details field in the request, which defaults to False.

This PR updates the router GUI to request the full path details. The routing client in the model repo will not request these path details to avoid bloating responses unnecessarily during prod runs. Once https://github.com/replicahq/idls/pull/111 merges, I'll update this PR to point to `idls` master instead of my `bwilliams/path-details` branch.

I updated the `RouterServerTest` to check that path details are only returned when requested, and to confirm the speed and osm id details are as expected for our existing custom speeds test case. I also updated `checkStreetBasedResponse` which is used throughout the class to confirm that the top-level stable edge ids and edge durations match the values from the path details. The method now also confirms that the stable edge ids and edge durations in the path details align, i.e. their GH start and end indexes always match. So you were correct yesterday when saying that the top-level stable edge ids and edge durations are always perfectly aligned, and we now have some automated checking! Sorry about the confusion there. Let me know if you want me to dig deeper into those occasional stable edge id/edge durations that stretch across multiple GH internal edges, but sounded like this was ~somewhat expected due to GH "hidden" edges? Can't remember the term you used.

As part of the unit testing, I discovered that the router is still enforcing a max speed for each vehicle type even when custom speeds are used. So this PR bumps the test custom speeds value down from 1000 to 90kph, which is below the max for cars, trucks, and small trucks. I considered allowing custom speeds to exceed these maximums, but it seems like a useful protection to have. If you're on board with keeping these maximums, I can add an explicit failure in a follow-up so the router will fail fast if it's given a custom speed above the max for the vehicle type rather than silently using the max instead as it does currently.

Ran the updated router GUI and confirmed the full path details are now printed:

<img width="1752" alt="router gui path details" src="https://github.com/replicahq/graphhopper/assets/112983365/ce1453ec-d088-4098-9495-83017fea600e">

Used the same Thurton drive test case. The `small_truck_default` profile prints the default truck speeds, whereas the `small_truck_custom_fast_thurton_drive` profile has the larger custom speed of 90kph along the first stretch of the path.



cc @rregue 