### PR TITLE
Bump GTFS validator runtime memory to fit n1-standard-32 machines

### DIFF
--- a/run_gtfs_validation.sh
+++ b/run_gtfs_validation.sh
@@ -8,6 +8,6 @@ export GTFS_FILE_LIST=$(ls ./gtfs/ | awk '{print "./gtfs/"$1}' | paste -s -d, -)
 GTFS_SCHEDULE_DAYS="$1"
 sed -i -e "s/{{ GTFS_SCHEDULE_DAYS }}/${GTFS_SCHEDULE_DAYS}/g" ./configs/gtfs_validation_gh_config_phase_2.yaml
 
-java -Xmx58g -Ddw.graphhopper.gtfs.file=$GTFS_FILE_LIST \
+java -Xmx110g -Ddw.graphhopper.gtfs.file=$GTFS_FILE_LIST \
   -Ddw.graphhopper.validation=true -classpath web/target/graphhopper-web-1.0-SNAPSHOT.jar \
   com.graphhopper.http.GraphHopperApplication validate-gtfs ./configs/gtfs_validation_gh_config_phase_2.yaml


### PR DESCRIPTION
While working on productionizing the nationwide transit router, I hit a simple [heap memory failure](https://console.cloud.google.com/cloud-build/builds;region=global/390a104c-c474-4338-a05f-0a3d128fe993?project=model-159019) in the gtfs validator DM. This change bumps the heap used by the validator to 10gb below the maximum memory available in the [n1-standard-32 machines we're going to use for the validator in the nationwide router PR](https://github.com/replicahq/model/compare/usa_router_test?diff=split&w=#diff-9a26a7ac1dcfd337648284483304f6dd1b4375bf266658b8006a93aa24fde2faR5) (120gb)

I successfully [built](https://github.com/replicahq/graphhopper/actions/runs/7188101691/job/19577060903) a new GTFS validator image off of this branch, and plugged it into the model repo PR where I'm working on the nationwide router. A new (nationwide) run of the validator [succeeded](https://cloud.prefect.io/replica/flow-run/6f40ded1-e7af-44b9-9c0d-44365fc88a4d) off of that branch

There should be no issue merging this before the related model repo PR lands, because on model's master branch (where n1-standard-16 machines are currently used for the validator), the TN CDP configs point to an older validator image built with an appropriate heap setting for those machines

cc @bryanwilliams1025 