### PR TITLE
Incorporate beta knob fix + expose max transfer time setting

### DIFF
--- a/configs/gtfs_validation_gh_config_phase_2.yaml
+++ b/configs/gtfs_validation_gh_config_phase_2.yaml
@@ -7,6 +7,7 @@ graphhopper:
   gtfs.file:
 
   gtfs.trip_based: true
+  gtfs.trip_based.max_transfer_time: 900  # 15 * 60
   gtfs.schedule_day: {{ GTFS_SCHEDULE_DAYS }}
 
   graph.location: transit_data/graphhopper

--- a/configs/gtfs_validation_gh_config_phase_2.yaml
+++ b/configs/gtfs_validation_gh_config_phase_2.yaml
@@ -7,7 +7,7 @@ graphhopper:
   gtfs.file:
 
   gtfs.trip_based: true
-  gtfs.trip_based.max_transfer_time: 900  # 15 * 60
+  gtfs.trip_based.max_transfer_time: 1200  # 20 * 60
   gtfs.schedule_day: {{ GTFS_SCHEDULE_DAYS }}
 
   graph.location: transit_data/graphhopper

--- a/configs/run_local_server_gh_config.yaml
+++ b/configs/run_local_server_gh_config.yaml
@@ -6,6 +6,7 @@ graphhopper:
   gtfs.file: web/test-data/gtfs/f-9qc-fairfield~ca~us.zip,web/test-data/gtfs/rosevill.zip,web/test-data/gtfs/srtd.zip,web/test-data/gtfs/vacaville.zip
 
   gtfs.trip_based: true
+  gtfs.trip_based.max_transfer_time: 900  # 15 * 60
   gtfs.schedule_day: 2019-10-15
 
   gtfs.max_transfer_interpolation_walk_time_seconds: 300

--- a/configs/run_local_server_gh_config.yaml
+++ b/configs/run_local_server_gh_config.yaml
@@ -6,7 +6,7 @@ graphhopper:
   gtfs.file: web/test-data/gtfs/f-9qc-fairfield~ca~us.zip,web/test-data/gtfs/rosevill.zip,web/test-data/gtfs/srtd.zip,web/test-data/gtfs/vacaville.zip
 
   gtfs.trip_based: true
-  gtfs.trip_based.max_transfer_time: 900  # 15 * 60
+  gtfs.trip_based.max_transfer_time: 1200  # 20 * 60
   gtfs.schedule_day: 2019-10-15
 
   gtfs.max_transfer_interpolation_walk_time_seconds: 300

--- a/configs/test_gh_config.yaml
+++ b/configs/test_gh_config.yaml
@@ -6,6 +6,7 @@ graphhopper:
   gtfs.file: {{ TEST_GTFS }}
 
   gtfs.trip_based: true
+  gtfs.trip_based.max_transfer_time: 900  # 15 * 60
   gtfs.schedule_day: 2019-10-15
 
   gtfs.max_transfer_interpolation_walk_time_seconds: 300

--- a/configs/test_gh_config.yaml
+++ b/configs/test_gh_config.yaml
@@ -6,7 +6,7 @@ graphhopper:
   gtfs.file: {{ TEST_GTFS }}
 
   gtfs.trip_based: true
-  gtfs.trip_based.max_transfer_time: 900  # 15 * 60
+  gtfs.trip_based.max_transfer_time: 1200  # 20 * 60
   gtfs.schedule_day: 2019-10-15
 
   gtfs.max_transfer_interpolation_walk_time_seconds: 300

--- a/replica-common/pom.xml
+++ b/replica-common/pom.xml
@@ -19,31 +19,31 @@
         <dependency>
             <groupId>com.graphhopper</groupId>
             <artifactId>graphhopper-core</artifactId>
-            <version>ca01da64b8af84f291a2b3105c11241f3ed55e27</version>
+            <version>09e3c5ee921cf203ded73db64fc705047f5b0b4a</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.graphhopper</groupId>
             <artifactId>graphhopper-reader-gtfs</artifactId>
-            <version>ca01da64b8af84f291a2b3105c11241f3ed55e27</version>
+            <version>09e3c5ee921cf203ded73db64fc705047f5b0b4a</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.graphhopper</groupId>
             <artifactId>graphhopper-web-bundle</artifactId>
-            <version>ca01da64b8af84f291a2b3105c11241f3ed55e27</version>
+            <version>09e3c5ee921cf203ded73db64fc705047f5b0b4a</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.graphhopper</groupId>
             <artifactId>graphhopper-web</artifactId>
-            <version>ca01da64b8af84f291a2b3105c11241f3ed55e27</version>
+            <version>09e3c5ee921cf203ded73db64fc705047f5b0b4a</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.graphhopper</groupId>
             <artifactId>graphhopper-tools</artifactId>
