### PR TITLE
Add quotes around all string columns in GTFS link mapper output CSV

### DIFF
--- a/web-bundle/src/main/java/com/graphhopper/replica/GtfsLinkMapper.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/GtfsLinkMapper.java
@@ -183,7 +183,7 @@ public class GtfsLinkMapper {
                 }
                 List<String> stableEdgeIds = Lists.newArrayList(gtfsLinkMappings.get(stopPairString).split(","));
                 String stableEdgeIdString = stableEdgeIds.size() == 0 ? ""
-                        : String.format("\"[%s]\"", stableEdgeIds.stream().map(id -> "'" + id + "'").collect(Collectors.joining(",")));
+                        : String.format("[%s]", stableEdgeIds.stream().map(id -> "'" + id + "'").collect(Collectors.joining(",")));
 
                 // format: "{feed_id}:{route_id}/{feed_id}:{stop_id}/{feed_id}:{next_stop_id}"
                 String transitEdgeString = stop.feed_id + ":" + routeId + "/" + stop.feed_id + ":"
@@ -199,7 +199,7 @@ public class GtfsLinkMapper {
     private static String getCsvLine(String routeId, String feedId, String stopId, String nextStopId,
                                      double stopLat, double stopLon, double stopLatNext, double stopLonNext,
                                      String stableEdgeIdString, String transitEdgeString) {
-        return String.format("%s,%s,%s,%s,%f,%f,%f,%f,%s,%s", routeId, feedId, stopId, nextStopId,
+        return String.format("\"%s\",\"%s\",\"%s\",\"%s\",%f,%f,%f,%f,\"%s\",\"%s\"", routeId, feedId, stopId, nextStopId,
                 stopLat, stopLon, stopLatNext, stopLonNext, stableEdgeIdString, transitEdgeString
         );
     }

--- a/web-bundle/src/main/java/com/graphhopper/replica/GtfsLinkMapper.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/GtfsLinkMapper.java
@@ -199,6 +199,7 @@ public class GtfsLinkMapper {
     private static String getCsvLine(String routeId, String feedId, String stopId, String nextStopId,
                                      double stopLat, double stopLon, double stopLatNext, double stopLonNext,
                                      String stableEdgeIdString, String transitEdgeString) {
+        // Add quotes around all string fields for ease of parsing CSV - some fields contain commas
         return String.format("\"%s\",\"%s\",\"%s\",\"%s\",%f,%f,%f,%f,\"%s\",\"%s\"", routeId, feedId, stopId, nextStopId,
                 stopLat, stopLon, stopLatNext, stopLonNext, stableEdgeIdString, transitEdgeString
         );


### PR DESCRIPTION
# Background
https://replicahq.atlassian.net/browse/RAD-6518

While building new versions of the TN CDP to incorporate bike/ped custom speed support ([branch](https://github.com/replicahq/model/compare/bike_ped_custom_speed?expand=1)), I hit an [error](https://cloud.prefect.io/replica/task-run/fefd0bea-2c4b-4b7c-adcc-1404706d90ac?logs=&logId=6b88af87-50f3-4733-bafc-53c9f3400464&schematic=a9dd73a9-a2d0-44f9-87c9-64209a3af8ac) in the `gtfs_metadata` DM for the 2023_Q4 nationwide TN CDP build.

Exploring further, I noticed lines in the nationwide 2023_Q4 GTFS link mapper CSV that were the source of the problem - some of the string columns contained commas, which messed up panda's parsing of the CSV in `gtfs_metadata`, eg
```
10_Pulaski Pike_Central Health, Calvary Library, Bessie K Russell Library, Sav-A-Lot, Showers Rec Center_FF2F72FF,f-dn4m-huntsvilleshuttle,Beard at Sitka__34.740557_-86.610174,Poplar at Arctic__34.739372_-86.606958,34.740557,-86.610174,34.739372,-86.606958,"['18181266604444354019','6538526469271641680','9379575148167167562','4810001069266628679','14415768003386197773']",f-dn4m-huntsvilleshuttle:10_Pulaski Pike_Central Health, Calvary Library, Bessie K Russell Library, Sav-A-Lot, Showers Rec Center_FF2F72FF/f-dn4m-huntsvilleshuttle:Beard at Sitka__34.740557_-86.610174/f-dn4m-huntsvilleshuttle:Poplar at Arctic__34.739372_-86.606958
```

---

Why didn't we hit this until now? I did some more testing and noticed that 
1) We only use the GTFS link mapper CSV in `gtfs_metadata` DM
2) In that DM, we only load the CSV in the case where a GTFS feed has no shapes, and we want to use the link-mapped routes to infer a geometry for the line

It seems as though regions where this is problematic never had missing GTFS shapes, and therefore, the link mapper was never loaded. For example, south_central 2023_Q4's CSV causes problems:
<img width="1204" alt="Screen Shot 2024-02-28 at 1 55 09 PM" src="https://github.com/replicahq/graphhopper/assets/13446427/b736df1a-eef9-46db-822d-0bf83ef0cc91">

However, the link mapping CSV is never loaded during south_central's `gtfs_metadata` run. For regions where the link mapping _is_ loaded, you see the log `Loading link map`  - [southwest is an example](https://cloud.prefect.io/replica/task-run/acc38721-831b-482d-8164-f3e859d6e0e3?logs). But for south_central, you [never see that log](https://cloud.prefect.io/replica/task-run/f7af56a2-b16b-4e32-8c8a-5620f3c7e6a4?logs), so the problematic CSV lines are never loaded + never cause an error.

In the nationwide case, however, we're bound to load the (nationwide) GTFS link mapping CSV, because at least 1 region has missing shapes (southwest is an example). In this situation, the link mapping CSV contains the bad lines from other regions (eg south_central) that have never been loaded in the regional build case, because that region doesn't have missing shapes itself

# Description
I updated the code that creates lines of CSV outputs to add `"` quotes around all string entries. Previously, the stable edge ID list had quotes explicitly added in earlier code; I removed the quotes there in favor of adding them in the final line creation where other fields were getting quotes added

# Testing

- [x] [Recreated 2023_Q4 south_central GTFS link mappings](https://cloud.prefect.io/replica/flow-run/d4875e73-079d-4019-ab29-3ad8314eae97) and tried the local test code again; no error! 🎉 
<img width="1206" alt="Screen Shot 2024-02-28 at 1 56 45 PM" src="https://github.com/replicahq/graphhopper/assets/13446427/52066108-88b6-4350-ac80-03e544dfda87">

- [x] Building a nationwide 2023_Q4 TN CDP, ensuring `gtfs_metadata` passes with this change included (build is [currently running](https://cloud.prefect.io/replica/flow-run/7faa7b27-0836-48bd-8206-63598b173a28))