### PR TITLE
Add grafana stats to track number of alternative routes

### DIFF
--- a/grpc/src/main/java/com/replica/api/CustomStreetRouter.java
+++ b/grpc/src/main/java/com/replica/api/CustomStreetRouter.java
@@ -49,7 +49,7 @@ public class CustomStreetRouter {
                 double durationSeconds = (System.currentTimeMillis() - startTime) / 1000.0;
                 String[] tags = {"mode:" + request.getProfile(), "api:grpc", "routes_found:false"};
                 tags = MetricUtils.applyCustomTags(tags, customTags);
-                MetricUtils.sendDatadogStats(statsDClient, tags, durationSeconds);
+                MetricUtils.sendRoutingStats(statsDClient, tags, durationSeconds);
 
                 Status status = Status.newBuilder()
                         .setCode(Code.NOT_FOUND.getNumber())
@@ -65,7 +65,7 @@ public class CustomStreetRouter {
                 double durationSeconds = (System.currentTimeMillis() - startTime) / 1000.0;
                 String[] tags = {"mode:" + request.getProfile(), "api:grpc", "routes_found:true"};
                 tags = MetricUtils.applyCustomTags(tags, customTags);
-                MetricUtils.sendDatadogStats(statsDClient, tags, durationSeconds);
+                MetricUtils.sendRoutingStats(statsDClient, tags, durationSeconds, ghResponse.getAll().size());
 
                 responseObserver.onNext(replyBuilder.build());
                 responseObserver.onCompleted();
@@ -78,7 +78,7 @@ public class CustomStreetRouter {
             double durationSeconds = (System.currentTimeMillis() - startTime) / 1000.0;
             String[] tags = {"mode:" + request.getProfile(), "api:grpc", "routes_found:error"};
             tags = MetricUtils.applyCustomTags(tags, customTags);
-            MetricUtils.sendDatadogStats(statsDClient, tags, durationSeconds);
+            MetricUtils.sendRoutingStats(statsDClient, tags, durationSeconds);
 
             Status status = Status.newBuilder()
                     .setCode(Code.INTERNAL.getNumber())

--- a/grpc/src/main/java/com/replica/api/CustomStreetRouter.java
+++ b/grpc/src/main/java/com/replica/api/CustomStreetRouter.java
@@ -49,7 +49,7 @@ public class CustomStreetRouter {
                 double durationSeconds = (System.currentTimeMillis() - startTime) / 1000.0;
                 String[] tags = {"mode:" + request.getProfile(), "api:grpc", "routes_found:false"};
                 tags = MetricUtils.applyCustomTags(tags, customTags);
-                MetricUtils.sendRoutingStats(statsDClient, tags, durationSeconds);
+                MetricUtils.sendRoutingStats(statsDClient, tags, durationSeconds, 0);
 
                 Status status = Status.newBuilder()
                         .setCode(Code.NOT_FOUND.getNumber())

--- a/grpc/src/main/java/com/replica/api/StreetRouter.java
+++ b/grpc/src/main/java/com/replica/api/StreetRouter.java
@@ -94,7 +94,7 @@ public class StreetRouter {
             double durationSeconds = (System.currentTimeMillis() - startTime) / 1000.0;
             String[] tags = {"mode:" + request.getProfile(), "api:grpc", "routes_found:false"};
             tags = MetricUtils.applyCustomTags(tags, customTags);
-            MetricUtils.sendRoutingStats(statsDClient, tags, durationSeconds);
+            MetricUtils.sendRoutingStats(statsDClient, tags, durationSeconds, 0);
 
             Status status = Status.newBuilder()
                     .setCode(Code.NOT_FOUND.getNumber())

--- a/grpc/src/main/java/com/replica/api/StreetRouter.java
+++ b/grpc/src/main/java/com/replica/api/StreetRouter.java
@@ -61,7 +61,7 @@ public class StreetRouter {
                 GHResponse ghResponse = graphHopper.route(ghRequest);
                 // ghResponse.hasErrors() means that the router returned no results
                 if (!ghResponse.hasErrors()) {
-                    pathsFound++;
+                    pathsFound += ghResponse.getAll().size();
                     ghResponse.getAll().stream()
                             .map(responsePath -> RouterConverters.toStreetPath(responsePath, profile, request.getReturnFullPathDetails()))
                             .forEach(replyBuilder::addPaths);

--- a/grpc/src/main/java/com/replica/api/StreetRouter.java
+++ b/grpc/src/main/java/com/replica/api/StreetRouter.java
@@ -54,14 +54,14 @@ public class StreetRouter {
         GHPoint dest = ghRequest.getPoints().get(1);
 
         StreetRouteReply.Builder replyBuilder = StreetRouteReply.newBuilder();
-        boolean anyPathsFound = false;
+        int pathsFound = 0;
         for (String profile : profilesToQuery) {
             ghRequest.setProfile(profile);
             try {
                 GHResponse ghResponse = graphHopper.route(ghRequest);
                 // ghResponse.hasErrors() means that the router returned no results
                 if (!ghResponse.hasErrors()) {
-                    anyPathsFound = true;
+                    pathsFound++;
                     ghResponse.getAll().stream()
                             .map(responsePath -> RouterConverters.toStreetPath(responsePath, profile, request.getReturnFullPathDetails()))
                             .forEach(replyBuilder::addPaths);
@@ -75,7 +75,7 @@ public class StreetRouter {
                 double durationSeconds = (System.currentTimeMillis() - startTime) / 1000.0;
                 String[] tags = {"mode:" + request.getProfile(), "api:grpc", "routes_found:error"};
                 tags = MetricUtils.applyCustomTags(tags, customTags);
-                MetricUtils.sendDatadogStats(statsDClient, tags, durationSeconds);
+                MetricUtils.sendRoutingStats(statsDClient, tags, durationSeconds);
 
                 Status status = Status.newBuilder()
                         .setCode(Code.INTERNAL.getNumber())
@@ -87,14 +87,14 @@ public class StreetRouter {
 
         // If no paths were found across any of the queried profiles,
         // return the standard NOT_FOUND grpc error code
-        if (!anyPathsFound) {
+        if (pathsFound == 0) {
             String message = "Path could not be found between "
                     + origin.lat + "," + origin.lon + " to " + dest.lat + "," + dest.lon;
 
             double durationSeconds = (System.currentTimeMillis() - startTime) / 1000.0;
             String[] tags = {"mode:" + request.getProfile(), "api:grpc", "routes_found:false"};
             tags = MetricUtils.applyCustomTags(tags, customTags);
-            MetricUtils.sendDatadogStats(statsDClient, tags, durationSeconds);
+            MetricUtils.sendRoutingStats(statsDClient, tags, durationSeconds);
 
             Status status = Status.newBuilder()
                     .setCode(Code.NOT_FOUND.getNumber())
@@ -105,7 +105,7 @@ public class StreetRouter {
             double durationSeconds = (System.currentTimeMillis() - startTime) / 1000.0;
             String[] tags = {"mode:" + request.getProfile(), "api:grpc", "routes_found:true"};
             tags = MetricUtils.applyCustomTags(tags, customTags);
-            MetricUtils.sendDatadogStats(statsDClient, tags, durationSeconds);
+            MetricUtils.sendRoutingStats(statsDClient, tags, durationSeconds, pathsFound);
 
             responseObserver.onNext(replyBuilder.build());
             responseObserver.onCompleted();

--- a/grpc/src/main/java/com/replica/api/TransitRouter.java
+++ b/grpc/src/main/java/com/replica/api/TransitRouter.java
@@ -85,7 +85,7 @@ public class TransitRouter {
                 double durationSeconds = (System.currentTimeMillis() - startTime) / 1000.0;
                 tags = new String[]{"mode:pt", "api:grpc", "routes_found:false"};
                 tags = MetricUtils.applyCustomTags(tags, customTags);
-                MetricUtils.sendDatadogStats(statsDClient, tags, durationSeconds);
+                MetricUtils.sendRoutingStats(statsDClient, tags, durationSeconds);
 
                 Status status = Status.newBuilder()
                         .setCode(Code.NOT_FOUND.getNumber())
@@ -105,7 +105,7 @@ public class TransitRouter {
                 double durationSeconds = (System.currentTimeMillis() - startTime) / 1000.0;
                 tags = new String[]{"mode:pt", "api:grpc", "routes_found:true"};
                 tags = MetricUtils.applyCustomTags(tags, customTags);
-                MetricUtils.sendDatadogStats(statsDClient, tags, durationSeconds);
+                MetricUtils.sendRoutingStats(statsDClient, tags, durationSeconds, pathsWithStableIds.size());
 
                 // Request info log for slow-running requests; uncomment if needed for debugging
                 /*
@@ -128,7 +128,7 @@ public class TransitRouter {
             double durationSeconds = (System.currentTimeMillis() - startTime) / 1000.0;
             String[] tags = {"mode:pt", "api:grpc", "routes_found:false"};
             tags = MetricUtils.applyCustomTags(tags, customTags);
-            MetricUtils.sendDatadogStats(statsDClient, tags, durationSeconds);
+            MetricUtils.sendRoutingStats(statsDClient, tags, durationSeconds);
 
             Status status = Status.newBuilder()
                     .setCode(Code.NOT_FOUND.getNumber())
@@ -141,7 +141,7 @@ public class TransitRouter {
             double durationSeconds = (System.currentTimeMillis() - startTime) / 1000.0;
             String[] tags = {"mode:pt", "api:grpc", "routes_found:error"};
             tags = MetricUtils.applyCustomTags(tags, customTags);
-            MetricUtils.sendDatadogStats(statsDClient, tags, durationSeconds);
+            MetricUtils.sendRoutingStats(statsDClient, tags, durationSeconds);
 
             Status status = Status.newBuilder()
                     .setCode(Code.INTERNAL.getNumber())

--- a/grpc/src/main/java/com/replica/api/TransitRouter.java
+++ b/grpc/src/main/java/com/replica/api/TransitRouter.java
@@ -85,7 +85,7 @@ public class TransitRouter {
                 double durationSeconds = (System.currentTimeMillis() - startTime) / 1000.0;
                 tags = new String[]{"mode:pt", "api:grpc", "routes_found:false"};
                 tags = MetricUtils.applyCustomTags(tags, customTags);
-                MetricUtils.sendRoutingStats(statsDClient, tags, durationSeconds);
+                MetricUtils.sendRoutingStats(statsDClient, tags, durationSeconds, 0);
 
                 Status status = Status.newBuilder()
                         .setCode(Code.NOT_FOUND.getNumber())
@@ -128,7 +128,7 @@ public class TransitRouter {
             double durationSeconds = (System.currentTimeMillis() - startTime) / 1000.0;
             String[] tags = {"mode:pt", "api:grpc", "routes_found:false"};
             tags = MetricUtils.applyCustomTags(tags, customTags);
-            MetricUtils.sendRoutingStats(statsDClient, tags, durationSeconds);
+            MetricUtils.sendRoutingStats(statsDClient, tags, durationSeconds, 0);
 
             Status status = Status.newBuilder()
                     .setCode(Code.NOT_FOUND.getNumber())

--- a/grpc/src/main/java/com/replica/util/MetricUtils.java
+++ b/grpc/src/main/java/com/replica/util/MetricUtils.java
@@ -12,7 +12,14 @@ public final class MetricUtils {
         // utility class
     }
 
-    public static void sendDatadogStats(StatsDClient statsDClient, String[] tags, double durationSeconds) {
+    public static void sendRoutingStats(StatsDClient statsDClient, String[] tags, double durationSeconds, int numAlternatives) {
+        if (statsDClient != null) {
+            statsDClient.histogram("routers.num_alternatives", numAlternatives, tags);
+        }
+        sendRoutingStats(statsDClient, tags, durationSeconds);
+    }
+
+    public static void sendRoutingStats(StatsDClient statsDClient, String[] tags, double durationSeconds) {
         if (statsDClient != null) {
             statsDClient.incrementCounter("routers.num_requests", tags);
             statsDClient.histogram("routers.request_seconds", durationSeconds, tags);

--- a/grpc/src/main/java/com/replica/util/MetricUtils.java
+++ b/grpc/src/main/java/com/replica/util/MetricUtils.java
@@ -12,9 +12,9 @@ public final class MetricUtils {
         // utility class
     }
 
-    public static void sendRoutingStats(StatsDClient statsDClient, String[] tags, double durationSeconds, int numAlternatives) {
+    public static void sendRoutingStats(StatsDClient statsDClient, String[] tags, double durationSeconds, int numRoutes) {
         if (statsDClient != null) {
-            statsDClient.histogram("routers.num_alternatives", numAlternatives, tags);
+            statsDClient.histogram("routers.num_routes", numRoutes, tags);
         }
         sendRoutingStats(statsDClient, tags, durationSeconds);
     }


### PR DESCRIPTION
### Background

https://replicahq.atlassian.net/browse/RAD-6527

Where relevant (transit and non-transit routing, when a route is successfully returned) adds a new grafana metric that tracks the number of returned routes for the request.

### Testing

Spun up MNC with the newly-built image, fired a bunch of auto routes, and saw reasonable grafana stats for average # of alternatives (eyeballing it myself, an average of ~5 routes were returned per request)
<img width="1520" alt="Screen Shot 2024-03-07 at 2 27 57 PM" src="https://github.com/replicahq/graphhopper/assets/13446427/85ccca94-1637-42d9-8411-1e9446a10c5e">

cc @rregue @bnaul 