-            <version>ca01da64b8af84f291a2b3105c11241f3ed55e27</version>
+            <version>09e3c5ee921cf203ded73db64fc705047f5b0b4a</version>
             <type>pom</type>
         </dependency>
         <dependency>

--- a/web/src/test/java/com/replica/RouterServerTest.java
+++ b/web/src/test/java/com/replica/RouterServerTest.java
@@ -68,15 +68,16 @@ public class RouterServerTest extends ReplicaGraphHopperTest {
     private static final double[] REQUEST_ORIGIN_2 = {38.59337420024281, -121.48746937746185}; // Sacramento area
     private static final double[] REQUEST_DESTINATION_1 = {38.55518457319914, -121.43714698730038}; // Sacramento area
     private static final double[] REQUEST_DESTINATION_2 = {38.69871256445126, -121.27320348867218}; // South of Roseville
+    private static final double[] REQUEST_DESTINATION_3 = {38.68163283946138,-121.15723016671839}; // Folsom
 
     // Should force a transfer between routes from 2 distinct feeds
     private static final RouterOuterClass.PtRouteRequest PT_REQUEST_DIFF_FEEDS = createPtRequest(REQUEST_ORIGIN_1, REQUEST_DESTINATION_1);
     // Should force a transfer between routes from the same feed
-    private static final RouterOuterClass.PtRouteRequest PT_REQUEST_SAME_FEED = createPtRequest(REQUEST_ORIGIN_2, REQUEST_DESTINATION_1);
+    private static final RouterOuterClass.PtRouteRequest PT_REQUEST_SAME_FEED = createPtRequest(REQUEST_ORIGIN_2, REQUEST_DESTINATION_2);
     // Tests park-and-ride routing, with custom access/egress modes
     private static final RouterOuterClass.PtRouteRequest PT_REQUEST_PARK_N_RIDE = createPtRequest(REQUEST_ORIGIN_1, REQUEST_DESTINATION_1, "car", "foot");
     // Tests park-and-ride routing for a longer route (with a transfer)
-    private static final RouterOuterClass.PtRouteRequest PT_REQUEST_PARK_N_RIDE_W_TRANSFER = createPtRequest(REQUEST_ORIGIN_1, REQUEST_DESTINATION_2, "car", "foot");
+    private static final RouterOuterClass.PtRouteRequest PT_REQUEST_PARK_N_RIDE_W_TRANSFER = createPtRequest(REQUEST_ORIGIN_2, REQUEST_DESTINATION_3, "car", "foot");
 
     private static final String DEFAULT_CAR_PROFILE_NAME = "car_default";
     private static final String DEFAULT_TRUCK_PROFILE_NAME = "truck_default";
@@ -287,7 +288,7 @@ public class RouterServerTest extends ReplicaGraphHopperTest {
         checkTransitQuery(response, 2, 3,
                 Lists.newArrayList("ACCESS", "TRANSFER", "EGRESS"),
                 expectedModeCounts,
-                Lists.newArrayList(5, 28, 1, 202, 15)
+                Lists.newArrayList(20, 446, 10, 224, 4)
         );
     }
 
@@ -302,7 +303,7 @@ public class RouterServerTest extends ReplicaGraphHopperTest {
         checkTransitQuery(response, 1, 2,
                 Lists.newArrayList("ACCESS", "EGRESS"),
                 expectedModeCounts,
-                Lists.newArrayList(118, 69, 27)
+                Lists.newArrayList(123, 63, 27)
         );
     }
 
@@ -318,7 +319,7 @@ public class RouterServerTest extends ReplicaGraphHopperTest {
         checkTransitQuery(response, 2, 3,
                 Lists.newArrayList("ACCESS", "TRANSFER", "EGRESS"),
                 expectedModeCounts,
-                Lists.newArrayList(26, 61, 5, 69, 3)
+                Lists.newArrayList(132, 109, 12, 53, 13)
         );
     }
 


### PR DESCRIPTION
https://replicahq.atlassian.net/browse/RAD-6608

Incorporates a new commit from @michaz's `patterns` branch, adding fixes for the functionality of the beta transfers + beta access/egress knobs, as well as exposing the max transfer time as a built-time parameter we can change ourselves

Aside from fixing up a few unit tests (routing behavior changes slightly given the beta knobs fix, so certain checks needed updating), we've run a few MNC runs successfully with routers built off this branch ([thread](https://replicahq.slack.com/archives/CK358RL0Z/p1723221459340449)) and we've run North Atlantic router performance tests with several values for max transfer time ([results](https://replicahq.slack.com/archives/CK358RL0Z/p1723492266235689); as expected, increasing max transfer time gives more successful PT routes but negatively impacts query performance)

cc @bryanwilliams1025 