### PR TITLE
Support custom speeds for bike + ped

### DIFF
--- a/configs/test_gh_config.yaml
+++ b/configs/test_gh_config.yaml
@@ -52,6 +52,9 @@ graphhopper:
       weighting: fastest
       # sets a zero speed for a section of Baseline Road in Roseville (OSM way id 76254223)
       custom_speed_file: test-data/custom_speeds/baseline_road_zero_speed.csv # mvn tests run from the /web folder
+    - name: foot  # "foot" profile name required for internal PT routing usage
+      vehicle: foot
+      weighting: fastest
     - name: foot_default  # _default suffix required for comparison against Thurton Drive custom speeds profile
       vehicle: foot
       weighting: fastest
@@ -85,6 +88,7 @@ graphhopper:
     - profile: car_custom_closed_baseline_road
     - profile: bike_default
     - profile: bike_custom_closed_baseline_road
+    - profile: foot
     - profile: foot_default
     - profile: foot_custom_closed_baseline_road
     - profile: truck_default

--- a/configs/test_gh_config.yaml
+++ b/configs/test_gh_config.yaml
@@ -44,7 +44,7 @@ graphhopper:
       weighting: fastest
       # sets a zero speed for a section of Baseline Road in Roseville (OSM way id 76254223)
       custom_speed_file: test-data/custom_speeds/baseline_road_zero_speed.csv # mvn tests run from the /web folder
-    - name: bike_default  # _default suffix required for comparison against Thurton Drive custom speeds profile
+    - name: bike_default  # _default suffix required for comparison against closed Baseline Road custom speeds profile
       vehicle: bike
       weighting: fastest
     - name: bike_custom_closed_baseline_road
@@ -55,7 +55,7 @@ graphhopper:
     - name: foot  # "foot" profile name required for internal PT routing usage
       vehicle: foot
       weighting: fastest
-    - name: foot_default  # _default suffix required for comparison against Thurton Drive custom speeds profile
+    - name: foot_default  # _default suffix required for comparison against closed Baseline Road custom speeds profile
       vehicle: foot
       weighting: fastest
     - name: foot_custom_closed_baseline_road

--- a/configs/test_gh_config.yaml
+++ b/configs/test_gh_config.yaml
@@ -44,12 +44,22 @@ graphhopper:
       weighting: fastest
       # sets a zero speed for a section of Baseline Road in Roseville (OSM way id 76254223)
       custom_speed_file: test-data/custom_speeds/baseline_road_zero_speed.csv # mvn tests run from the /web folder
-    - name: bike
+    - name: bike_default  # _default suffix required for comparison against Thurton Drive custom speeds profile
       vehicle: bike
       weighting: fastest
-    - name: foot
+    - name: bike_custom_closed_baseline_road
+      vehicle: bike_custom_closed_baseline_road
+      weighting: fastest
+      # sets a zero speed for a section of Baseline Road in Roseville (OSM way id 76254223)
+      custom_speed_file: test-data/custom_speeds/baseline_road_zero_speed.csv # mvn tests run from the /web folder
+    - name: foot_default  # _default suffix required for comparison against Thurton Drive custom speeds profile
       vehicle: foot
       weighting: fastest
+    - name: foot_custom_closed_baseline_road
+      vehicle: foot_custom_closed_baseline_road
+      weighting: fastest
+      # sets a zero speed for a section of Baseline Road in Roseville (OSM way id 76254223)
+      custom_speed_file: test-data/custom_speeds/baseline_road_zero_speed.csv # mvn tests run from the /web folder
     - name: truck_default # needed for comparison against Thurton Drive custom speeds profile
       vehicle: truck
       weighting: fastest
@@ -73,8 +83,10 @@ graphhopper:
     - profile: car_freeway
     - profile: car_custom_fast_thurton_drive
     - profile: car_custom_closed_baseline_road
-    - profile: bike
-    - profile: foot
+    - profile: bike_default
+    - profile: bike_custom_closed_baseline_road
+    - profile: foot_default
+    - profile: foot_custom_closed_baseline_road
     - profile: truck_default
     - profile: truck_custom_fast_thurton_drive
     - profile: small_truck_default

--- a/replica-common/src/main/java/com/graphhopper/RouterConstants.java
+++ b/replica-common/src/main/java/com/graphhopper/RouterConstants.java
@@ -10,15 +10,11 @@ public final class RouterConstants {
         // utility class
     }
 
