### PR TITLE
Update GUI alternate route default settings to match python client

### DIFF
--- a/grpc/src/main/resources/assets/index.html
+++ b/grpc/src/main/resources/assets/index.html
@@ -54,9 +54,9 @@
             <label for="alt_route_max_paths">Alternate route max paths:</label>
             <input type="number" id="alt_route_max_paths" name="alt_route_max_paths" value="5"><br>
             <label for="alt_route_max_weight_factor">Alternate route max weight factor:</label>
-            <input type="number" id="alt_route_max_weight_factor" name="alt_route_max_weight_factor" value="2.0" step="0.1"><br>
+            <input type="number" id="alt_route_max_weight_factor" name="alt_route_max_weight_factor" value="1.15" step="0.1"><br>
             <label for="alt_route_max_share_factor">Alternate route max share factor:</label>
-            <input type="number" id="alt_route_max_share_factor" name="alt_route_max_share_factor" value="0.4" step="0.1"><br>
+            <input type="number" id="alt_route_max_share_factor" name="alt_route_max_share_factor" value="0.95" step="0.1"><br>
         </div>
         <form id="locationform">
             <div class="time_input">


### PR DESCRIPTION
https://replicahq.atlassian.net/browse/RAD-6526

Updates knobs in non-transit routing GUI for alternative routes to match the values in the python routing client

Testing:
<img width="548" alt="Screen Shot 2024-03-07 at 11 49 15 AM" src="https://github.com/replicahq/graphhopper/assets/13446427/4a373d01-132a-4fd3-ad64-08bca78c25dd">

cc @alexeisw @bryanwilliams1025 