### PR TITLE
Insert empty ACCESS/TRANSFER/EGRESS walking legs in PT responses if missing

### DIFF
--- a/grpc/src/main/java/com/replica/CustomStreetLeg.java
+++ b/grpc/src/main/java/com/replica/CustomStreetLeg.java
@@ -18,7 +18,6 @@ public class CustomStreetLeg extends Trip.WalkLeg {
         super(leg.departureLocation, leg.getDepartureTime(), leg.geometry,
                 leg.distance, leg.instructions, leg.details, leg.getArrivalTime());
         this.stableEdgeIds = stableEdgeIds;
-        this.details.clear();
         this.travelSegmentType = travelSegmentType;
         this.mode = mode;
     }

--- a/grpc/src/main/java/com/replica/api/TransitRouter.java
+++ b/grpc/src/main/java/com/replica/api/TransitRouter.java
@@ -157,7 +157,8 @@ public class TransitRouter {
      * Performs public-transit-specific modifications to the legs of the ResponsePath. Specifically:
      *
      * - adds stable edge ids to the walk and PT legs
-     * - stores ACCESS/EGRESS metadata on walk legs
+     * - stores ACCESS/TRANSFER/EGRESS metadata on walk legs
+     * - inserts empty walking ACCESS/TRANSFER/EGRESS legs, if they're missing
      *
      * @param path the ResponsePath to augment. modified in place
      */

--- a/grpc/src/main/java/com/replica/api/TransitRouter.java
+++ b/grpc/src/main/java/com/replica/api/TransitRouter.java
@@ -174,7 +174,6 @@ public class TransitRouter {
             Trip.Leg leg = legs.get(i);
             // Note: graphhopper returns Trip.WalkLegs even if we requested different access/egress modes
             if (leg instanceof Trip.WalkLeg) {
-                lastSeenLeg = leg;
                 Trip.WalkLeg thisLeg = (Trip.WalkLeg) leg;
                 String travelSegmentType;
                 String legMode = "foot";
@@ -209,7 +208,6 @@ public class TransitRouter {
                             leg.getDepartureTime(), "TRANSFER", "foot"
                     ));
                 }
-                lastSeenLeg = leg;
 
                 long startTime = System.currentTimeMillis();
                 CustomPtLeg customPtLeg = RouterConverters.toCustomPtLeg(thisLeg, gtfsFeedIdMapping, gtfsLinkMappings, gtfsRouteInfo);
@@ -219,6 +217,7 @@ public class TransitRouter {
 
                 path.getLegs().add(customPtLeg);
             }
+            lastSeenLeg = leg;
         }
 
         // If no EGRESS walk leg exists, insert an empty one

--- a/grpc/src/main/java/com/replica/util/RouterConverters.java
+++ b/grpc/src/main/java/com/replica/util/RouterConverters.java
@@ -8,10 +8,7 @@ import com.google.protobuf.Timestamp;
 import com.graphhopper.*;
 import com.graphhopper.gtfs.Request;
 import com.graphhopper.jackson.Jackson;
-import com.graphhopper.util.CustomModel;
-import com.graphhopper.util.DistanceCalcEarth;
-import com.graphhopper.util.PMap;
-import com.graphhopper.util.Parameters;
+import com.graphhopper.util.*;
 import com.graphhopper.util.details.PathDetail;
 import com.graphhopper.util.shapes.GHPoint;
 import com.replica.CustomPtLeg;
