### PR TITLE
Integrate transit algo transfer behavior fix

### DIFF
--- a/replica-common/pom.xml
+++ b/replica-common/pom.xml
@@ -19,31 +19,31 @@
         <dependency>
             <groupId>com.graphhopper</groupId>
             <artifactId>graphhopper-core</artifactId>
-            <version>09e3c5ee921cf203ded73db64fc705047f5b0b4a</version>
+            <version>febf7555a6cea16f216b816621550ab6c4ea4afd</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.graphhopper</groupId>
             <artifactId>graphhopper-reader-gtfs</artifactId>
-            <version>09e3c5ee921cf203ded73db64fc705047f5b0b4a</version>
+            <version>febf7555a6cea16f216b816621550ab6c4ea4afd</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.graphhopper</groupId>
             <artifactId>graphhopper-web-bundle</artifactId>
-            <version>09e3c5ee921cf203ded73db64fc705047f5b0b4a</version>
+            <version>febf7555a6cea16f216b816621550ab6c4ea4afd</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.graphhopper</groupId>
             <artifactId>graphhopper-web</artifactId>
-            <version>09e3c5ee921cf203ded73db64fc705047f5b0b4a</version>
+            <version>febf7555a6cea16f216b816621550ab6c4ea4afd</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.graphhopper</groupId>
             <artifactId>graphhopper-tools</artifactId>
-            <version>09e3c5ee921cf203ded73db64fc705047f5b0b4a</version>
+            <version>febf7555a6cea16f216b816621550ab6c4ea4afd</version>
             <type>pom</type>
         </dependency>
         <dependency>

--- a/replica-common/pom.xml
+++ b/replica-common/pom.xml
@@ -19,31 +19,31 @@
         <dependency>
             <groupId>com.graphhopper</groupId>
             <artifactId>graphhopper-core</artifactId>
-            <version>febf7555a6cea16f216b816621550ab6c4ea4afd</version>
+            <version>fa79c0eca22eaed15e3b3dcbc039f7c59863eaca</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.graphhopper</groupId>
             <artifactId>graphhopper-reader-gtfs</artifactId>
-            <version>febf7555a6cea16f216b816621550ab6c4ea4afd</version>
+            <version>fa79c0eca22eaed15e3b3dcbc039f7c59863eaca</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.graphhopper</groupId>
             <artifactId>graphhopper-web-bundle</artifactId>
-            <version>febf7555a6cea16f216b816621550ab6c4ea4afd</version>
+            <version>fa79c0eca22eaed15e3b3dcbc039f7c59863eaca</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.graphhopper</groupId>
             <artifactId>graphhopper-web</artifactId>
-            <version>febf7555a6cea16f216b816621550ab6c4ea4afd</version>
+            <version>fa79c0eca22eaed15e3b3dcbc039f7c59863eaca</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.graphhopper</groupId>
             <artifactId>graphhopper-tools</artifactId>
-            <version>febf7555a6cea16f216b816621550ab6c4ea4afd</version>
+            <version>fa79c0eca22eaed15e3b3dcbc039f7c59863eaca</version>
             <type>pom</type>
         </dependency>
         <dependency>

--- a/web/src/test/java/com/replica/RouterServerTest.java
+++ b/web/src/test/java/com/replica/RouterServerTest.java
@@ -288,7 +288,7 @@ public class RouterServerTest extends ReplicaGraphHopperTest {
         checkTransitQuery(response, 2, 3,
                 Lists.newArrayList("ACCESS", "TRANSFER", "EGRESS"),
                 expectedModeCounts,
-                Lists.newArrayList(20, 446, 10, 224, 4)
+                Lists.newArrayList(17, 208, 271, 49, 4)
         );
     }
 

--- a/web/src/test/java/com/replica/RouterServerTest.java
+++ b/web/src/test/java/com/replica/RouterServerTest.java
@@ -283,10 +283,11 @@ public class RouterServerTest extends ReplicaGraphHopperTest {
 
         Map<String, Integer> expectedModeCounts = Maps.newHashMap();
         expectedModeCounts.put("car", 0);
-        expectedModeCounts.put("foot", 3);
+        expectedModeCounts.put("foot", 2);
 
-        checkTransitQuery(response, 2, 3,
-                Lists.newArrayList("ACCESS", "TRANSFER", "EGRESS"),
+        // Transfers are so close that no transfer legs are returned in this query
+        checkTransitQuery(response, 3, 2,
+                Lists.newArrayList("ACCESS", "EGRESS"),
                 expectedModeCounts,
                 Lists.newArrayList(17, 208, 271, 49, 4)
         );


### PR DESCRIPTION
https://replicahq.atlassian.net/browse/RAD-6635

Bumps our GH dependency to include Michael's new fix around transfer behavior. One test needed a bit of updating, as some of the returned route info changed due to the behavior change.

Tested by running a 2024_Q2 MNC full run and a 2023_Q4 NA 2%; confirmed [here](https://replicahq.slack.com/archives/C076XPT2XA5/p1725037440343629?thread_ts=1725035763.439799&cid=C076XPT2XA5) that changes look good 🎉 