### PR TITLE
Refactor OSM tag parsing logic

### DIFF
--- a/replica-common/src/main/java/com/graphhopper/CustomGraphHopperGtfs.java
+++ b/replica-common/src/main/java/com/graphhopper/CustomGraphHopperGtfs.java
@@ -209,6 +209,9 @@ public class CustomGraphHopperGtfs extends GraphHopperGtfs {
                     }
                     for (ReaderRelation.Member member : relation.getMembers()) {
                         if (member.getType() == ReaderElement.Type.WAY) {
+                            // Store the relation ID for the Way
+                            osmIdToWayTags.put(member.getRef(), Map.of(OSM_RELATION_ID, Long.toString(relation.getId())));
+
                             // If we haven't recorded a street name for a Way in this Relation,
                             // use the Relation's name instead, if it exists
                             if (!osmIdToWayTags.containsKey(member.getRef()) || !osmIdToWayTags.get(member.getRef()).containsKey(OSM_NAME_TAG)) {

--- a/replica-common/src/main/java/com/graphhopper/CustomGraphHopperGtfs.java
+++ b/replica-common/src/main/java/com/graphhopper/CustomGraphHopperGtfs.java
@@ -214,14 +214,16 @@ public class CustomGraphHopperGtfs extends GraphHopperGtfs {
                             // Store the relation ID for the Way
                             osmIdToWayTags.put(member.getRef(), Map.of(OSM_RELATION_ID, Long.toString(relation.getId())));
 
-                            // If we haven't recorded a street name for a Way in this Relation,
-                            // use the Relation's name instead, if it exists
-                            if (!osmIdToWayTags.containsKey(member.getRef()) || !osmIdToWayTags.get(member.getRef()).containsKey(OSM_NAME_TAG)) {
-                                String streetName = getConcatNameFromOsmElement(relation);
-                                if (streetName != null) {
-                                    Map<String, String> currentWayTags = new HashMap<>(osmIdToWayTags.getOrDefault(member.getRef(), Maps.newHashMap()));
-                                    currentWayTags.put(OSM_NAME_TAG, streetName);
-                                    osmIdToWayTags.put(member.getRef(), currentWayTags);
+                            // If we haven't recorded a street name/direction for a Way in this Relation,
+                            // use the Relation's name/direction instead, if it exists
+                            for (String osmTag : List.of(OSM_NAME_TAG, OSM_DIRECTION_TAG)) {
+                                if (!osmIdToWayTags.containsKey(member.getRef()) || !osmIdToWayTags.get(member.getRef()).containsKey(osmTag)) {
+                                    String tagValue = osmTag.equals(OSM_NAME_TAG) ? getConcatNameFromOsmElement(relation) : getTagValueFromOsmElement(relation, osmTag);
+                                    if (tagValue != null) {
+                                        Map<String, String> currentWayTags = new HashMap<>(osmIdToWayTags.getOrDefault(member.getRef(), Maps.newHashMap()));
+                                        currentWayTags.put(osmTag, tagValue);
+                                        osmIdToWayTags.put(member.getRef(), currentWayTags);
+                                    }
                                 }
                             }
                         }

--- a/replica-common/src/main/java/com/graphhopper/CustomGraphHopperGtfs.java
+++ b/replica-common/src/main/java/com/graphhopper/CustomGraphHopperGtfs.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.IOException;
 import java.text.DateFormat;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -57,6 +58,7 @@ public class CustomGraphHopperGtfs extends GraphHopperGtfs {
     public CustomGraphHopperGtfs(GraphHopperConfig ghConfig) {
         super(ghConfig);
         this.osmPath = ghConfig.getString("datareader.file", "");
+        this.osmIdToWayTags = Maps.newHashMap();
 
         // Error if gtfs_link_mapper profile wasn't properly included in GH config (link mapper step will fail in this case)
         if (ghConfig.getProfiles().stream().noneMatch(p -> p.getName().equals(GTFS_LINK_MAPPER_PROFILE))) {
@@ -217,7 +219,7 @@ public class CustomGraphHopperGtfs extends GraphHopperGtfs {
                             if (!osmIdToWayTags.containsKey(member.getRef()) || !osmIdToWayTags.get(member.getRef()).containsKey(OSM_NAME_TAG)) {
                                 String streetName = getConcatNameFromOsmElement(relation);
                                 if (streetName != null) {
-                                    Map<String, String> currentWayTags = osmIdToWayTags.getOrDefault(member.getRef(), Maps.newHashMap());
+                                    Map<String, String> currentWayTags = new HashMap<>(osmIdToWayTags.getOrDefault(member.getRef(), Maps.newHashMap()));
                                     currentWayTags.put(OSM_NAME_TAG, streetName);
                                     osmIdToWayTags.put(member.getRef(), currentWayTags);
                                 }

--- a/replica-common/src/main/java/com/graphhopper/CustomGraphHopperGtfs.java
+++ b/replica-common/src/main/java/com/graphhopper/CustomGraphHopperGtfs.java
@@ -1,14 +1,8 @@
 package com.graphhopper;
 
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.graphhopper.gtfs.GraphHopperGtfs;
-import com.graphhopper.reader.ReaderElement;
-import com.graphhopper.reader.ReaderRelation;
-import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.reader.osm.CustomOsmReader;
-import com.graphhopper.reader.osm.OSMInput;
-import com.graphhopper.reader.osm.OSMInputFile;
 import com.graphhopper.routing.util.AreaIndex;
 import com.graphhopper.routing.util.CustomArea;
 import com.graphhopper.storage.DAType;
@@ -22,11 +16,9 @@ import java.io.File;
 import java.io.IOException;
 import java.text.DateFormat;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static com.graphhopper.OsmHelper.*;
 import static com.graphhopper.util.GHUtility.readCountries;
 import static com.graphhopper.util.Helper.createFormatter;
 import static com.graphhopper.util.Helper.isEmpty;
@@ -179,61 +171,8 @@ public class CustomGraphHopperGtfs extends GraphHopperGtfs {
         }
     }
 
-    // todo: can we move this logic into CustomOsmReader?
-    // todo: not all of the info we parse here is relevant for the server - can we stop parsing it here?
     public void collectOsmInfo() {
-        LOG.info("Creating custom OSM reader; reading file and parsing lane tag and street name info.");
-        List<ReaderRelation> roadRelations = Lists.newArrayList();
-        int readCount = 0;
-        try (OSMInput input = new OSMInputFile(new File(osmPath)).setWorkerThreads(2).open()) {
-            ReaderElement next;
-            while((next = input.getNext()) != null) {
-                if (next.getType().equals(ReaderElement.Type.WAY)) {
-                    if (++readCount % 100_000 == 0) {
-                        LOG.info("Parsing tag info from OSM ways. " + readCount + " read so far.");
-                    }
-                    final ReaderWay ghReaderWay = (ReaderWay) next;
-                    osmIdToWayTags.put(ghReaderWay.getId(), parseWayTags(ghReaderWay));
-                } else if (next.getType().equals(ReaderElement.Type.RELATION)) {
-                    if (next.hasTag("route", "road")) {
-                        roadRelations.add((ReaderRelation) next);
-                    }
-                }
-            }
-            LOG.info("Finished parsing lane tag info from OSM ways. " + readCount + " total ways were parsed.");
-
-            readCount = 0;
-            LOG.info("Scanning road relations to populate street names for Ways that didn't have them set.");
-            for (ReaderRelation relation : roadRelations) {
-                if (relation.hasTag("route", "road")) {
-                    if (++readCount % 1000 == 0) {
-                        LOG.info("Parsing tag info from OSM relations. " + readCount + " read so far.");
-                    }
-                    for (ReaderRelation.Member member : relation.getMembers()) {
-                        if (member.getType() == ReaderElement.Type.WAY) {
-                            // Store the relation ID for the Way
-                            osmIdToWayTags.put(member.getRef(), Map.of(OSM_RELATION_ID, Long.toString(relation.getId())));
-
-                            // If we haven't recorded a street name/direction for a Way in this Relation,
-                            // use the Relation's name/direction instead, if it exists
-                            for (String osmTag : List.of(OSM_NAME_TAG, OSM_DIRECTION_TAG)) {
-                                if (!osmIdToWayTags.containsKey(member.getRef()) || !osmIdToWayTags.get(member.getRef()).containsKey(osmTag)) {
-                                    String tagValue = osmTag.equals(OSM_NAME_TAG) ? getConcatNameFromOsmElement(relation) : getTagValueFromOsmElement(relation, osmTag);
-                                    if (tagValue != null) {
-                                        Map<String, String> currentWayTags = new HashMap<>(osmIdToWayTags.getOrDefault(member.getRef(), Maps.newHashMap()));
-                                        currentWayTags.put(osmTag, tagValue);
-                                        osmIdToWayTags.put(member.getRef(), currentWayTags);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            LOG.info("Finished scanning road relations for additional street names. " + readCount + " total relations were considered.");
-        } catch (Exception e) {
-            throw new RuntimeException("Can't open OSM file provided at " + osmPath + "!");
-        }
+        OsmHelper.collectOsmInfo(osmPath, osmIdToWayTags);
     }
 
     public Map<Long, Map<String, String>> getOsmIdToWayTags() {

--- a/replica-common/src/main/java/com/graphhopper/CustomGraphHopperOSM.java
+++ b/replica-common/src/main/java/com/graphhopper/CustomGraphHopperOSM.java
@@ -200,6 +200,9 @@ public class CustomGraphHopperOSM extends GraphHopper {
                     }
                     for (ReaderRelation.Member member : relation.getMembers()) {
                         if (member.getType() == ReaderElement.Type.WAY) {
+                            // Store the relation ID for the Way
+                            osmIdToWayTags.put(member.getRef(), Map.of(OSM_RELATION_ID, Long.toString(relation.getId())));
+
                             // If we haven't recorded a street name for a Way in this Relation,
                             // use the Relation's name instead, if it exists
                             if (!osmIdToWayTags.containsKey(member.getRef()) || !osmIdToWayTags.get(member.getRef()).containsKey(OSM_NAME_TAG)) {

--- a/replica-common/src/main/java/com/graphhopper/CustomGraphHopperOSM.java
+++ b/replica-common/src/main/java/com/graphhopper/CustomGraphHopperOSM.java
@@ -1,13 +1,7 @@
 package com.graphhopper;
 
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.graphhopper.reader.ReaderElement;
-import com.graphhopper.reader.ReaderRelation;
-import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.reader.osm.CustomOsmReader;
-import com.graphhopper.reader.osm.OSMInput;
-import com.graphhopper.reader.osm.OSMInputFile;
 import com.graphhopper.routing.util.AreaIndex;
 import com.graphhopper.routing.util.CustomArea;
 import com.graphhopper.storage.DAType;
@@ -21,11 +15,9 @@ import java.io.File;
 import java.io.IOException;
 import java.text.DateFormat;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static com.graphhopper.OsmHelper.*;
 import static com.graphhopper.util.GHUtility.readCountries;
 import static com.graphhopper.util.Helper.createFormatter;
 import static com.graphhopper.util.Helper.isEmpty;
@@ -171,60 +163,8 @@ public class CustomGraphHopperOSM extends GraphHopper {
         }
     }
 
-    // todo: can we move this logic into CustomOsmReader?
     public void collectOsmInfo() {
-        LOG.info("Creating custom OSM reader; reading file and parsing lane tag and street name info.");
-        List<ReaderRelation> roadRelations = Lists.newArrayList();
-        int readCount = 0;
-        try (OSMInput input = new OSMInputFile(new File(osmPath)).setWorkerThreads(2).open()) {
-            ReaderElement next;
-            while((next = input.getNext()) != null) {
-                if (next.getType().equals(ReaderElement.Type.WAY)) {
-                    if (++readCount % 100_000 == 0) {
-                        LOG.info("Parsing tag info from OSM ways. " + readCount + " read so far.");
-                    }
-                    final ReaderWay ghReaderWay = (ReaderWay) next;
-                    osmIdToWayTags.put(ghReaderWay.getId(), parseWayTags(ghReaderWay));
-                } else if (next.getType().equals(ReaderElement.Type.RELATION)) {
-                    if (next.hasTag("route", "road")) {
-                        roadRelations.add((ReaderRelation) next);
-                    }
-                }
-            }
-            LOG.info("Finished parsing lane tag info from OSM ways. " + readCount + " total ways were parsed.");
-
-            readCount = 0;
-            LOG.info("Scanning road relations to populate street names for Ways that didn't have them set.");
-            for (ReaderRelation relation : roadRelations) {
-                if (relation.hasTag("route", "road")) {
-                    if (++readCount % 1000 == 0) {
-                        LOG.info("Parsing tag info from OSM relations. " + readCount + " read so far.");
-                    }
-                    for (ReaderRelation.Member member : relation.getMembers()) {
-                        if (member.getType() == ReaderElement.Type.WAY) {
-                            // Store the relation ID for the Way
-                            osmIdToWayTags.put(member.getRef(), Map.of(OSM_RELATION_ID, Long.toString(relation.getId())));
-
-                            // If we haven't recorded a street name/direction for a Way in this Relation,
-                            // use the Relation's name/direction instead, if it exists
-                            for (String osmTag : List.of(OSM_NAME_TAG, OSM_DIRECTION_TAG)) {
-                                if (!osmIdToWayTags.containsKey(member.getRef()) || !osmIdToWayTags.get(member.getRef()).containsKey(osmTag)) {
-                                    String tagValue = osmTag.equals(OSM_NAME_TAG) ? getConcatNameFromOsmElement(relation) : getTagValueFromOsmElement(relation, osmTag);
-                                    if (tagValue != null) {
-                                        Map<String, String> currentWayTags = new HashMap<>(osmIdToWayTags.getOrDefault(member.getRef(), Maps.newHashMap()));
-                                        currentWayTags.put(osmTag, tagValue);
-                                        osmIdToWayTags.put(member.getRef(), currentWayTags);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            LOG.info("Finished scanning road relations for additional street names. " + readCount + " total relations were considered.");
-        } catch (Exception e) {
-            throw new RuntimeException("Can't open OSM file provided at " + osmPath + "!");
-        }
+        OsmHelper.collectOsmInfo(osmPath, osmIdToWayTags);
     }
 
     public Map<Long, Map<String, String>> getOsmIdToWayTags() {

--- a/replica-common/src/main/java/com/graphhopper/CustomGraphHopperOSM.java
+++ b/replica-common/src/main/java/com/graphhopper/CustomGraphHopperOSM.java
@@ -20,7 +20,9 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.text.DateFormat;
-import java.util.*;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
 
 import static com.graphhopper.OsmHelper.*;
 import static com.graphhopper.util.GHUtility.readCountries;
@@ -180,7 +182,7 @@ public class CustomGraphHopperOSM extends GraphHopper {
                         LOG.info("Parsing tag info from OSM ways. " + readCount + " read so far.");
                     }
                     final ReaderWay ghReaderWay = (ReaderWay) next;
-                    parseWayTags(ghReaderWay);
+                    osmIdToWayTags.put(ghReaderWay.getId(), parseWayTags(ghReaderWay));
                 } else if (next.getType().equals(ReaderElement.Type.RELATION)) {
                     if (next.hasTag("route", "road")) {
                         roadRelations.add((ReaderRelation) next);
@@ -216,23 +218,6 @@ public class CustomGraphHopperOSM extends GraphHopper {
         } catch (Exception e) {
             throw new RuntimeException("Can't open OSM file provided at " + osmPath + "!");
         }
-    }
-
-    public void parseWayTags(ReaderWay ghReaderWay) {
-        long osmId = ghReaderWay.getId();
-        Map<String, String> parsedWayTagValues = Maps.newHashMap();
-
-        // Parse street name, which is a concat of `name` and `ref` tags (if present)
-        parsedWayTagValues.put(OSM_NAME_TAG, getConcatNameFromOsmElement(ghReaderWay));
-
-        // Parse highway and direction tags, plus all tags needed for determining lane counts
-        for (String wayTag : ALL_TAGS_TO_PARSE) {
-            parsedWayTagValues.put(wayTag, getTagValueFromOsmWay(ghReaderWay, wayTag));
-        }
-
-        // Remove any tags that weren't present for this Way (ie the value was parsed as null)
-        parsedWayTagValues.values().removeIf(Objects::isNull);
-        osmIdToWayTags.put(osmId, parsedWayTagValues);
     }
 
     public Map<Long, Map<String, String>> getOsmIdToWayTags() {

--- a/replica-common/src/main/java/com/graphhopper/CustomGraphHopperOSM.java
+++ b/replica-common/src/main/java/com/graphhopper/CustomGraphHopperOSM.java
@@ -205,14 +205,16 @@ public class CustomGraphHopperOSM extends GraphHopper {
                             // Store the relation ID for the Way
                             osmIdToWayTags.put(member.getRef(), Map.of(OSM_RELATION_ID, Long.toString(relation.getId())));
 
-                            // If we haven't recorded a street name for a Way in this Relation,
-                            // use the Relation's name instead, if it exists
-                            if (!osmIdToWayTags.containsKey(member.getRef()) || !osmIdToWayTags.get(member.getRef()).containsKey(OSM_NAME_TAG)) {
-                                String streetName = getConcatNameFromOsmElement(relation);
-                                if (streetName != null) {
-                                    Map<String, String> currentWayTags = new HashMap<>(osmIdToWayTags.getOrDefault(member.getRef(), Maps.newHashMap()));
-                                    currentWayTags.put(OSM_NAME_TAG, streetName);
-                                    osmIdToWayTags.put(member.getRef(), currentWayTags);
+                            // If we haven't recorded a street name/direction for a Way in this Relation,
+                            // use the Relation's name/direction instead, if it exists
+                            for (String osmTag : List.of(OSM_NAME_TAG, OSM_DIRECTION_TAG)) {
+                                if (!osmIdToWayTags.containsKey(member.getRef()) || !osmIdToWayTags.get(member.getRef()).containsKey(osmTag)) {
+                                    String tagValue = osmTag.equals(OSM_NAME_TAG) ? getConcatNameFromOsmElement(relation) : getTagValueFromOsmElement(relation, osmTag);
+                                    if (tagValue != null) {
+                                        Map<String, String> currentWayTags = new HashMap<>(osmIdToWayTags.getOrDefault(member.getRef(), Maps.newHashMap()));
+                                        currentWayTags.put(osmTag, tagValue);
+                                        osmIdToWayTags.put(member.getRef(), currentWayTags);
+                                    }
                                 }
                             }
                         }

--- a/replica-common/src/main/java/com/graphhopper/CustomGraphHopperOSM.java
+++ b/replica-common/src/main/java/com/graphhopper/CustomGraphHopperOSM.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.IOException;
 import java.text.DateFormat;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -52,6 +53,7 @@ public class CustomGraphHopperOSM extends GraphHopper {
 
     public CustomGraphHopperOSM(GraphHopperConfig ghConfig) {
         this.osmPath = ghConfig.getString("datareader.file", "");
+        this.osmIdToWayTags = Maps.newHashMap();
     }
 
     @Override
@@ -208,7 +210,7 @@ public class CustomGraphHopperOSM extends GraphHopper {
                             if (!osmIdToWayTags.containsKey(member.getRef()) || !osmIdToWayTags.get(member.getRef()).containsKey(OSM_NAME_TAG)) {
                                 String streetName = getConcatNameFromOsmElement(relation);
                                 if (streetName != null) {
-                                    Map<String, String> currentWayTags = osmIdToWayTags.getOrDefault(member.getRef(), Maps.newHashMap());
+                                    Map<String, String> currentWayTags = new HashMap<>(osmIdToWayTags.getOrDefault(member.getRef(), Maps.newHashMap()));
                                     currentWayTags.put(OSM_NAME_TAG, streetName);
                                     osmIdToWayTags.put(member.getRef(), currentWayTags);
                                 }

--- a/replica-common/src/main/java/com/graphhopper/OsmHelper.java
+++ b/replica-common/src/main/java/com/graphhopper/OsmHelper.java
@@ -102,7 +102,9 @@ public class OsmHelper {
     public static void updateOsmIdToWayTags(Map<Long, Map<String, String>> osmIdToWayTags, Long osmId, Map<String, String> newTagValues) {
         Map<String, String> currentWayTags = new HashMap<>(osmIdToWayTags.getOrDefault(osmId, Maps.newHashMap()));
         for (String tag : newTagValues.keySet()) {
-            if (!currentWayTags.containsKey(tag)) {
+            if (currentWayTags.containsKey(tag)) {
+                throw new RuntimeException("Value for tag " + tag + " has already been stored! Only new tag values not already in osmIdToWayTags allowed");
+            } else {
                 currentWayTags.put(tag, newTagValues.get(tag));
             }
         }

--- a/replica-common/src/main/java/com/graphhopper/OsmHelper.java
+++ b/replica-common/src/main/java/com/graphhopper/OsmHelper.java
@@ -60,9 +60,9 @@ public class OsmHelper {
         return osmIdToWayTags.getOrDefault(osmId, null);
     }
 
-    public static String getTagValueFromOsmWay(ReaderWay way, String tagName) {
-        if (way.hasTag(tagName)) {
-            return way.getTag(tagName);
+    public static String getTagValueFromOsmElement(ReaderElement wayOrRelation, String tagName) {
+        if (wayOrRelation.hasTag(tagName)) {
+            return wayOrRelation.getTag(tagName);
         } else {
             return null;
         }
@@ -76,7 +76,7 @@ public class OsmHelper {
 
         // Parse highway and direction tags, plus all tags needed for determining lane counts
         for (String wayTag : ALL_TAGS_TO_PARSE) {
-            parsedWayTagValues.put(wayTag, getTagValueFromOsmWay(ghReaderWay, wayTag));
+            parsedWayTagValues.put(wayTag, getTagValueFromOsmElement(ghReaderWay, wayTag));
         }
 
         // Remove any tags that weren't present for this Way (ie the value was parsed as null)
@@ -86,10 +86,7 @@ public class OsmHelper {
 
     // if only `name` or only `ref` tag exist, return that. if both exist, return "<ref>, <name>". else, return null
     public static String getConcatNameFromOsmElement(ReaderElement wayOrRelation) {
-        String name = null;
-        if (wayOrRelation.hasTag("name")) {
-            name = wayOrRelation.getTag("name");
-        }
+        String name = getTagValueFromOsmElement(wayOrRelation, "name");
         if (wayOrRelation.hasTag("ref")) {
             name = name == null ? wayOrRelation.getTag("ref") : wayOrRelation.getTag("ref") + ", " + name;
         }

--- a/replica-common/src/main/java/com/graphhopper/OsmHelper.java
+++ b/replica-common/src/main/java/com/graphhopper/OsmHelper.java
@@ -1,5 +1,6 @@
 package com.graphhopper;
 
+import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.graphhopper.reader.ReaderElement;
 import com.graphhopper.reader.ReaderWay;
@@ -7,6 +8,7 @@ import com.graphhopper.storage.DataAccess;
 import com.graphhopper.util.BitUtil;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 public class OsmHelper {
@@ -63,6 +65,22 @@ public class OsmHelper {
         } else {
             return null;
         }
+    }
+
+    public static Map<String, String> parseWayTags(ReaderWay ghReaderWay) {
+        Map<String, String> parsedWayTagValues = Maps.newHashMap();
+
+        // Parse street name, which is a concat of `name` and `ref` tags (if present)
+        parsedWayTagValues.put(OSM_NAME_TAG, getConcatNameFromOsmElement(ghReaderWay));
+
+        // Parse highway and direction tags, plus all tags needed for determining lane counts
+        for (String wayTag : ALL_TAGS_TO_PARSE) {
+            parsedWayTagValues.put(wayTag, getTagValueFromOsmWay(ghReaderWay, wayTag));
+        }
+
+        // Remove any tags that weren't present for this Way (ie the value was parsed as null)
+        parsedWayTagValues.values().removeIf(Objects::isNull);
+        return parsedWayTagValues;
     }
 
     // if only `name` or only `ref` tag exist, return that. if both exist, return "<ref>, <name>". else, return null

--- a/replica-common/src/main/java/com/graphhopper/OsmHelper.java
+++ b/replica-common/src/main/java/com/graphhopper/OsmHelper.java
@@ -13,6 +13,13 @@ public class OsmHelper {
     private DataAccess ghEdgeIdToSegmentIndexMapping;
     private BitUtil bitUtil;
 
+    public static final String OSM_NAME_TAG = "name";
+    public static final String OSM_HIGHWAY_TAG = "highway";
+    public static final String OSM_DIRECTION_TAG = "direction";
+    public static final String OSM_LANES_TAG = "lanes";
+    public static final String OSM_FORWARD_LANES_TAG = "lanes:forward";
+    public static final String OSM_BACKWARD_LANES_TAG = "lanes:backward";
+
     public OsmHelper(DataAccess nodeMapping,
                      DataAccess artificialIdToOsmNodeIdMapping,
                      DataAccess ghEdgeIdToSegmentIndexMapping,
@@ -38,13 +45,13 @@ public class OsmHelper {
         return ghEdgeIdToSegmentIndexMapping.getInt(pointer);
     }
 
-    public static Map<String, String> getLanesTag(long osmId, Map<Long, Map<String, String>> osmIdToLaneTags) {
-        return osmIdToLaneTags.getOrDefault(osmId, null);
+    public static Map<String, String> getWayTag(long osmId, Map<Long, Map<String, String>> osmIdToWayTags) {
+        return osmIdToWayTags.getOrDefault(osmId, null);
     }
 
-    public static String getHighwayFromOsmWay(ReaderWay way) {
-        if (way.hasTag("highway")) {
-            return way.getTag("highway");
+    public static String getTagValueFromOsmWay(ReaderWay way, String tagName) {
+        if (way.hasTag(tagName)) {
+            return way.getTag(tagName);
         } else {
             return null;
         }

--- a/replica-common/src/main/java/com/graphhopper/OsmHelper.java
+++ b/replica-common/src/main/java/com/graphhopper/OsmHelper.java
@@ -1,11 +1,13 @@
 package com.graphhopper;
 
+import com.google.common.collect.Sets;
 import com.graphhopper.reader.ReaderElement;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.storage.DataAccess;
 import com.graphhopper.util.BitUtil;
 
 import java.util.Map;
+import java.util.Set;
 
 public class OsmHelper {
     private DataAccess nodeMapping;
@@ -19,6 +21,12 @@ public class OsmHelper {
     public static final String OSM_LANES_TAG = "lanes";
     public static final String OSM_FORWARD_LANES_TAG = "lanes:forward";
     public static final String OSM_BACKWARD_LANES_TAG = "lanes:backward";
+
+    // Tags we consider when calculating the value of the `lanes` column
+    public static final Set<String> LANE_TAGS = Sets.newHashSet(OSM_LANES_TAG, OSM_FORWARD_LANES_TAG, OSM_BACKWARD_LANES_TAG);
+    // Tags we parse to include as columns in network link export
+    public static final Set<String> WAY_TAGS = Sets.newHashSet(OSM_HIGHWAY_TAG, OSM_DIRECTION_TAG);
+    public static final Set<String> ALL_TAGS_TO_PARSE = Sets.union(LANE_TAGS, WAY_TAGS);
 
     public OsmHelper(DataAccess nodeMapping,
                      DataAccess artificialIdToOsmNodeIdMapping,

--- a/replica-common/src/main/java/com/graphhopper/OsmHelper.java
+++ b/replica-common/src/main/java/com/graphhopper/OsmHelper.java
@@ -21,6 +21,7 @@ public class OsmHelper {
     public static final String OSM_HIGHWAY_TAG = "highway";
     public static final String OSM_DIRECTION_TAG = "direction";
     public static final String OSM_LANES_TAG = "lanes";
+    public static final String OSM_RELATION_ID = "relation";  // Not a formal OSM tag, just a placeholder to hold relation ID for Ways
     public static final String OSM_FORWARD_LANES_TAG = "lanes:forward";
     public static final String OSM_BACKWARD_LANES_TAG = "lanes:backward";
 

--- a/replica-common/src/main/java/com/graphhopper/OsmHelper.java
+++ b/replica-common/src/main/java/com/graphhopper/OsmHelper.java
@@ -31,10 +31,10 @@ public class OsmHelper {
     public static final String OSM_BACKWARD_LANES_TAG = "lanes:backward";
 
     // Tags we consider when calculating the value of the `lanes` column
-    public static final Set<String> LANE_TAGS = Sets.newHashSet(OSM_LANES_TAG, OSM_FORWARD_LANES_TAG, OSM_BACKWARD_LANES_TAG);
+    public static final Set<String> LANE_TAGS = Collections.unmodifiableSet(Sets.newHashSet(OSM_LANES_TAG, OSM_FORWARD_LANES_TAG, OSM_BACKWARD_LANES_TAG));
     // Tags we parse to include as columns in network link export
-    public static final Set<String> OTHER_WAY_TAGS = Sets.newHashSet(OSM_HIGHWAY_TAG, OSM_NAME_TAG);
-    public static final Set<String> ALL_WAY_TAGS_TO_PARSE = Sets.union(LANE_TAGS, OTHER_WAY_TAGS);
+    public static final Set<String> OTHER_WAY_TAGS = Collections.unmodifiableSet(Sets.newHashSet(OSM_HIGHWAY_TAG, OSM_NAME_TAG));
+    public static final Set<String> ALL_WAY_TAGS_TO_PARSE = Collections.unmodifiableSet(Sets.union(LANE_TAGS, OTHER_WAY_TAGS));
 
     public OsmHelper(DataAccess nodeMapping,
                      DataAccess artificialIdToOsmNodeIdMapping,

--- a/web-bundle/src/main/java/com/graphhopper/replica/StreetEdgeExportRecord.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/StreetEdgeExportRecord.java
@@ -19,16 +19,12 @@ public class StreetEdgeExportRecord {
     public String highwayTag;
     public long startOsmNode;
     public long endOsmNode;
-    public String direction;
-    public Long osmRelationId;
-    public String osmRelationName;
 
     public StreetEdgeExportRecord(String edgeId, String humanReadableEdgeId, int startVertexId, int endVertexId,
                                   double startLat, double startLon, double endLat, double endLon,
                                   String geometryString, String streetName, long distanceMillimeters,
                                   long osmId, int speedCms, String flags, int lanes, String highwayTag,
-                                  long startOsmNode, long endOsmNode, String direction, Long osmRelationId,
-                                  String osmRelationName) {
+                                  long startOsmNode, long endOsmNode) {
         this.edgeId = edgeId;
         this.humanReadableEdgeId = humanReadableEdgeId;
         this.startVertexId = startVertexId;
@@ -47,9 +43,5 @@ public class StreetEdgeExportRecord {
         this.highwayTag = highwayTag;
         this.startOsmNode = startOsmNode;
         this.endOsmNode = endOsmNode;
-        this.direction = direction;
-        this.osmRelationId = osmRelationId;
-        this.osmRelationName = osmRelationName;
     }
 }
-

--- a/web-bundle/src/main/java/com/graphhopper/replica/StreetEdgeExportRecord.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/StreetEdgeExportRecord.java
@@ -20,13 +20,15 @@ public class StreetEdgeExportRecord {
     public long startOsmNode;
     public long endOsmNode;
     public String direction;
-    public long osmRelationId;
+    public Long osmRelationId;
+    public String osmRelationName;
 
     public StreetEdgeExportRecord(String edgeId, String humanReadableEdgeId, int startVertexId, int endVertexId,
                                   double startLat, double startLon, double endLat, double endLon,
                                   String geometryString, String streetName, long distanceMillimeters,
                                   long osmId, int speedCms, String flags, int lanes, String highwayTag,
-                                  long startOsmNode, long endOsmNode, String direction, long osmRelationId) {
+                                  long startOsmNode, long endOsmNode, String direction, Long osmRelationId,
+                                  String osmRelationName) {
         this.edgeId = edgeId;
         this.humanReadableEdgeId = humanReadableEdgeId;
         this.startVertexId = startVertexId;
@@ -47,6 +49,7 @@ public class StreetEdgeExportRecord {
         this.endOsmNode = endOsmNode;
         this.direction = direction;
         this.osmRelationId = osmRelationId;
+        this.osmRelationName = osmRelationName;
     }
 }
 

--- a/web-bundle/src/main/java/com/graphhopper/replica/StreetEdgeExportRecord.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/StreetEdgeExportRecord.java
@@ -20,12 +20,13 @@ public class StreetEdgeExportRecord {
     public long startOsmNode;
     public long endOsmNode;
     public String direction;
+    public long osmRelationId;
 
     public StreetEdgeExportRecord(String edgeId, String humanReadableEdgeId, int startVertexId, int endVertexId,
                                   double startLat, double startLon, double endLat, double endLon,
                                   String geometryString, String streetName, long distanceMillimeters,
                                   long osmId, int speedCms, String flags, int lanes, String highwayTag,
-                                  long startOsmNode, long endOsmNode, String direction) {
+                                  long startOsmNode, long endOsmNode, String direction, long osmRelationId) {
         this.edgeId = edgeId;
         this.humanReadableEdgeId = humanReadableEdgeId;
         this.startVertexId = startVertexId;
@@ -45,6 +46,7 @@ public class StreetEdgeExportRecord {
         this.startOsmNode = startOsmNode;
         this.endOsmNode = endOsmNode;
         this.direction = direction;
+        this.osmRelationId = osmRelationId;
     }
 }
 

--- a/web-bundle/src/main/java/com/graphhopper/replica/StreetEdgeExportRecord.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/StreetEdgeExportRecord.java
@@ -19,12 +19,13 @@ public class StreetEdgeExportRecord {
     public String highwayTag;
     public long startOsmNode;
     public long endOsmNode;
+    public String direction;
 
     public StreetEdgeExportRecord(String edgeId, String humanReadableEdgeId, int startVertexId, int endVertexId,
                                   double startLat, double startLon, double endLat, double endLon,
                                   String geometryString, String streetName, long distanceMillimeters,
                                   long osmId, int speedCms, String flags, int lanes, String highwayTag,
-                                  long startOsmNode, long endOsmNode) {
+                                  long startOsmNode, long endOsmNode, String direction) {
         this.edgeId = edgeId;
         this.humanReadableEdgeId = humanReadableEdgeId;
         this.startVertexId = startVertexId;
@@ -43,6 +44,7 @@ public class StreetEdgeExportRecord {
         this.highwayTag = highwayTag;
         this.startOsmNode = startOsmNode;
         this.endOsmNode = endOsmNode;
+        this.direction = direction;
     }
 }
 

--- a/web-bundle/src/main/java/com/graphhopper/replica/StreetEdgeExporter.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/StreetEdgeExporter.java
@@ -34,7 +34,7 @@ public class StreetEdgeExporter {
     private static final List<String> INACCESSIBLE_MOTORWAY_TAGS = Lists.newArrayList("motorway", "motorway_link");
     private static final String[] COLUMN_HEADERS = {"stableEdgeId", "humanReadableStableEdgeId", "startVertex", "endVertex", "startLat", "startLon",
             "endLat", "endLon", "geometry", "streetName", "distance", "osmid", "speed", "flags", "lanes", "highway",
-            "startOsmNode", "endOsmNode", "direction", "osmRelationId"};
+            "startOsmNode", "endOsmNode", "osmDirection", "osmRelationId"};
     public static final CSVFormat CSV_FORMAT = CSVFormat.DEFAULT.withHeader(COLUMN_HEADERS);
 
     private Map<Long, Map<String, String>> osmIdToWayTags;

--- a/web-bundle/src/main/java/com/graphhopper/replica/StreetEdgeExporter.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/StreetEdgeExporter.java
@@ -176,15 +176,6 @@ public class StreetEdgeExporter {
                 }
             }
         }
-
-        // Grab direction we parsed from Way
-        String direction = Optional.ofNullable(parseWayTag(osmWayId, osmIdToWayTags, OSM_DIRECTION_TAG)).orElse("");
-
-        // Grab relation ID and relation name associated with Way
-        String parsedRelationId = parseWayTag(osmWayId, osmIdToWayTags, OSM_RELATION_ID);
-        Long osmRelationId = parsedRelationId != null ? Long.parseLong(parsedRelationId) : null;
-        String osmRelationName = parseWayTag(osmWayId, osmIdToWayTags, OSM_RELATION_NAME_TAG);
-
         // Filter out edges with unwanted highway tags
         if (!HIGHWAY_FILTER_TAGS.contains(highwayTag)) {
             // Print line for each edge direction, if edge is accessible; inaccessible edges should have
@@ -193,13 +184,13 @@ public class StreetEdgeExporter {
                 output.add(new StreetEdgeExportRecord(forwardStableEdgeId, humanReadableForwardStableEdgeId,
                         startVertex, endVertex, startLat, startLon, endLat, endLon, geometryString, streetName,
                         distanceMillimeters, osmWayId, speedcms, forwardFlags.toString(), forwardLanes, highwayTag,
-                        startOsmNode, endOsmNode, direction, osmRelationId, osmRelationName));
+                        startOsmNode, endOsmNode));
             }
             if (!(backwardFlags.isEmpty() && INACCESSIBLE_MOTORWAY_TAGS.contains(highwayTag))) {
                 output.add(new StreetEdgeExportRecord(backwardStableEdgeId, humanReadableBackwardStableEdgeId,
                         endVertex, startVertex, endLat, endLon, startLat, startLon, reverseGeometryString, streetName,
                         distanceMillimeters, osmWayId, speedcms, backwardFlags.toString(), backwardLanes, highwayTag,
-                        endOsmNode, startOsmNode, direction, osmRelationId, osmRelationName));
+                        endOsmNode, startOsmNode));
             }
         }
 
@@ -231,7 +222,7 @@ public class StreetEdgeExporter {
                     for(StreetEdgeExportRecord r : records) {
                         printer.printRecord(r.edgeId, r.humanReadableEdgeId, r.startVertexId, r.endVertexId, r.startLat, r.startLon, r.endLat, r.endLon,
                                 r.geometryString, r.streetName, r.distanceMillimeters, r.osmId, r.speedCms, r.flags, r.lanes, r.highwayTag,
-                                r.startOsmNode, r.endOsmNode, r.direction, r.osmRelationId, r.osmRelationName);
+                                r.startOsmNode, r.endOsmNode);
                     }
                 }
             }

--- a/web-bundle/src/main/java/com/graphhopper/replica/StreetEdgeExporter.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/StreetEdgeExporter.java
@@ -231,7 +231,7 @@ public class StreetEdgeExporter {
                     for(StreetEdgeExportRecord r : records) {
                         printer.printRecord(r.edgeId, r.humanReadableEdgeId, r.startVertexId, r.endVertexId, r.startLat, r.startLon, r.endLat, r.endLon,
                                 r.geometryString, r.streetName, r.distanceMillimeters, r.osmId, r.speedCms, r.flags, r.lanes, r.highwayTag,
-                                r.startOsmNode, r.endOsmNode, r.direction, r.osmRelationId);
+                                r.startOsmNode, r.endOsmNode, r.direction, r.osmRelationId, r.osmRelationName);
                     }
                 }
             }

--- a/web-bundle/src/main/java/com/graphhopper/replica/StreetEdgeExporter.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/StreetEdgeExporter.java
@@ -34,7 +34,7 @@ public class StreetEdgeExporter {
     private static final List<String> INACCESSIBLE_MOTORWAY_TAGS = Lists.newArrayList("motorway", "motorway_link");
     private static final String[] COLUMN_HEADERS = {"stableEdgeId", "humanReadableStableEdgeId", "startVertex", "endVertex", "startLat", "startLon",
             "endLat", "endLon", "geometry", "streetName", "distance", "osmid", "speed", "flags", "lanes", "highway",
-            "startOsmNode", "endOsmNode", "direction"};
+            "startOsmNode", "endOsmNode", "direction", "osmRelationId"};
     public static final CSVFormat CSV_FORMAT = CSVFormat.DEFAULT.withHeader(COLUMN_HEADERS);
 
     private Map<Long, Map<String, String>> osmIdToWayTags;
@@ -180,6 +180,9 @@ public class StreetEdgeExporter {
         // Grab direction we parsed from Way
         String direction = Optional.ofNullable(parseWayTag(osmWayId, osmIdToWayTags, OSM_DIRECTION_TAG)).orElse("");
 
+        // Grab relation ID associated with Way
+        long osmRelationId = Long.parseLong(Optional.ofNullable(parseWayTag(osmWayId, osmIdToWayTags, OSM_RELATION_ID)).orElse("0"));
+
         // Filter out edges with unwanted highway tags
         if (!HIGHWAY_FILTER_TAGS.contains(highwayTag)) {
             // Print line for each edge direction, if edge is accessible; inaccessible edges should have
@@ -188,13 +191,13 @@ public class StreetEdgeExporter {
                 output.add(new StreetEdgeExportRecord(forwardStableEdgeId, humanReadableForwardStableEdgeId,
                         startVertex, endVertex, startLat, startLon, endLat, endLon, geometryString, streetName,
                         distanceMillimeters, osmWayId, speedcms, forwardFlags.toString(), forwardLanes, highwayTag,
-                        startOsmNode, endOsmNode, direction));
+                        startOsmNode, endOsmNode, direction, osmRelationId));
             }
             if (!(backwardFlags.isEmpty() && INACCESSIBLE_MOTORWAY_TAGS.contains(highwayTag))) {
                 output.add(new StreetEdgeExportRecord(backwardStableEdgeId, humanReadableBackwardStableEdgeId,
                         endVertex, startVertex, endLat, endLon, startLat, startLon, reverseGeometryString, streetName,
                         distanceMillimeters, osmWayId, speedcms, backwardFlags.toString(), backwardLanes, highwayTag,
-                        endOsmNode, startOsmNode, direction));
+                        endOsmNode, startOsmNode, direction, osmRelationId));
             }
         }
 
@@ -226,7 +229,7 @@ public class StreetEdgeExporter {
                     for(StreetEdgeExportRecord r : records) {
                         printer.printRecord(r.edgeId, r.humanReadableEdgeId, r.startVertexId, r.endVertexId, r.startLat, r.startLon, r.endLat, r.endLon,
                                 r.geometryString, r.streetName, r.distanceMillimeters, r.osmId, r.speedCms, r.flags, r.lanes, r.highwayTag,
-                                r.startOsmNode, r.endOsmNode, r.direction);
+                                r.startOsmNode, r.endOsmNode, r.direction, r.osmRelationId);
                     }
                 }
             }

--- a/web-bundle/src/main/java/com/graphhopper/replica/StreetEdgeExporter.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/StreetEdgeExporter.java
@@ -34,7 +34,7 @@ public class StreetEdgeExporter {
     private static final List<String> INACCESSIBLE_MOTORWAY_TAGS = Lists.newArrayList("motorway", "motorway_link");
     private static final String[] COLUMN_HEADERS = {"stableEdgeId", "humanReadableStableEdgeId", "startVertex", "endVertex", "startLat", "startLon",
             "endLat", "endLon", "geometry", "streetName", "distance", "osmid", "speed", "flags", "lanes", "highway",
-            "startOsmNode", "endOsmNode", "osmDirection", "osmRelationId"};
+            "startOsmNode", "endOsmNode", "osmDirection", "osmRelationId", "osmRelationName"};
     public static final CSVFormat CSV_FORMAT = CSVFormat.DEFAULT.withHeader(COLUMN_HEADERS);
 
     private Map<Long, Map<String, String>> osmIdToWayTags;

--- a/web-bundle/src/main/java/com/graphhopper/replica/StreetEdgeExporter.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/StreetEdgeExporter.java
@@ -118,10 +118,10 @@ public class StreetEdgeExporter {
         }
 
         // Use street name parsed from Ways/Relations, if it exists; otherwise, use default GH edge name
-        String streetName = Optional.ofNullable(parseWayTag(osmWayId, osmIdToWayTags, OSM_NAME_TAG)).orElse(iteratorState.getName());
+        String streetName = parseWayTag(osmWayId, osmIdToWayTags, OSM_NAME_TAG).orElse(iteratorState.getName());
 
         // Grab OSM highway type and encoded stable IDs for both edge directions
-        String highwayTag = Optional.ofNullable(parseWayTag(osmWayId, osmIdToWayTags, OSM_HIGHWAY_TAG)).orElse(iteratorState.get(roadClassEnc).toString());
+        String highwayTag = parseWayTag(osmWayId, osmIdToWayTags, OSM_HIGHWAY_TAG).orElse(iteratorState.get(roadClassEnc).toString());
         String forwardStableEdgeId = stableIdEncodedValues.getStableId(false, iteratorState);
         String backwardStableEdgeId = stableIdEncodedValues.getStableId(true, iteratorState);
 
@@ -237,14 +237,14 @@ public class StreetEdgeExporter {
         }
     }
 
-    private static String parseWayTag(long osmId, Map<Long, Map<String, String>> osmIdToWayTags, String wayTag) {
+    private static Optional<String> parseWayTag(long osmId, Map<Long, Map<String, String>> osmIdToWayTags, String wayTag) {
         Map<String, String> wayTagsOnEdge = OsmHelper.getWayTag(osmId, osmIdToWayTags);
         if (wayTagsOnEdge != null) {
             if (wayTagsOnEdge.containsKey(wayTag)) {
-                return wayTagsOnEdge.get(wayTag);
+                return Optional.ofNullable(wayTagsOnEdge.get(wayTag));
             }
         }
-        return null;
+        return Optional.empty();
     }
 
     // Taken from R5's lane parsing logic. See EdgeServiceServer.java in R5 repo

--- a/web-bundle/src/main/java/com/graphhopper/replica/StreetEdgeExporter.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/StreetEdgeExporter.java
@@ -180,8 +180,10 @@ public class StreetEdgeExporter {
         // Grab direction we parsed from Way
         String direction = Optional.ofNullable(parseWayTag(osmWayId, osmIdToWayTags, OSM_DIRECTION_TAG)).orElse("");
 
-        // Grab relation ID associated with Way
-        long osmRelationId = Long.parseLong(Optional.ofNullable(parseWayTag(osmWayId, osmIdToWayTags, OSM_RELATION_ID)).orElse("0"));
+        // Grab relation ID and relation name associated with Way
+        String parsedRelationId = parseWayTag(osmWayId, osmIdToWayTags, OSM_RELATION_ID);
+        Long osmRelationId = parsedRelationId != null ? Long.parseLong(parsedRelationId) : null;
+        String osmRelationName = parseWayTag(osmWayId, osmIdToWayTags, OSM_RELATION_NAME_TAG);
 
         // Filter out edges with unwanted highway tags
         if (!HIGHWAY_FILTER_TAGS.contains(highwayTag)) {
@@ -191,13 +193,13 @@ public class StreetEdgeExporter {
                 output.add(new StreetEdgeExportRecord(forwardStableEdgeId, humanReadableForwardStableEdgeId,
                         startVertex, endVertex, startLat, startLon, endLat, endLon, geometryString, streetName,
                         distanceMillimeters, osmWayId, speedcms, forwardFlags.toString(), forwardLanes, highwayTag,
-                        startOsmNode, endOsmNode, direction, osmRelationId));
+                        startOsmNode, endOsmNode, direction, osmRelationId, osmRelationName));
             }
             if (!(backwardFlags.isEmpty() && INACCESSIBLE_MOTORWAY_TAGS.contains(highwayTag))) {
                 output.add(new StreetEdgeExportRecord(backwardStableEdgeId, humanReadableBackwardStableEdgeId,
                         endVertex, startVertex, endLat, endLon, startLat, startLon, reverseGeometryString, streetName,
                         distanceMillimeters, osmWayId, speedcms, backwardFlags.toString(), backwardLanes, highwayTag,
-                        endOsmNode, startOsmNode, direction, osmRelationId));
+                        endOsmNode, startOsmNode, direction, osmRelationId, osmRelationName));
             }
         }
 

--- a/web-bundle/src/main/java/com/graphhopper/replica/StreetEdgeExporter.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/StreetEdgeExporter.java
@@ -34,7 +34,7 @@ public class StreetEdgeExporter {
     private static final List<String> INACCESSIBLE_MOTORWAY_TAGS = Lists.newArrayList("motorway", "motorway_link");
     private static final String[] COLUMN_HEADERS = {"stableEdgeId", "humanReadableStableEdgeId", "startVertex", "endVertex", "startLat", "startLon",
             "endLat", "endLon", "geometry", "streetName", "distance", "osmid", "speed", "flags", "lanes", "highway",
-            "startOsmNode", "endOsmNode", "osmDirection", "osmRelationId", "osmRelationName"};
+            "startOsmNode", "endOsmNode"};
     public static final CSVFormat CSV_FORMAT = CSVFormat.DEFAULT.withHeader(COLUMN_HEADERS);
 
     private Map<Long, Map<String, String>> osmIdToWayTags;

--- a/web/src/main/java/com/graphhopper/http/cli/ExportNationwideCommand.java
+++ b/web/src/main/java/com/graphhopper/http/cli/ExportNationwideCommand.java
@@ -32,8 +32,7 @@ public class ExportNationwideCommand extends ConfiguredCommand<GraphHopperServer
         logger.info("Done building graph from OSM, parsing tags, and setting stable edge IDs");
 
         // Write processed street network out to CSV
-        StreetEdgeExporter.writeStreetEdgesCsv(gh, gh.getOsmIdToLaneTags(),
-                gh.getOsmIdToStreetName(), gh.getOsmIdToHighwayTag(), gh.getOsmHelper());
+        StreetEdgeExporter.writeStreetEdgesCsv(gh, gh.getOsmIdToWayTags(), gh.getOsmHelper());
         gh.close();
     }
 }

--- a/web/src/test/java/com/replica/StreetEdgeExporterTest.java
+++ b/web/src/test/java/com/replica/StreetEdgeExporterTest.java
@@ -117,9 +117,7 @@ public class StreetEdgeExporterTest extends ReplicaGraphHopperTest {
         gh.collectOsmInfo();
 
         // Copied from writeStreetEdgesCsv
-        StreetEdgeExporter exporter = new StreetEdgeExporter(
-                configuredGraphHopper, gh.getOsmIdToLaneTags(), gh.getOsmIdToStreetName(), gh.getOsmIdToHighwayTag(), gh.getOsmHelper()
-        );
+        StreetEdgeExporter exporter = new StreetEdgeExporter(configuredGraphHopper, gh.getOsmIdToWayTags(), gh.getOsmHelper());
         AllEdgesIterator edgeIterator = configuredGraphHopper.getBaseGraph().getAllEdges();
 
         // Generate the rows for the first item in the edge iterator

--- a/web/src/test/java/com/replica/StreetEdgeExporterTest.java
+++ b/web/src/test/java/com/replica/StreetEdgeExporterTest.java
@@ -17,7 +17,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;


### PR DESCRIPTION
Precursor to the main changes that add new columns to our network link export, for https://replicahq.atlassian.net/browse/RAD-6540

This PR results in no logic/output changes, just moves things around to reduce code duplication + clean up how our custom OSM tag parsing logic works. The follow-up to this change will introduce the logic necessary to parse + output 3 new columns (direction, relation name, and relation ID) - [here's](https://github.com/replicahq/graphhopper/pull/161/commits/5d12abec3c9f630a5b2706441e31a7cd883e8e16) a glimpse at what those changes will look like.

Some main changes to note:
- Moved main tag parsing logic from being duplicated in 2 places (`CustomGraphHopperGtfs` and `CustomGraphHopperOsm`) into one place `OsmHelper.collectOsmInfo()`
- Moved from storing different types of tag data each in separate data structures (eg highway tag, street name, lane-related tags), to storing all tag data in one unified data structure, `osmIdToWayTags`. This structure maps from `OSM Way ID -> Map of (OSM Tag name -> Tag value)`, and supports storing all tag data we parse in one place
- Added several constants to store tag names, instead of hardcoding them as strings, and updated the methods in `OsmHelper` that allow accessing parsed tag data to utilize the new "all-in-one" `osmIdToWayTags` structure

Testing:
Aside from unit tests passing, I generated a street export file using the test config we have set up to test this part of the codebase (`configs/test_export_gh_config.yaml`) and compared it to a file I generated in the same way off of current `original-direction`. `diff` showed the two files were identical