### PR TITLE
Fix memory usage of street route deduplication

### DIFF
--- a/grpc/src/main/java/com/replica/api/StreetRouter.java
+++ b/grpc/src/main/java/com/replica/api/StreetRouter.java
@@ -8,7 +8,6 @@ import com.graphhopper.GHResponse;
 import com.graphhopper.GraphHopper;
 import com.graphhopper.ResponsePath;
 import com.graphhopper.config.Profile;
-import com.graphhopper.util.PointList;
 import com.graphhopper.util.shapes.GHPoint;
 import com.replica.util.MetricUtils;
 import com.replica.util.RouterConverters;
@@ -72,7 +71,9 @@ public class StreetRouter {
                         pathsToReturn = ghResponse.getAll();
                     } else {
                         // Filter out duplicate paths by removing those with point lists
-                        // whose hashcode matches a path that's already in return set
+                        // whose hashcode matches a path that's already in return set.
+                        // Note: we store a hash rather than a full PointList object because
+                        // the latter causes a blowup in memory usage
                         pathsToReturn = Lists.newArrayList();
                         for (ResponsePath responsePath : ghResponse.getAll()) {
                             if (!pathHashesInReturnSet.contains(responsePath.getPoints().hashCode())) {

--- a/grpc/src/main/java/com/replica/api/StreetRouter.java
+++ b/grpc/src/main/java/com/replica/api/StreetRouter.java
@@ -60,7 +60,7 @@ public class StreetRouter {
 
         StreetRouteReply.Builder replyBuilder = StreetRouteReply.newBuilder();
         int pathsFound = 0;
-        Set<PointList> pathsInReturnSet = Sets.newHashSet();
+        Set<Integer> pathHashesInReturnSet = Sets.newHashSet();
         for (String profile : profilesToQuery) {
             ghRequest.setProfile(profile);
             try {
@@ -72,12 +72,12 @@ public class StreetRouter {
                         pathsToReturn = ghResponse.getAll();
                     } else {
                         // Filter out duplicate paths by removing those with point lists
-                        // matching a path that's already in return set
+                        // whose hashcode matches a path that's already in return set
                         pathsToReturn = Lists.newArrayList();
                         for (ResponsePath responsePath : ghResponse.getAll()) {
-                            if (!pathsInReturnSet.contains(responsePath.getPoints())) {
+                            if (!pathHashesInReturnSet.contains(responsePath.getPoints().hashCode())) {
                                 pathsToReturn.add(responsePath);
-                                pathsInReturnSet.add(responsePath.getPoints());
+                                pathHashesInReturnSet.add(responsePath.getPoints().hashCode());
                             }
                         }
                     }


### PR DESCRIPTION
https://replicahq.atlassian.net/browse/RAD-6568

Updates our method of server-side route deduping (see #163 ) to fix the increased memory usage we saw in our first full test runs with the prior change [[thread for context](https://replicahq.slack.com/archives/C072W5Q5F5E/p1716482148284629)].

The change here is simple - use the built-in `hashcode` of the `PointList` object as the data we keep track of for each route during the deduping process, instead of the full `PointList` object itself. This obviously cuts down memory significantly, as we move from storing a full object containing lat/lons of all points along the route to storing a single int, and we still get the behavior of routes being deduped based solely on their geometry (as expected)

We discussed in #163 the advantages of built-in methods like `hashcode` for deduping purposes vs. using our own implementation. Theoretically, hash collisions are possible, but this would be true of any hash we use (whether we define it ourselves or not), and the impact of having very infrequent collisions would be quite small given the context (eg we don't care if 1/100,000 routes contains a duplicate). Also: `PointList.hashcode` looks to be a well thought-out hashing implementation IMO

[Tested by running a MNC commutes DM successfully](https://replicahq.slack.com/archives/C072W5Q5F5E/p1716581464623049?thread_ts=1716482148.284629&cid=C072W5Q5F5E); no routers failed due to memory.

cc @rregue 