### PR TITLE
Bump upload-artifact github action from v2 to v4

### DIFF
--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -112,13 +112,13 @@ jobs:
       # todo: use job-specific archive names to prevent parallel jobs from overwriting each other's results?
       # Does it matter, given the results will be analyzed instantly after this?
       - name: Archive street functional test results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: functional-test-street-results
           path: ${{ env.TMPDIR }}/street_responses.json
 
       - name: Archive transit functional test results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: functional-test-transit-results
           path: ${{ env.TMPDIR }}/transit_responses.json

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -195,12 +195,12 @@ jobs:
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
       - name: Download archived street functional test results
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: functional-test-street-results
 
       - name: Download transit functional test results
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: functional-test-transit-results
 


### PR DESCRIPTION
Same deal as https://github.com/replicahq/model/pull/8821

[[failure](https://github.com/replicahq/graphhopper/actions/runs/10998468986/job/30536453478)]
> Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v2`. Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

Bumps `actions/upload-artifact` from v2 to v4

### Testing

Once CI passes, I'll run the FT off of this branch