### PR TITLE
Update GraphHopper dependency to incorporate park-and-ride road closure fix

### DIFF
--- a/replica-common/pom.xml
+++ b/replica-common/pom.xml
@@ -19,31 +19,31 @@
         <dependency>
             <groupId>com.graphhopper</groupId>
             <artifactId>graphhopper-core</artifactId>
-            <version>99682c42c3df04226349421c82c44fa0474eedb4</version>
+            <version>c5f100cef372e184252d323b937c173e6be0a87a</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.graphhopper</groupId>
             <artifactId>graphhopper-reader-gtfs</artifactId>
-            <version>99682c42c3df04226349421c82c44fa0474eedb4</version>
+            <version>c5f100cef372e184252d323b937c173e6be0a87a</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.graphhopper</groupId>
             <artifactId>graphhopper-web-bundle</artifactId>
-            <version>99682c42c3df04226349421c82c44fa0474eedb4</version>
+            <version>c5f100cef372e184252d323b937c173e6be0a87a</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.graphhopper</groupId>
             <artifactId>graphhopper-web</artifactId>
-            <version>99682c42c3df04226349421c82c44fa0474eedb4</version>
+            <version>c5f100cef372e184252d323b937c173e6be0a87a</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.graphhopper</groupId>
             <artifactId>graphhopper-tools</artifactId>
-            <version>99682c42c3df04226349421c82c44fa0474eedb4</version>
+            <version>c5f100cef372e184252d323b937c173e6be0a87a</version>
             <type>pom</type>
         </dependency>
         <dependency>


### PR DESCRIPTION
https://replicahq.atlassian.net/browse/RAD-6548

[[thread](https://replicahq.slack.com/archives/CK358RL0Z/p1712617280838619)]

Updates the GraphHopper commit we depend on to incorporate [Michael's fix](https://github.com/graphhopper/graphhopper/commit/c5f100cef372e184252d323b937c173e6be0a87a) for park-and-ride requests that occur near road closures.

## Testing
- First, I built a test router based on the baltimore bridge collapse scenario in which we first identified the issue. I downloaded the custom speed file encompassing the original (verbose) closure we set up @ `gs://city_data/scenario/replica/baltimore_bridge_collapse_fall_2023/full_closure_1/custom_speeds.csv`, and split it into separate per-mode speed files locally. I then placed the files in GCS, [pointed to them](https://github.com/replicahq/model/commit/d62dea5ae234deebc5d78b03a02c75e6b4e0a84f#diff-cbb10bd0644902e710944bdfa9de1b0215a0ce59dbf7c0f998d937e65394b918L7) in the mid atlantic 2023_Q2 TN CDP config, and [updated the graphhopper config we use to build routers](https://github.com/replicahq/model/commit/d62dea5ae234deebc5d78b03a02c75e6b4e0a84f#diff-21ab1f4a98fbdeca633f333c7b21472b2a2bd3b385e2bc5bd76270616d9ccf01L37) to use these custom speed files in all car + truck-related routing profiles. Then I kicked off a router build
- I tested that this router didn't exhibit the same erroneous behavior as the old version (~30+ second request time with bad request, massive increase in mem). The request I used was the original "bad" example we'd found: `http://localhost:8999/maps/pt/?pt.earliest_departure_time=2022-09-22T07%3A20%3A00Z&pt.arrive_by=false&locale=en-US&profile=pt&pt.limit_solutions=4&pt.max_profile_duration=10&pt.limit_street_time=2880&pt.use_pareto=false&pt.beta_transfers=720000&pt.access_mode=car&pt.egress_mode=foot&pt.beta_access_time=1.5&pt.beta_egress_time=1.5&pt.max_visited_nodes=1000000&point=39.00328759511982%2C-76.69784511706473&point=38.892951895284526%2C-77.04770522599479`
- Finally, I downloaded the [complete scenario config](https://github.com/replicahq/model/commit/d62dea5ae234deebc5d78b03a02c75e6b4e0a84f#diff-616ce5dadc570464c525eb77c3e7ae1786f62e8a2803b0eb2b6738f2dd26d43d) we'd used to run the bridge closure scenario, updated the graphhopper runner image tag + disk snapshot to point to the image built off of this branch + the newly-built router files, respectively, and re-ran the bridge closure scenario. That run succeeded without exhibiting any of the original symptoms we'd seen in the first run; full rundown of performance results is in [this slack message](https://replicahq.slack.com/archives/CK358RL0Z/p1713809032724299?thread_ts=1712617280.838619&cid=CK358RL0Z)