@@ -310,6 +307,16 @@ public final class RouterConverters {
         return leg.details.get(ReplicaPathDetails.STABLE_EDGE_IDS).stream()
                 .map(idPathDetail -> (String) idPathDetail.getValue())
                 .collect(toList());
+    }
+
+    public static CustomStreetLeg createEmptyCustomStreetLeg(org.locationtech.jts.geom.Point point, Date departureTime,
+                                                             String travelSegmentType, String mode) {
+        // Set departureLocation, instructions, and details params as either "" or null (these values aren't used in
+        // our returned proto objects). Departure and arrival time are set as equal, and distance is set to 0.0
+        Trip.WalkLeg emptyWalkLeg = new Trip.WalkLeg("", departureTime, point, 0.0, null, null, departureTime);
+
+        // Set stable edge ID list as empty
+        return new CustomStreetLeg(emptyWalkLeg, Lists.newArrayList(), travelSegmentType, mode);
     }
 
     private static String gtfsRouteInfoKey(Trip.PtLeg leg) {

--- a/replica-common/pom.xml
+++ b/replica-common/pom.xml
@@ -19,31 +19,31 @@
         <dependency>
             <groupId>com.graphhopper</groupId>
             <artifactId>graphhopper-core</artifactId>
-            <version>09e3c5ee921cf203ded73db64fc705047f5b0b4a</version>
+            <version>febf7555a6cea16f216b816621550ab6c4ea4afd</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.graphhopper</groupId>
             <artifactId>graphhopper-reader-gtfs</artifactId>
-            <version>09e3c5ee921cf203ded73db64fc705047f5b0b4a</version>
+            <version>febf7555a6cea16f216b816621550ab6c4ea4afd</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.graphhopper</groupId>
             <artifactId>graphhopper-web-bundle</artifactId>
-            <version>09e3c5ee921cf203ded73db64fc705047f5b0b4a</version>
+            <version>febf7555a6cea16f216b816621550ab6c4ea4afd</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.graphhopper</groupId>
             <artifactId>graphhopper-web</artifactId>
-            <version>09e3c5ee921cf203ded73db64fc705047f5b0b4a</version>
+            <version>febf7555a6cea16f216b816621550ab6c4ea4afd</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.graphhopper</groupId>
             <artifactId>graphhopper-tools</artifactId>
-            <version>09e3c5ee921cf203ded73db64fc705047f5b0b4a</version>
+            <version>febf7555a6cea16f216b816621550ab6c4ea4afd</version>
             <type>pom</type>
         </dependency>
         <dependency>

--- a/replica-common/pom.xml
+++ b/replica-common/pom.xml
@@ -19,31 +19,31 @@
         <dependency>
             <groupId>com.graphhopper</groupId>
             <artifactId>graphhopper-core</artifactId>
-            <version>febf7555a6cea16f216b816621550ab6c4ea4afd</version>
+            <version>fa79c0eca22eaed15e3b3dcbc039f7c59863eaca</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.graphhopper</groupId>
             <artifactId>graphhopper-reader-gtfs</artifactId>
-            <version>febf7555a6cea16f216b816621550ab6c4ea4afd</version>
+            <version>fa79c0eca22eaed15e3b3dcbc039f7c59863eaca</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.graphhopper</groupId>
             <artifactId>graphhopper-web-bundle</artifactId>
-            <version>febf7555a6cea16f216b816621550ab6c4ea4afd</version>
+            <version>fa79c0eca22eaed15e3b3dcbc039f7c59863eaca</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.graphhopper</groupId>
             <artifactId>graphhopper-web</artifactId>
-            <version>febf7555a6cea16f216b816621550ab6c4ea4afd</version>
+            <version>fa79c0eca22eaed15e3b3dcbc039f7c59863eaca</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.graphhopper</groupId>
             <artifactId>graphhopper-tools</artifactId>
-            <version>febf7555a6cea16f216b816621550ab6c4ea4afd</version>
+            <version>fa79c0eca22eaed15e3b3dcbc039f7c59863eaca</version>
             <type>pom</type>
         </dependency>
         <dependency>

--- a/web/src/test/java/com/replica/RouterServerTest.java
+++ b/web/src/test/java/com/replica/RouterServerTest.java
@@ -273,7 +273,6 @@ public class RouterServerTest extends ReplicaGraphHopperTest {
         final RouterOuterClass.PtRouteReply response = routerStub.routePt(PT_REQUEST_DIFF_FEEDS);
 
         Map<String, Integer> expectedModeCounts = Maps.newHashMap();
-        expectedModeCounts.put("car", 0);
         expectedModeCounts.put("foot", 3);
 
         checkTransitQuery(response, 2, 3,
@@ -289,7 +288,6 @@ public class RouterServerTest extends ReplicaGraphHopperTest {
         final RouterOuterClass.PtRouteReply response = routerStub.routePt(PT_REQUEST_SAME_FEED);
 
         Map<String, Integer> expectedModeCounts = Maps.newHashMap();
-        expectedModeCounts.put("car", 0);
         expectedModeCounts.put("foot", 4);
 
         // Ensure that 2 empty walk transfer legs are inserted between transit legs
@@ -338,7 +336,6 @@ public class RouterServerTest extends ReplicaGraphHopperTest {
         // in testIntraFeedPublicTransitQuery()
         final RouterOuterClass.PtRouteReply emptyAccessLegResponse = routerStub.routePt(PT_REQUEST_EMPTY_ACCESS_LEG);
         Map<String, Integer> expectedModeCounts = Maps.newHashMap();
-        expectedModeCounts.put("car", 0);
         expectedModeCounts.put("foot", 3);
 
         checkTransitQuery(emptyAccessLegResponse, 2, 3,
@@ -349,7 +346,6 @@ public class RouterServerTest extends ReplicaGraphHopperTest {
 
         final RouterOuterClass.PtRouteReply emptyEgressLegResponse = routerStub.routePt(PT_REQUEST_EMPTY_EGRESS_LEG);
         expectedModeCounts = Maps.newHashMap();
-        expectedModeCounts.put("car", 0);
         expectedModeCounts.put("foot", 2);
 
         checkTransitQuery(emptyEgressLegResponse, 1, 2,
@@ -396,7 +392,14 @@ public class RouterServerTest extends ReplicaGraphHopperTest {
             observedDistanceMeters += streetLeg.getDistanceMeters();
         }
         assertEquals(expectedTravelSegmentTypes, observedTravelSegmentTypes);
-        assertEquals(expectedModeCounts, observedModeCounts);
+        for (String expectedMode: expectedModeCounts.keySet()) {
+            assertEquals(expectedModeCounts.get(expectedMode), observedModeCounts.get(expectedMode));
+        }
+        for (String observedMode: observedModeCounts.keySet()) {
+            if (observedModeCounts.get(observedMode) > 0) {
+                assertTrue(expectedModeCounts.containsKey(observedMode));
+            }
+        }
 
         // Check that PT legs contains proper info
         for (RouterOuterClass.PtLeg ptLeg : ptLegs) {

--- a/web/src/test/java/com/replica/RouterServerTest.java
+++ b/web/src/test/java/com/replica/RouterServerTest.java
@@ -381,11 +381,16 @@ public class RouterServerTest extends ReplicaGraphHopperTest {
         int observedStableEdgeIdCount = 0;
         double observedDistanceMeters = 0;
         for (RouterOuterClass.PtLeg streetLeg : streetLegs) {
-            assertTrue(streetLeg.getStableEdgeIdsCount() >= 0);
+            // If stable edge ID list is emtpy, ensure leg was an empty leg we added on purpose (with distance/duration of 0)
+            if (streetLeg.getStableEdgeIdsCount() == 0) {
+                assertEquals(streetLeg.getArrivalTime().getSeconds(), streetLeg.getDepartureTime().getSeconds());
+                assertEquals(0.0, streetLeg.getDistanceMeters());
+            } else {
+                assertTrue(streetLeg.getArrivalTime().getSeconds() > streetLeg.getDepartureTime().getSeconds());
+                assertTrue(streetLeg.getDistanceMeters() > 0.0);
+            }
             observedStableEdgeIdCount += streetLeg.getStableEdgeIdsCount();
             observedStableEdgeIds.addAll(streetLeg.getStableEdgeIdsList());
-            assertTrue(streetLeg.getArrivalTime().getSeconds() >= streetLeg.getDepartureTime().getSeconds());
-            assertTrue(streetLeg.getDistanceMeters() >= 0.0);
             assertFalse(streetLeg.getTravelSegmentType().isEmpty());
             observedTravelSegmentTypes.add(streetLeg.getTravelSegmentType());
             observedModeCounts.put(streetLeg.getMode(), observedModeCounts.get(streetLeg.getMode()) + 1);

--- a/web/src/test/java/com/replica/RouterServerTest.java
+++ b/web/src/test/java/com/replica/RouterServerTest.java
@@ -66,9 +66,11 @@ public class RouterServerTest extends ReplicaGraphHopperTest {
             Timestamp.newBuilder().setSeconds(Instant.parse("2019-10-15T13:30:00Z").toEpochMilli() / 1000).build();
     private static final double[] REQUEST_ORIGIN_1 = {38.74891667931467, -121.29023848101498}; // Roseville area
     private static final double[] REQUEST_ORIGIN_2 = {38.59337420024281, -121.48746937746185}; // Sacramento area
+    private static final double[] REQUEST_ORIGIN_3 = {38.60641317625813,-121.44842859546773}; // North of Sacramento, directly on SRT Blue line stop
     private static final double[] REQUEST_DESTINATION_1 = {38.55518457319914, -121.43714698730038}; // Sacramento area
     private static final double[] REQUEST_DESTINATION_2 = {38.69871256445126, -121.27320348867218}; // South of Roseville
     private static final double[] REQUEST_DESTINATION_3 = {38.68163283946138,-121.15723016671839}; // Folsom
+    private static final double[] REQUEST_DESTINATION_4 = {38.5698294,-121.4888139}; // Sacramento, directly on SRT Blue line stop
 
     // Should force a transfer between routes from 2 distinct feeds
     private static final RouterOuterClass.PtRouteRequest PT_REQUEST_DIFF_FEEDS = createPtRequest(REQUEST_ORIGIN_1, REQUEST_DESTINATION_1);
@@ -78,6 +80,10 @@ public class RouterServerTest extends ReplicaGraphHopperTest {
     private static final RouterOuterClass.PtRouteRequest PT_REQUEST_PARK_N_RIDE = createPtRequest(REQUEST_ORIGIN_1, REQUEST_DESTINATION_1, "car", "foot");
     // Tests park-and-ride routing for a longer route (with a transfer)
     private static final RouterOuterClass.PtRouteRequest PT_REQUEST_PARK_N_RIDE_W_TRANSFER = createPtRequest(REQUEST_ORIGIN_2, REQUEST_DESTINATION_3, "car", "foot");
+    // Tests insertion of empty access walk leg when origin is on top of existing transit stop
+    private static final RouterOuterClass.PtRouteRequest PT_REQUEST_EMPTY_ACCESS_LEG = createPtRequest(REQUEST_ORIGIN_3, REQUEST_DESTINATION_1);
+    // Tests insertion of empty egress walk leg when destination is on top of existing transit stop
+    private static final RouterOuterClass.PtRouteRequest PT_REQUEST_EMPTY_EGRESS_LEG = createPtRequest(REQUEST_ORIGIN_2, REQUEST_DESTINATION_4);
 
     private static final String DEFAULT_CAR_PROFILE_NAME = "car_default";
     private static final String DEFAULT_TRUCK_PROFILE_NAME = "truck_default";
@@ -277,20 +283,23 @@ public class RouterServerTest extends ReplicaGraphHopperTest {
         );
     }
 
+
     @Test
     public void testIntraFeedPublicTransitQuery() {
         final RouterOuterClass.PtRouteReply response = routerStub.routePt(PT_REQUEST_SAME_FEED);
 
         Map<String, Integer> expectedModeCounts = Maps.newHashMap();
         expectedModeCounts.put("car", 0);
-        expectedModeCounts.put("foot", 2);
+        expectedModeCounts.put("foot", 4);
 
-        // Transfers are so close that no transfer legs are returned in this query
-        checkTransitQuery(response, 3, 2,
-                Lists.newArrayList("ACCESS", "EGRESS"),
+        checkTransitQuery(response, 3, 4,
+                Lists.newArrayList("ACCESS", "TRANSFER", "TRANSFER", "EGRESS"),
                 expectedModeCounts,
-                Lists.newArrayList(17, 208, 271, 49, 4)
+                Lists.newArrayList(17, 208, 0, 271, 0, 49, 4)
         );
+
+        // Check that empty walk transfer leg was inserted after first transit leg
+        assertEquals(0, response.getPaths(0).getLegs(2).getStableEdgeIdsCount());
     }
 
     @Test
@@ -324,6 +333,34 @@ public class RouterServerTest extends ReplicaGraphHopperTest {
         );
     }
 
+    @Test
+    public void testEmptyAccessEgressLegCreation() {
+
+        // todo: add comment describing this
+        // todo: mention how we check for empty transfer leg being added in testIntraFeedPublicTransitQuery()
+
+
+        final RouterOuterClass.PtRouteReply emptyAccessLegResponse = routerStub.routePt(PT_REQUEST_EMPTY_ACCESS_LEG);
+
+        Map<String, Integer> expectedModeCounts = Maps.newHashMap();
+        expectedModeCounts.put("car", 0);
+        expectedModeCounts.put("foot", 3);
+        //
+        /*
+        checkTransitQuery(emptyAccessLegResponse, 2, 3,
+                Lists.newArrayList("ACCESS", "TRANSFER", "EGRESS"),
+                expectedModeCounts,
+                Lists.newArrayList(132, 109, 12, 53, 13)
+        );
+        */
+
+        final RouterOuterClass.PtRouteReply emptyEgressLegResponse = routerStub.routePt(PT_REQUEST_EMPTY_EGRESS_LEG);
+
+        expectedModeCounts = Maps.newHashMap();
+        expectedModeCounts.put("car", 0);
+        expectedModeCounts.put("foot", 2);
+    }
+
     private void checkTransitQuery(RouterOuterClass.PtRouteReply response,
                                    int expectedPtLegs, int expectedStreetLegs,
                                    List<String> expectedTravelSegmentTypes,
@@ -350,11 +387,11 @@ public class RouterServerTest extends ReplicaGraphHopperTest {
         int observedStableEdgeIdCount = 0;
         double observedDistanceMeters = 0;
         for (RouterOuterClass.PtLeg streetLeg : streetLegs) {
-            assertTrue(streetLeg.getStableEdgeIdsCount() > 0);
+            assertTrue(streetLeg.getStableEdgeIdsCount() >= 0);
             observedStableEdgeIdCount += streetLeg.getStableEdgeIdsCount();
             observedStableEdgeIds.addAll(streetLeg.getStableEdgeIdsList());
-            assertTrue(streetLeg.getArrivalTime().getSeconds() > streetLeg.getDepartureTime().getSeconds());
-            assertTrue(streetLeg.getDistanceMeters() > 0);
+            assertTrue(streetLeg.getArrivalTime().getSeconds() >= streetLeg.getDepartureTime().getSeconds());
+            assertTrue(streetLeg.getDistanceMeters() >= 0.0);
             assertFalse(streetLeg.getTravelSegmentType().isEmpty());
             observedTravelSegmentTypes.add(streetLeg.getTravelSegmentType());
             observedModeCounts.put(streetLeg.getMode(), observedModeCounts.get(streetLeg.getMode()) + 1);
@@ -398,6 +435,9 @@ public class RouterServerTest extends ReplicaGraphHopperTest {
         for (int i = 0; i < path.getLegsList().size(); i++) {
             assertEquals(expectedStableEdgeIdCount.get(i), path.getLegsList().get(i).getStableEdgeIdsCount());
         }
+
+        // Check number of transfers is correct
+        assertEquals(expectedTravelSegmentTypes.stream().filter(t -> t.equals("TRANSFER")).count(), path.getTransfers());
     }
 
     @Test

--- a/web/src/test/java/com/replica/RouterServerTest.java
+++ b/web/src/test/java/com/replica/RouterServerTest.java
@@ -288,7 +288,7 @@ public class RouterServerTest extends ReplicaGraphHopperTest {
         checkTransitQuery(response, 2, 3,
                 Lists.newArrayList("ACCESS", "TRANSFER", "EGRESS"),
                 expectedModeCounts,
-                Lists.newArrayList(20, 446, 10, 224, 4)
+                Lists.newArrayList(17, 208, 271, 49, 4)
         );
     }
 

--- a/web/src/test/java/com/replica/RouterServerTest.java
+++ b/web/src/test/java/com/replica/RouterServerTest.java
@@ -283,10 +283,11 @@ public class RouterServerTest extends ReplicaGraphHopperTest {
 
         Map<String, Integer> expectedModeCounts = Maps.newHashMap();
         expectedModeCounts.put("car", 0);
-        expectedModeCounts.put("foot", 3);
+        expectedModeCounts.put("foot", 2);
 
-        checkTransitQuery(response, 2, 3,
-                Lists.newArrayList("ACCESS", "TRANSFER", "EGRESS"),
+        // Transfers are so close that no transfer legs are returned in this query
+        checkTransitQuery(response, 3, 2,
+                Lists.newArrayList("ACCESS", "EGRESS"),
                 expectedModeCounts,
                 Lists.newArrayList(17, 208, 271, 49, 4)
         );


### PR DESCRIPTION
https://replicahq.atlassian.net/browse/RAD-6640

As the ticket notes, a new algorithmic fix Michael made to the transit algorithm we're using resulted in the router returning many more routes with transfers that occur at a single station (ie, routes where the end of one transit leg has the identical lat/lon to the start of the next transit leg).

In these cases, GraphHopper currently does not insert a walking leg, meaning it's easy to miscalculate the number of transfers when doing analysis of Places trip data, and surgery seems to do odd things like cut out entire _transit_ legs of trips, making them look downright wrong when viewed raw in BQ.

It turns out that if you set an origin or destination exactly on top of a transit station, you also don't get back `ACCESS` or `EGRESS` walking legs; this case seems much less likely to happen (as opposed to same-station transfers, which are common), but still worth addressing:

<img width="1159" alt="Screenshot 2024-09-19 at 3 00 06 PM" src="https://github.com/user-attachments/assets/3c0a203b-c415-47a1-a2ee-120eb4a69a60">

<img width="1193" alt="Screenshot 2024-09-19 at 3 00 13 PM" src="https://github.com/user-attachments/assets/64146fa4-1367-4e27-9512-e80c6c84f91b">

---

I added logic to `augmentLegsForPt` to address this, which is already doing similar manipulation of transit response legs. The logic covers each case:
- if the first leg in GraphHopper's response is a transit leg, we add an empty `ACCESS` leg to the start of the path
- if two consecutive transit legs appear in a path, we add an empty `TRANSFER` walking leg between them
- if the final leg in GraphHopper's response is a transit leg, we add an empty `EGRESS` leg to the end of the path

I've added a new test that covers the empty `ACCESS` and `EGRESS` leg insertion cases, and the existing `testIntraFeedPublicTransitQuery()` test already covers the `TRANSFER` leg case