### PR TITLE
Allow deduping of returned routes for non-transit route requests

### DIFF
--- a/grpc/src/main/java/com/replica/api/StreetRouter.java
+++ b/grpc/src/main/java/com/replica/api/StreetRouter.java
@@ -43,9 +43,13 @@ public class StreetRouter {
         this.customTags = customTags;
     }
 
-    private static Long calculatePathId(ResponsePath responsePath) {
-        String pathStableEdgeIdsString = String.join(",", getPathStableEdgeIds(responsePath));
-        String edgeTimeString = getEdgeTimes(responsePath).stream().map(Object::toString).collect(Collectors.joining(","));
+    public static Long calculatePathId(ResponsePath responsePath) {
+        return calculatePathId(getPathStableEdgeIds(responsePath), getEdgeTimes(responsePath));
+    }
+
+    public static Long calculatePathId(List<String> pathStableEdgeIds, List<Long> pathEdgeTimes) {
+        String pathStableEdgeIdsString = String.join(",", pathStableEdgeIds);
+        String edgeTimeString = pathEdgeTimes.stream().map(Object::toString).collect(Collectors.joining(","));
         String hashString = pathStableEdgeIdsString + edgeTimeString;
         HashCode hc = Hashing.farmHashFingerprint64().hashString(hashString, Charsets.UTF_8);
         return hc.asLong();

--- a/grpc/src/main/java/com/replica/api/StreetRouter.java
+++ b/grpc/src/main/java/com/replica/api/StreetRouter.java
@@ -60,7 +60,7 @@ public class StreetRouter {
 
         StreetRouteReply.Builder replyBuilder = StreetRouteReply.newBuilder();
         int pathsFound = 0;
-        Set<PointList> pointListsInReturnSet = Sets.newHashSet();
+        Set<PointList> pathsInReturnSet = Sets.newHashSet();
         for (String profile : profilesToQuery) {
             ghRequest.setProfile(profile);
             try {
@@ -75,9 +75,9 @@ public class StreetRouter {
                         // matching a path that's already in return set
                         pathsToReturn = Lists.newArrayList();
                         for (ResponsePath responsePath : ghResponse.getAll()) {
-                            if (!pointListsInReturnSet.contains(responsePath.getPoints())) {
+                            if (!pathsInReturnSet.contains(responsePath.getPoints())) {
                                 pathsToReturn.add(responsePath);
-                                pointListsInReturnSet.add(responsePath.getPoints());
+                                pathsInReturnSet.add(responsePath.getPoints());
                             }
                         }
                     }

--- a/grpc/src/main/java/com/replica/api/StreetRouter.java
+++ b/grpc/src/main/java/com/replica/api/StreetRouter.java
@@ -81,8 +81,6 @@ public class StreetRouter {
                 GHResponse ghResponse = graphHopper.route(ghRequest);
                 // ghResponse.hasErrors() means that the router returned no results
                 if (!ghResponse.hasErrors()) {
-                    pathsFound += ghResponse.getAll().size();
-
                     List<ResponsePath> pathsToReturn;
                     if (request.getIncludeDuplicateRoutes()) {
                         pathsToReturn = ghResponse.getAll();
@@ -98,6 +96,7 @@ public class StreetRouter {
                             }
                         }
                     }
+                    pathsFound += pathsToReturn.size();
 
                     // Add filtered set of paths to full response set
                     pathsToReturn.stream()

--- a/grpc/src/main/java/com/replica/api/StreetRouter.java
+++ b/grpc/src/main/java/com/replica/api/StreetRouter.java
@@ -79,14 +79,19 @@ public class StreetRouter {
                 if (!ghResponse.hasErrors()) {
                     pathsFound += ghResponse.getAll().size();
 
-                    // Filter out duplicate paths by removing those with path ID
-                    // matching a path that's already in return set
-                    List<ResponsePath> pathsToReturn = Lists.newArrayList();
-                    for (ResponsePath responsePath : ghResponse.getAll()) {
-                        Long pathId = calculatePathId(responsePath);
-                        if (!pathIdsInReturnSet.contains(pathId)) {
-                            pathsToReturn.add(responsePath);
-                            pathIdsInReturnSet.add(pathId);
+                    List<ResponsePath> pathsToReturn;
+                    if (request.getIncludeDuplicateRoutes()) {
+                        pathsToReturn = ghResponse.getAll();
+                    } else {
+                        // Filter out duplicate paths by removing those with path ID
+                        // matching a path that's already in return set
+                        pathsToReturn = Lists.newArrayList();
+                        for (ResponsePath responsePath : ghResponse.getAll()) {
+                            Long pathId = calculatePathId(responsePath);
+                            if (!pathIdsInReturnSet.contains(pathId)) {
+                                pathsToReturn.add(responsePath);
+                                pathIdsInReturnSet.add(pathId);
+                            }
                         }
                     }
 

--- a/grpc/src/main/java/com/replica/api/StreetRouter.java
+++ b/grpc/src/main/java/com/replica/api/StreetRouter.java
@@ -41,14 +41,6 @@ public class StreetRouter {
         this.customTags = customTags;
     }
 
-    public static int calculatePathId(ResponsePath responsePath) {
-        return calculatePathId(responsePath.getPoints());
-    }
-
-    public static int calculatePathId(PointList pathPointList) {
-        return pathPointList.hashCode();
-    }
-
     public void routeStreetMode(StreetRouteRequest request, StreamObserver<StreetRouteReply> responseObserver) {
         long startTime = System.currentTimeMillis();
 
@@ -68,7 +60,7 @@ public class StreetRouter {
 
         StreetRouteReply.Builder replyBuilder = StreetRouteReply.newBuilder();
         int pathsFound = 0;
-        Set<Integer> pathIdsInReturnSet = Sets.newHashSet();
+        Set<PointList> pointListsInReturnSet = Sets.newHashSet();
         for (String profile : profilesToQuery) {
             ghRequest.setProfile(profile);
             try {
@@ -79,14 +71,13 @@ public class StreetRouter {
                     if (request.getIncludeDuplicateRoutes()) {
                         pathsToReturn = ghResponse.getAll();
                     } else {
-                        // Filter out duplicate paths by removing those with path ID
+                        // Filter out duplicate paths by removing those with point lists
                         // matching a path that's already in return set
                         pathsToReturn = Lists.newArrayList();
                         for (ResponsePath responsePath : ghResponse.getAll()) {
-                            int pathId = calculatePathId(responsePath);
-                            if (!pathIdsInReturnSet.contains(pathId)) {
+                            if (!pointListsInReturnSet.contains(responsePath.getPoints())) {
                                 pathsToReturn.add(responsePath);
-                                pathIdsInReturnSet.add(pathId);
+                                pointListsInReturnSet.add(responsePath.getPoints());
                             }
                         }
                     }

--- a/grpc/src/main/java/com/replica/util/RouterConverters.java
+++ b/grpc/src/main/java/com/replica/util/RouterConverters.java
@@ -251,14 +251,21 @@ public final class RouterConverters {
         return ghPtRequest;
     }
 
-    public static StreetPath toStreetPath(ResponsePath responsePath, String profile, boolean returnFullPathDetails) {
-        List<String> pathStableEdgeIds = responsePath.getPathDetails().get(ReplicaPathDetails.STABLE_EDGE_IDS).stream()
+    public static List<String> getPathStableEdgeIds(ResponsePath responsePath) {
+        return responsePath.getPathDetails().get(ReplicaPathDetails.STABLE_EDGE_IDS).stream()
                 .map(pathDetail -> (String) pathDetail.getValue())
                 .collect(Collectors.toList());
+    }
 
-        List<Long> edgeTimes = responsePath.getPathDetails().get(ReplicaPathDetails.TIME).stream()
+    public static List<Long> getEdgeTimes(ResponsePath responsePath) {
+        return responsePath.getPathDetails().get(ReplicaPathDetails.TIME).stream()
                 .map(pathDetail -> (Long) pathDetail.getValue())
                 .collect(Collectors.toList());
+    }
+
+    public static StreetPath toStreetPath(ResponsePath responsePath, String profile, boolean returnFullPathDetails) {
+        List<String> pathStableEdgeIds = getPathStableEdgeIds(responsePath);
+        List<Long> edgeTimes = getEdgeTimes(responsePath);
 
         StreetPath.Builder streetPath = StreetPath.newBuilder()
                 .setDurationMillis(responsePath.getTime())

--- a/grpc/src/main/java/com/replica/util/RouterConverters.java
+++ b/grpc/src/main/java/com/replica/util/RouterConverters.java
@@ -251,21 +251,14 @@ public final class RouterConverters {
         return ghPtRequest;
     }
 
-    public static List<String> getPathStableEdgeIds(ResponsePath responsePath) {
-        return responsePath.getPathDetails().get(ReplicaPathDetails.STABLE_EDGE_IDS).stream()
+    public static StreetPath toStreetPath(ResponsePath responsePath, String profile, boolean returnFullPathDetails) {
+        List<String> pathStableEdgeIds = responsePath.getPathDetails().get(ReplicaPathDetails.STABLE_EDGE_IDS).stream()
                 .map(pathDetail -> (String) pathDetail.getValue())
                 .collect(Collectors.toList());
-    }
 
-    public static List<Long> getEdgeTimes(ResponsePath responsePath) {
-        return responsePath.getPathDetails().get(ReplicaPathDetails.TIME).stream()
+        List<Long> edgeTimes = responsePath.getPathDetails().get(ReplicaPathDetails.TIME).stream()
                 .map(pathDetail -> (Long) pathDetail.getValue())
                 .collect(Collectors.toList());
-    }
-
-    public static StreetPath toStreetPath(ResponsePath responsePath, String profile, boolean returnFullPathDetails) {
-        List<String> pathStableEdgeIds = getPathStableEdgeIds(responsePath);
-        List<Long> edgeTimes = getEdgeTimes(responsePath);
 
         StreetPath.Builder streetPath = StreetPath.newBuilder()
                 .setDurationMillis(responsePath.getTime())

--- a/replica-common/src/main/java/com/graphhopper/OsmHelper.java
+++ b/replica-common/src/main/java/com/graphhopper/OsmHelper.java
@@ -1,5 +1,6 @@
 package com.graphhopper;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -31,10 +32,10 @@ public class OsmHelper {
     public static final String OSM_BACKWARD_LANES_TAG = "lanes:backward";
 
     // Tags we consider when calculating the value of the `lanes` column
-    public static final Set<String> LANE_TAGS = Collections.unmodifiableSet(Sets.newHashSet(OSM_LANES_TAG, OSM_FORWARD_LANES_TAG, OSM_BACKWARD_LANES_TAG));
+    public static final Set<String> LANE_TAGS = ImmutableSet.of(OSM_LANES_TAG, OSM_FORWARD_LANES_TAG, OSM_BACKWARD_LANES_TAG);
     // Tags we parse to include as columns in network link export
-    public static final Set<String> OTHER_WAY_TAGS = Collections.unmodifiableSet(Sets.newHashSet(OSM_HIGHWAY_TAG, OSM_NAME_TAG));
-    public static final Set<String> ALL_WAY_TAGS_TO_PARSE = Collections.unmodifiableSet(Sets.union(LANE_TAGS, OTHER_WAY_TAGS));
+    public static final Set<String> OTHER_WAY_TAGS = ImmutableSet.of(OSM_HIGHWAY_TAG, OSM_NAME_TAG);
+    public static final Set<String> ALL_WAY_TAGS_TO_PARSE = ImmutableSet.copyOf(Sets.union(LANE_TAGS, OTHER_WAY_TAGS));
 
     public OsmHelper(DataAccess nodeMapping,
                      DataAccess artificialIdToOsmNodeIdMapping,

--- a/web/src/test/java/com/replica/RouterServerTest.java
+++ b/web/src/test/java/com/replica/RouterServerTest.java
@@ -658,7 +658,9 @@ public class RouterServerTest extends ReplicaGraphHopperTest {
         expectedProfilesAfterDuplicatesFiltered.removeAll(Set.of(CUSTOM_THURTON_DRIVE_CAR_PROFILE_NAME, CLOSED_BASELINE_ROAD_CAR_PROFILE_NAME));
         final RouterOuterClass.StreetRouteReply responseWithoutDuplicates = routerStub.routeStreetMode(
                 createStreetRequest("car", false, REQUEST_ORIGIN_1, REQUEST_DESTINATION_1, false, false));
-        assertEquals(expectedProfilesAfterDuplicatesFiltered.size(), responseWithoutDuplicates.getPathsList().size());
+        Set<String> responseWithoutDuplicatesProfiles = responseWithoutDuplicates.getPathsList().stream()
+                .map(RouterOuterClass.StreetPath::getProfile).collect(Collectors.toSet());
+        assertEquals(expectedProfilesAfterDuplicatesFiltered, responseWithoutDuplicatesProfiles);
     }
 
     @Test


### PR DESCRIPTION
## Background

https://replicahq.atlassian.net/browse/RAD-6557

Adds new logic to allow the filtering out of duplicate routes for non-transit route requests. Relies on a [new flag](https://github.com/replicahq/idls/compare/dupe_routes_flag?expand=1) `include_duplicate_routes` added for these requests that indicates whether duplicates should be included or not (based on how proto messages work, this will default to false - don't include duplicates - if not specified).

The new feature is based off of some simple hashing logic @rregue implemented in his [client-side version of this deduping logic](https://github.com/replicahq/model/pull/8431/files#diff-cd52aaee92a787513161e6c887293397a54bef827ebe83450f1d13b243481305R79-R86); I hashed together the same details to form a "path ID" used to check for path uniqueness when filtering out dupes, with the only differences being that I didn't include start time or mode in the calculations. Keeping otherwise identical routes just because their start time differs didn't make sense to me given the features of routes we care about in our modeling, and mode seemed unnecessary to include because all deduping is happening within the context of a single mode being requested.

## Testing
Nothing aside from unit tests; added 2 tests, one that covers the overall server logic + behavior of the new flag, and one that tests the underlying path ID generation hash that's used in the deduping logic.