-    // TODO: Do we want to use these, when there's an equivalent definition in VehicleEncodedValuesFactory?
     public static final String CAR_VEHICLE_NAME = "car";
     public static final String TRUCK_VEHICLE_NAME = "truck";
     public static final String SMALL_TRUCK_VEHICLE_NAME = "small_truck";
     public static final String BIKE_VEHICLE_NAME = "bike";
     public static final String FOOT_VEHICLE_NAME = "foot";
-
-    // TODO: maybe move this? Use different (higher) value too?
-    public static final int FOOT_MAX_SPEED = 10;
 
     public static final Set<Integer> STREET_BASED_ROUTE_TYPES = Sets.newHashSet(0, 3, 5);
 

--- a/replica-common/src/main/java/com/graphhopper/RouterConstants.java
+++ b/replica-common/src/main/java/com/graphhopper/RouterConstants.java
@@ -18,7 +18,7 @@ public final class RouterConstants {
     public static final String FOOT_VEHICLE_NAME = "foot";
 
     // TODO: maybe move this? Use different (higher) value too?
-    public static final int FOOT_MAX_SPEED = 5;
+    public static final int FOOT_MAX_SPEED = 10;
 
     public static final Set<Integer> STREET_BASED_ROUTE_TYPES = Sets.newHashSet(0, 3, 5);
 

--- a/replica-common/src/main/java/com/graphhopper/RouterConstants.java
+++ b/replica-common/src/main/java/com/graphhopper/RouterConstants.java
@@ -10,9 +10,15 @@ public final class RouterConstants {
         // utility class
     }
 
+    // TODO: Do we want to use these, when there's an equivalent definition in VehicleEncodedValuesFactory?
     public static final String CAR_VEHICLE_NAME = "car";
     public static final String TRUCK_VEHICLE_NAME = "truck";
     public static final String SMALL_TRUCK_VEHICLE_NAME = "small_truck";
+    public static final String BIKE_VEHICLE_NAME = "bike";
+    public static final String FOOT_VEHICLE_NAME = "foot";
+
+    // TODO: maybe move this? Use different (higher) value too?
+    public static final int FOOT_MAX_SPEED = 5;
 
     public static final Set<Integer> STREET_BASED_ROUTE_TYPES = Sets.newHashSet(0, 3, 5);
 

--- a/web-bundle/src/main/java/com/graphhopper/customspeeds/CustomSpeedsVehicle.java
+++ b/web-bundle/src/main/java/com/graphhopper/customspeeds/CustomSpeedsVehicle.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.graphhopper.RouterConstants;
 import com.graphhopper.http.TruckAverageSpeedParser;
+import com.graphhopper.routing.util.parsers.BikeAverageSpeedParser;
 import com.graphhopper.routing.util.parsers.CarAverageSpeedParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,11 +14,12 @@ import java.util.*;
 public class CustomSpeedsVehicle {
     private static final Logger logger = LoggerFactory.getLogger(CustomSpeedsVehicle.class);
 
-    // TODO support custom speeds for bikes and pedestrians (RAD-6445, RAD-6446)
     public enum VehicleType {
         CAR(CarAverageSpeedParser.CAR_MAX_SPEED),
         TRUCK(TruckAverageSpeedParser.EE_TRUCK_MAX_SPEED),
-        SMALL_TRUCK(TruckAverageSpeedParser.EE_SMALL_TRUCK_MAX_SPEED);
+        SMALL_TRUCK(TruckAverageSpeedParser.EE_SMALL_TRUCK_MAX_SPEED),
+        BIKE(BikeAverageSpeedParser.MAX_SPEED),
+        FOOT(RouterConstants.FOOT_MAX_SPEED);
 
         private double maxValidSpeed;
 
@@ -72,6 +74,12 @@ public class CustomSpeedsVehicle {
         }
         if (customVehicleName.startsWith(RouterConstants.SMALL_TRUCK_VEHICLE_NAME)) {
             return CustomSpeedsVehicle.VehicleType.SMALL_TRUCK;
+        }
+        if (customVehicleName.startsWith(RouterConstants.BIKE_VEHICLE_NAME)) {
+            return CustomSpeedsVehicle.VehicleType.BIKE;
+        }
+        if (customVehicleName.startsWith(RouterConstants.FOOT_VEHICLE_NAME)) {
+            return CustomSpeedsVehicle.VehicleType.FOOT;
         }
         throw new IllegalArgumentException("Could not determine base vehicle type for custom speeds vehicle " + customVehicleName + ". Supported base vehicle types: " + EnumSet.allOf(CustomSpeedsVehicle.VehicleType.class));
     }

--- a/web-bundle/src/main/java/com/graphhopper/customspeeds/CustomSpeedsVehicle.java
+++ b/web-bundle/src/main/java/com/graphhopper/customspeeds/CustomSpeedsVehicle.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.graphhopper.RouterConstants;
 import com.graphhopper.http.TruckAverageSpeedParser;
+import com.graphhopper.replica.ReplicaCustomSpeedsFootTagParser;
 import com.graphhopper.routing.util.parsers.BikeAverageSpeedParser;
 import com.graphhopper.routing.util.parsers.CarAverageSpeedParser;
 import org.slf4j.Logger;
@@ -19,7 +20,7 @@ public class CustomSpeedsVehicle {
         TRUCK(TruckAverageSpeedParser.EE_TRUCK_MAX_SPEED),
         SMALL_TRUCK(TruckAverageSpeedParser.EE_SMALL_TRUCK_MAX_SPEED),
         BIKE(BikeAverageSpeedParser.MAX_SPEED),
-        FOOT(RouterConstants.FOOT_MAX_SPEED);
+        FOOT(ReplicaCustomSpeedsFootTagParser.FOOT_MAX_SPEED);
 
         private double maxValidSpeed;
 

--- a/web-bundle/src/main/java/com/graphhopper/replica/ReplicaCustomSpeedsBikeTagParser.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/ReplicaCustomSpeedsBikeTagParser.java
@@ -1,0 +1,22 @@
+package com.graphhopper.replica;
+
+import com.google.common.collect.ImmutableMap;
+import com.graphhopper.customspeeds.CustomSpeedsUtils;
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.EncodedValueLookup;
+import com.graphhopper.routing.util.parsers.BikeAverageSpeedParser;
+import com.graphhopper.util.PMap;
+
+public class ReplicaCustomSpeedsBikeTagParser extends BikeAverageSpeedParser {
+    private final ImmutableMap<Long, Double> osmWayIdToMaxSpeed;
+
+    public ReplicaCustomSpeedsBikeTagParser(EncodedValueLookup lookup, PMap configuration, ImmutableMap<Long, Double> osmWayIdToMaxSpeed) {
+        super(lookup, configuration);
+        this.osmWayIdToMaxSpeed = osmWayIdToMaxSpeed;
+    }
+
+    @Override
+    public double applyMaxSpeed(ReaderWay way, double speed, boolean bwd) {
+        return CustomSpeedsUtils.getCustomMaxSpeed(way, osmWayIdToMaxSpeed).orElseGet(() -> super.applyMaxSpeed(way, speed, bwd));
+    }
+}

--- a/web-bundle/src/main/java/com/graphhopper/replica/ReplicaCustomSpeedsCarTagParser.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/ReplicaCustomSpeedsCarTagParser.java
@@ -5,10 +5,7 @@ import com.graphhopper.customspeeds.CustomSpeedsUtils;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.EncodedValueLookup;
 import com.graphhopper.routing.util.parsers.CarAverageSpeedParser;
-import com.graphhopper.routing.util.parsers.TagParser;
 import com.graphhopper.util.PMap;
-
-import java.util.Objects;
 
 public class ReplicaCustomSpeedsCarTagParser extends CarAverageSpeedParser {
     private final ImmutableMap<Long, Double> osmWayIdToMaxSpeed;

--- a/web-bundle/src/main/java/com/graphhopper/replica/ReplicaCustomSpeedsFootTagParser.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/ReplicaCustomSpeedsFootTagParser.java
@@ -1,0 +1,59 @@
+package com.graphhopper.replica;
+
+import com.google.common.collect.ImmutableMap;
+import com.graphhopper.customspeeds.CustomSpeedsUtils;
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.EdgeIntAccess;
+import com.graphhopper.routing.ev.EncodedValueLookup;
+import com.graphhopper.routing.util.parsers.FootAverageSpeedParser;
+import com.graphhopper.util.PMap;
+
+public class ReplicaCustomSpeedsFootTagParser extends FootAverageSpeedParser {
+    private final ImmutableMap<Long, Double> osmWayIdToMaxSpeed;
+
+    // Copied directly from FootAverageSpeedParser
+    static final int SLOW_SPEED = 2;
+    static final int MEAN_SPEED = 5;
+
+    public ReplicaCustomSpeedsFootTagParser(EncodedValueLookup lookup, PMap configuration, ImmutableMap<Long, Double> osmWayIdToMaxSpeed) {
+        super(lookup, configuration);
+        this.osmWayIdToMaxSpeed = osmWayIdToMaxSpeed;
+    }
+
+    // Copied directly from FootAverageSpeedParser, edited to call edited setSpeed() function
+    @Override
+    public void handleWayTags(int edgeId, EdgeIntAccess edgeIntAccess, ReaderWay way) {
+        String highwayValue = way.getTag("highway");
+        if (highwayValue == null) {
+            if (way.hasTag("route", ferries)) {
+                double ferrySpeed = ferrySpeedCalc.getSpeed(way);
+                setSpeed(edgeId, edgeIntAccess, true, true, ferrySpeed, way);
+            }
+            if (!way.hasTag("railway", "platform") && !way.hasTag("man_made", "pier"))
+                return;
+        }
+
+        String sacScale = way.getTag("sac_scale");
+        if (sacScale != null) {
+            setSpeed(edgeId, edgeIntAccess, true, true, "hiking".equals(sacScale) ? MEAN_SPEED : SLOW_SPEED, way);
+        } else {
+            setSpeed(edgeId, edgeIntAccess, true, true, way.hasTag("highway", "steps") ? MEAN_SPEED - 2 : MEAN_SPEED, way);
+        }
+    }
+
+    // Overrides speed with custom speed, if one exists
+    void setSpeed(int edgeId, EdgeIntAccess edgeIntAccess, boolean fwd, boolean bwd, double speed, ReaderWay way) {
+         double speedToSet = CustomSpeedsUtils.getCustomMaxSpeed(way, osmWayIdToMaxSpeed).orElse(speed);
+         setSpeed(edgeId, edgeIntAccess, fwd, bwd, speedToSet);
+    }
+
+    // Copied directly from FootAverageSpeedParser
+    void setSpeed(int edgeId, EdgeIntAccess edgeIntAccess, boolean fwd, boolean bwd, double speed) {
+        if (speed > getMaxSpeed())
+            speed = getMaxSpeed();
+        if (fwd)
+            avgSpeedEnc.setDecimal(false, edgeId, edgeIntAccess, speed);
+        if (bwd && avgSpeedEnc.isStoreTwoDirections())
+            avgSpeedEnc.setDecimal(true, edgeId, edgeIntAccess, speed);
+    }
+}

--- a/web-bundle/src/main/java/com/graphhopper/replica/ReplicaCustomSpeedsFootTagParser.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/ReplicaCustomSpeedsFootTagParser.java
@@ -11,6 +11,9 @@ import com.graphhopper.util.PMap;
 public class ReplicaCustomSpeedsFootTagParser extends FootAverageSpeedParser {
     private final ImmutableMap<Long, Double> osmWayIdToMaxSpeed;
 
+    // Replica-specific limit for custom walking speeds
+    public static final int FOOT_MAX_SPEED = 10;
+    
     // Copied directly from FootAverageSpeedParser
     static final int SLOW_SPEED = 2;
     static final int MEAN_SPEED = 5;

--- a/web-bundle/src/main/java/com/graphhopper/replica/ReplicaVehicleEncodedValuesFactory.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/ReplicaVehicleEncodedValuesFactory.java
@@ -29,12 +29,17 @@ public class ReplicaVehicleEncodedValuesFactory extends DefaultVehicleEncodedVal
             baseCustomSpeedsVehicleType = customSpeedsVehiclesByName.get(vehicleName).baseVehicleType;
         }
 
+        // TODO: Do we need to have the first clause in these checks? Won't the super() call handle these cases fine?
         if (vehicleName.equals(RouterConstants.CAR_VEHICLE_NAME) || baseCustomSpeedsVehicleType == CustomSpeedsVehicle.VehicleType.CAR) {
             return VehicleEncodedValues.car(configuration);
         } else if (vehicleName.equals(RouterConstants.TRUCK_VEHICLE_NAME) || baseCustomSpeedsVehicleType == CustomSpeedsVehicle.VehicleType.TRUCK) {
             return TruckFlagEncoder.createTruck(vehicleName);
         } else if (vehicleName.equals(RouterConstants.SMALL_TRUCK_VEHICLE_NAME) || baseCustomSpeedsVehicleType == CustomSpeedsVehicle.VehicleType.SMALL_TRUCK) {
             return TruckFlagEncoder.createSmallTruck(vehicleName);
+        } else if (vehicleName.equals(RouterConstants.BIKE_VEHICLE_NAME) || baseCustomSpeedsVehicleType == CustomSpeedsVehicle.VehicleType.BIKE) {
+            return VehicleEncodedValues.bike(configuration);
+        } else if (vehicleName.equals(RouterConstants.FOOT_VEHICLE_NAME) || baseCustomSpeedsVehicleType == CustomSpeedsVehicle.VehicleType.FOOT) {
+            return VehicleEncodedValues.foot(configuration);
         }
 
         return super.createVehicleEncodedValues(vehicleName, configuration);

--- a/web-bundle/src/main/java/com/graphhopper/replica/ReplicaVehicleEncodedValuesFactory.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/ReplicaVehicleEncodedValuesFactory.java
@@ -29,7 +29,6 @@ public class ReplicaVehicleEncodedValuesFactory extends DefaultVehicleEncodedVal
             baseCustomSpeedsVehicleType = customSpeedsVehiclesByName.get(vehicleName).baseVehicleType;
         }
 
-        // TODO: Do we need to have the first clause in these checks? Won't the super() call handle these cases fine?
         if (vehicleName.equals(RouterConstants.CAR_VEHICLE_NAME) || baseCustomSpeedsVehicleType == CustomSpeedsVehicle.VehicleType.CAR) {
             return VehicleEncodedValues.car(configuration);
         } else if (vehicleName.equals(RouterConstants.TRUCK_VEHICLE_NAME) || baseCustomSpeedsVehicleType == CustomSpeedsVehicle.VehicleType.TRUCK) {

--- a/web-bundle/src/main/java/com/graphhopper/replica/ReplicaVehicleTagParserFactory.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/ReplicaVehicleTagParserFactory.java
@@ -27,7 +27,7 @@ import com.graphhopper.reader.osm.conditional.DateRangeParser;
 import com.graphhopper.routing.ev.EncodedValueLookup;
 import com.graphhopper.routing.util.DefaultVehicleTagParserFactory;
 import com.graphhopper.routing.util.VehicleTagParsers;
-import com.graphhopper.routing.util.parsers.CarAccessParser;
+import com.graphhopper.routing.util.parsers.*;
 import com.graphhopper.util.PMap;
 
 import static com.graphhopper.http.TruckAverageSpeedParser.*;
@@ -63,9 +63,23 @@ public class ReplicaVehicleTagParserFactory extends DefaultVehicleTagParserFacto
             return new VehicleTagParsers(
                     new CarAccessParser(lookup, configuration).init(configuration.getObject("date_range_parser", new DateRangeParser())),
                     new ReplicaCustomSpeedsCarTagParser(lookup, configuration, osmWayIdToCustomSpeed),
-                    null);
-
-        } else if (vehicleName.equals(RouterConstants.CAR_VEHICLE_NAME) ) {
+                    null
+            );
+        } else if (baseCustomSpeedsVehicleType == CustomSpeedsVehicle.VehicleType.BIKE) {
+            return new VehicleTagParsers(
+                    new BikeAccessParser(lookup, configuration).init(configuration.getObject("date_range_parser", new DateRangeParser())),
+                    new ReplicaCustomSpeedsBikeTagParser(lookup, configuration, osmWayIdToCustomSpeed),
+                    new BikePriorityParser(lookup, configuration)
+            );
+        } else if (baseCustomSpeedsVehicleType == CustomSpeedsVehicle.VehicleType.FOOT) {
+            return new VehicleTagParsers(
+                    new FootAccessParser(lookup, configuration).init(configuration.getObject("date_range_parser", new DateRangeParser())),
+                    new ReplicaCustomSpeedsFootTagParser(lookup, configuration, osmWayIdToCustomSpeed),
+                    new FootPriorityParser(lookup, configuration)
+            );
+        } else if (vehicleName.equals(RouterConstants.CAR_VEHICLE_NAME)
+                || vehicleName.equals(RouterConstants.BIKE_VEHICLE_NAME)
+                || vehicleName.equals(RouterConstants.FOOT_VEHICLE_NAME)) {
             // do nothing and carry through to superclass implementation. we could use pass an empty custom speeds mapping
             // to ReplicaCustomSpeedsCarTagParser, but it's safer to use the default GraphHopper behavior directly
         } else if (vehicleName.equals(RouterConstants.TRUCK_VEHICLE_NAME) || baseCustomSpeedsVehicleType == CustomSpeedsVehicle.VehicleType.TRUCK) {

--- a/web-bundle/src/test/java/com/graphhopper/customspeeds/CustomSpeedsUtilsTest.java
+++ b/web-bundle/src/test/java/com/graphhopper/customspeeds/CustomSpeedsUtilsTest.java
@@ -15,6 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class CustomSpeedsUtilsTest {
     private static final ImmutableMap<Long, Double> TEST_CUSTOM_SPEEDS = ImmutableMap.of(1L, 2.0, 3L, 4.0, 123L, 45.6789);
     private static final ImmutableMap<Long, Double> FAST_THRUTON_DRIVE_SPEEDS = ImmutableMap.of(10485465L, 90.0);
+    private static final ImmutableMap<Long, Double> BASELINE_ROAD_CLOSURE_SPEEDS = ImmutableMap.of(76254223L, 0.0);
 
     @Test
     public void testGetCustomSpeedVehiclesByName() {
@@ -23,7 +24,9 @@ public class CustomSpeedsUtilsTest {
                 createProfile("prof2", "car_custom", "../web/test-data/custom_speeds/test_custom_speeds.csv"),
                 createProfile("prof3", "car_custom_2", "../web/test-data/custom_speeds/custom_fast_thurton_drive_speed.csv"),
                 createProfile("prof4", "truck", "../web/test-data/custom_speeds/custom_fast_thurton_drive_speed.csv"),
-                createProfile("prof5", "small_truck", "../web/test-data/custom_speeds/test_custom_speeds.csv")
+                createProfile("prof5", "small_truck", "../web/test-data/custom_speeds/test_custom_speeds.csv"),
+                createProfile("prof6", "foot", "../web/test-data/custom_speeds/baseline_road_zero_speed.csv"),
+                createProfile("prof7", "bike", "../web/test-data/custom_speeds/baseline_road_zero_speed.csv")
         );
         ImmutableMap<String, CustomSpeedsVehicle> customSpeedVehiclesByName =
                 CustomSpeedsUtils.getCustomSpeedVehiclesByName(profiles);
@@ -31,7 +34,9 @@ public class CustomSpeedsUtilsTest {
                 "car_custom", CustomSpeedsVehicle.create("car_custom", TEST_CUSTOM_SPEEDS),
                 "car_custom_2", CustomSpeedsVehicle.create("car_custom_2", FAST_THRUTON_DRIVE_SPEEDS),
                 "truck", CustomSpeedsVehicle.create("truck", FAST_THRUTON_DRIVE_SPEEDS),
-                "small_truck", CustomSpeedsVehicle.create("small_truck", TEST_CUSTOM_SPEEDS));
+                "small_truck", CustomSpeedsVehicle.create("small_truck", TEST_CUSTOM_SPEEDS),
+                "foot", CustomSpeedsVehicle.create("foot", BASELINE_ROAD_CLOSURE_SPEEDS),
+                "bike", CustomSpeedsVehicle.create("bike", BASELINE_ROAD_CLOSURE_SPEEDS));
         assertEquals(expectedCustomSpeedVehiclesByName, customSpeedVehiclesByName);
     }
 
@@ -67,9 +72,9 @@ public class CustomSpeedsUtilsTest {
 
     @Test
     public void testGetCustomSpeedVehiclesByNameUnsupportedBaseVehicle() {
-        // custom speeds only currently support cars/trucks/small_trucks
+        // custom speeds only currently support cars/trucks/small_trucks/foot/bike
         List<Profile> invalidProfiles = ImmutableList.of(
-                createProfile("prof1", "bike_custom", "../web/test-data/custom_speeds/test_custom_speeds.csv")
+                createProfile("prof1", "ferry_custom", "../web/test-data/custom_speeds/test_custom_speeds.csv")
         );
         assertThrows(IllegalArgumentException.class, () ->
                 CustomSpeedsUtils.getCustomSpeedVehiclesByName(invalidProfiles));

--- a/web-bundle/src/test/java/com/graphhopper/customspeeds/CustomSpeedsVehicleTest.java
+++ b/web-bundle/src/test/java/com/graphhopper/customspeeds/CustomSpeedsVehicleTest.java
@@ -18,6 +18,12 @@ public class CustomSpeedsVehicleTest {
         ImmutableMap<Long, Double> invalidTruckCustomSpeeds = ImmutableMap.of(1L, 100.0, 2L, 0.0);
         assertFalse(CustomSpeedsVehicle.validateCustomSpeeds("truck_invalid", invalidTruckCustomSpeeds));
 
+        ImmutableMap<Long, Double> invalidBikeCustomSpeeds = ImmutableMap.of(1L, 35.0, 2L, 0.0);
+        assertFalse(CustomSpeedsVehicle.validateCustomSpeeds("bike_invalid", invalidBikeCustomSpeeds));
+
+        ImmutableMap<Long, Double> invalidFootCustomSpeeds = ImmutableMap.of(1L, 15.0, 2L, 0.0);
+        assertFalse(CustomSpeedsVehicle.validateCustomSpeeds("foot_invalid", invalidFootCustomSpeeds));
+
         // validation should be vehicle-specific. speed is too high for trucks, but valid for cars
         ImmutableMap<Long, Double> validCarCustomSpeeds = invalidTruckCustomSpeeds;
         assertTrue(CustomSpeedsVehicle.validateCustomSpeeds("car_valid", validCarCustomSpeeds));

--- a/web/src/test/java/com/replica/RouterServerTest.java
+++ b/web/src/test/java/com/replica/RouterServerTest.java
@@ -81,6 +81,8 @@ public class RouterServerTest extends ReplicaGraphHopperTest {
     private static final String DEFAULT_CAR_PROFILE_NAME = "car_default";
     private static final String DEFAULT_TRUCK_PROFILE_NAME = "truck_default";
     private static final String DEFAULT_SMALL_TRUCK_PROFILE_NAME = "small_truck_default";
+    private static final String DEFAULT_BIKE_PROFILE_NAME = "bike_default";
+    private static final String DEFAULT_FOOT_PROFILE_NAME = "foot_default";
 
     private static final RouterOuterClass.StreetRouteRequest AUTO_REQUEST =
             createStreetRequest("car", false, REQUEST_ORIGIN_1, REQUEST_DESTINATION_1);
@@ -121,6 +123,8 @@ public class RouterServerTest extends ReplicaGraphHopperTest {
     private static final double THURTON_DRIVE_CUSTOM_SPEED = 90;
     private static final String CUSTOM_THURTON_DRIVE_CAR_PROFILE_NAME = "car_custom_fast_thurton_drive";
     private static final String CLOSED_BASELINE_ROAD_CAR_PROFILE_NAME = "car_custom_closed_baseline_road";
+    private static final String CLOSED_BASELINE_ROAD_BIKE_PROFILE_NAME = "bike_custom_closed_baseline_road";
+    private static final String CLOSED_BASELINE_ROAD_FOOT_PROFILE_NAME = "foot_custom_closed_baseline_road";
     private static final ImmutableSet<String> CAR_PROFILES =
             ImmutableSet.of("car", "car_freeway", DEFAULT_CAR_PROFILE_NAME, CUSTOM_THURTON_DRIVE_CAR_PROFILE_NAME, CLOSED_BASELINE_ROAD_CAR_PROFILE_NAME);
 
@@ -594,13 +598,20 @@ public class RouterServerTest extends ReplicaGraphHopperTest {
 
         Predicate<Long> onlyOnePathPredicate = pathCount -> pathCount == 1L;
 
+        checkCustomSpeedRoadClosure(CLOSED_BASELINE_ROAD_CAR_PROFILE_NAME, DEFAULT_CAR_PROFILE_NAME, origin, dest, onlyOnePathPredicate);
+        checkCustomSpeedRoadClosure(CLOSED_BASELINE_ROAD_BIKE_PROFILE_NAME, DEFAULT_BIKE_PROFILE_NAME, origin, dest, onlyOnePathPredicate);
+        checkCustomSpeedRoadClosure(CLOSED_BASELINE_ROAD_FOOT_PROFILE_NAME, DEFAULT_FOOT_PROFILE_NAME, origin, dest, onlyOnePathPredicate);
+    }
+
+    private static void checkCustomSpeedRoadClosure(String closedRoadProfileName, String defaultProfileName,
+                                                    double[] origin, double[] dest, Predicate<Long> onlyOnePathPredicate) {
         final RouterOuterClass.StreetRouteReply customSpeedsResponse = routerStub.routeStreetMode(
-                createStreetRequest(CLOSED_BASELINE_ROAD_CAR_PROFILE_NAME, false, origin, dest));
-        checkStreetBasedResponse(customSpeedsResponse, ImmutableSet.of(CLOSED_BASELINE_ROAD_CAR_PROFILE_NAME), onlyOnePathPredicate);
+                createStreetRequest(closedRoadProfileName, false, origin, dest));
+        checkStreetBasedResponse(customSpeedsResponse, ImmutableSet.of(closedRoadProfileName), onlyOnePathPredicate);
 
         final RouterOuterClass.StreetRouteReply defaultSpeedsResponse = routerStub.routeStreetMode(
-                createStreetRequest(DEFAULT_CAR_PROFILE_NAME, false, origin, dest));
-        checkStreetBasedResponse(defaultSpeedsResponse, ImmutableSet.of(DEFAULT_CAR_PROFILE_NAME), onlyOnePathPredicate);
+                createStreetRequest(defaultProfileName, false, origin, dest));
+        checkStreetBasedResponse(defaultSpeedsResponse, ImmutableSet.of(defaultProfileName), onlyOnePathPredicate);
 
         RouterOuterClass.StreetPath customSpeedsPath = Iterables.getOnlyElement(customSpeedsResponse.getPathsList());
         RouterOuterClass.StreetPath defaultSpeedsPath = Iterables.getOnlyElement(defaultSpeedsResponse.getPathsList());

--- a/web/src/test/java/com/replica/RouterServerTest.java
+++ b/web/src/test/java/com/replica/RouterServerTest.java
@@ -127,6 +127,7 @@ public class RouterServerTest extends ReplicaGraphHopperTest {
     private static final String CLOSED_BASELINE_ROAD_FOOT_PROFILE_NAME = "foot_custom_closed_baseline_road";
     private static final ImmutableSet<String> CAR_PROFILES =
             ImmutableSet.of("car", "car_freeway", DEFAULT_CAR_PROFILE_NAME, CUSTOM_THURTON_DRIVE_CAR_PROFILE_NAME, CLOSED_BASELINE_ROAD_CAR_PROFILE_NAME);
+    private static final ImmutableSet<String> WALK_PROFILES = ImmutableSet.of("foot", DEFAULT_FOOT_PROFILE_NAME, CLOSED_BASELINE_ROAD_FOOT_PROFILE_NAME);
 
     private static final ImmutableMap<String, String> CUSTOM_THURTON_DRIVE_PROFILE_TO_DEFAULT_PROFILE = ImmutableMap.of(CUSTOM_THURTON_DRIVE_CAR_PROFILE_NAME, DEFAULT_CAR_PROFILE_NAME, "truck_custom_fast_thurton_drive", DEFAULT_TRUCK_PROFILE_NAME, "small_truck_custom_fast_thurton_drive", DEFAULT_SMALL_TRUCK_PROFILE_NAME);
 
@@ -430,10 +431,8 @@ public class RouterServerTest extends ReplicaGraphHopperTest {
     @Test
     public void testWalkQuery() {
         final RouterOuterClass.StreetRouteReply response = routerStub.routeStreetMode(WALK_REQUEST);
-
-        Set<String> expectedWalkProfiles = ImmutableSet.of("foot");
         Predicate<Long> perProfilePathCountPredicate = pathCount -> pathCount == 1L;
-        checkStreetBasedResponse(response, expectedWalkProfiles, perProfilePathCountPredicate);
+        checkStreetBasedResponse(response, WALK_PROFILES, perProfilePathCountPredicate);
     }
 
     @Test


### PR DESCRIPTION
https://replicahq.atlassian.net/browse/RAD-6446
https://replicahq.atlassian.net/browse/RAD-6445

Adds custom speed support for bikes + pedestrians. Both cases follow a very similar model to custom speeds for cars, so supporting these new modes was relatively straightforward with the existing architecture.

---
Testing-wise, I added unit tests that match existing tests for other custom speeds scenarios. I decided to only test road closure situations with bike/ped, as it seems a lot more likely we'll hit those in production settings than speed changes, but I'm happy to add additional tests if it seems warranted.

Outside of unit tests, I locally built a router that included both the default `foot` + `bike` profiles, as well as foot + bike profiles where Baseline Road outside of Sac is closed (ie the road closure we test in unit tests). I was able to confirm that in the returned routes, only the default `foot`/`bike` profiles took the section of Baseline Road that was closed:

<img width="1753" alt="Screen Shot 2024-02-22 at 2 04 19 PM" src="https://github.com/replicahq/graphhopper/assets/13446427/824e7479-e96b-4fb3-ab5f-b7bfc5a97faf">

---

I've left comments on other areas that might need a bit of clarification

---

cc @rslassman @rregue 
