### PR TITLE
[RAD-6652] Implement RouteStreetProfiles endpoint

### DIFF
--- a/grpc/src/main/java/com/replica/RouterImpl.java
+++ b/grpc/src/main/java/com/replica/RouterImpl.java
@@ -85,6 +85,11 @@ public class RouterImpl extends router.RouterGrpc.RouterImplBase {
     }
 
     @Override
+    public void routeStreetProfiles(ProfilesStreetRouteRequest request, StreamObserver<router.RouterOuterClass.StreetRouteReply> responseObserver) {
+        streetRouter.routeStreetProfiles(request, responseObserver);
+    }
+
+    @Override
     public void routeCustom(CustomRouteRequest request, StreamObserver<StreetRouteReply> responseObserver) {
         customStreetRouter.routeCustom(request, responseObserver);
     }

--- a/grpc/src/main/java/com/replica/api/StreetRouter.java
+++ b/grpc/src/main/java/com/replica/api/StreetRouter.java
@@ -45,17 +45,17 @@ public class StreetRouter {
         ProfilesStreetRouteRequest profilesStreetRouteRequest = RouterConverters.toProfilesStreetRouteRequest(request, graphHopper);
         // for backcompat, use a metric tag of "mode". clients typically send modes within the profile field, and these
         // are translated into profiles using prefix matching
-        String profileMetricTags = "mode:" + request.getProfile();
-        routeStreetProfiles(profilesStreetRouteRequest, responseObserver, profileMetricTags);
+        String profileMetricTag = "mode:" + request.getProfile();
+        routeStreetProfiles(profilesStreetRouteRequest, responseObserver, profileMetricTag);
     }
 
     public void routeStreetProfiles(ProfilesStreetRouteRequest request, StreamObserver<StreetRouteReply> responseObserver) {
-        String profileMetricTags = "profiles:" + request.getProfilesList();
-        routeStreetProfiles(request, responseObserver, profileMetricTags);
+        String profileMetricTag = "profiles:" + request.getProfilesList();
+        routeStreetProfiles(request, responseObserver, profileMetricTag);
     }
 
     private void routeStreetProfiles(ProfilesStreetRouteRequest request, StreamObserver<StreetRouteReply> responseObserver,
-                                     String profileMetricTags) {
+                                     String profileMetricTag) {
         long startTime = System.currentTimeMillis();
 
         Point origin = request.getPoints(0);
@@ -99,7 +99,7 @@ public class StreetRouter {
                 logger.error(message, e);
 
                 double durationSeconds = (System.currentTimeMillis() - startTime) / 1000.0;
-                String[] tags = {profileMetricTags, "api:grpc", "routes_found:error"};
+                String[] tags = {profileMetricTag, "api:grpc", "routes_found:error"};
                 tags = MetricUtils.applyCustomTags(tags, customTags);
                 MetricUtils.sendRoutingStats(statsDClient, tags, durationSeconds);
 
@@ -118,7 +118,7 @@ public class StreetRouter {
                     + origin.getLat() + "," + origin.getLon() + " to " + dest.getLat() + "," + dest.getLon();
 
             double durationSeconds = (System.currentTimeMillis() - startTime) / 1000.0;
-            String[] tags = {profileMetricTags, "api:grpc", "routes_found:false"};
+            String[] tags = {profileMetricTag, "api:grpc", "routes_found:false"};
             tags = MetricUtils.applyCustomTags(tags, customTags);
             MetricUtils.sendRoutingStats(statsDClient, tags, durationSeconds, 0);
 
@@ -129,7 +129,7 @@ public class StreetRouter {
             responseObserver.onError(StatusProto.toStatusRuntimeException(status));
         } else {
             double durationSeconds = (System.currentTimeMillis() - startTime) / 1000.0;
-            String[] tags = {profileMetricTags, "api:grpc", "routes_found:true"};
+            String[] tags = {profileMetricTag, "api:grpc", "routes_found:true"};
             tags = MetricUtils.applyCustomTags(tags, customTags);
             MetricUtils.sendRoutingStats(statsDClient, tags, durationSeconds, pathsFound);
 

--- a/grpc/src/main/java/com/replica/api/StreetRouter.java
+++ b/grpc/src/main/java/com/replica/api/StreetRouter.java
@@ -17,13 +17,14 @@ import io.grpc.stub.StreamObserver;
 import org.glassfish.jersey.internal.guava.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import router.RouterOuterClass.Point;
+import router.RouterOuterClass.ProfilesStreetRouteRequest;
 import router.RouterOuterClass.StreetRouteReply;
 import router.RouterOuterClass.StreetRouteRequest;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 public class StreetRouter {
 
@@ -41,27 +42,29 @@ public class StreetRouter {
     }
 
     public void routeStreetMode(StreetRouteRequest request, StreamObserver<StreetRouteReply> responseObserver) {
+        ProfilesStreetRouteRequest profilesStreetRouteRequest = RouterConverters.toProfilesStreetRouteRequest(request, graphHopper);
+        // for backcompat, use a metric tag of "mode". clients typically send modes within the profile field, and these
+        // are translated into profiles using prefix matching
+        String profileMetricTags = "mode:" + request.getProfile();
+        routeStreetProfiles(profilesStreetRouteRequest, responseObserver, profileMetricTags);
+    }
+
+    public void routeStreetProfiles(ProfilesStreetRouteRequest request, StreamObserver<StreetRouteReply> responseObserver) {
+        String profileMetricTags = "profiles:" + request.getProfilesList();
+        routeStreetProfiles(request, responseObserver, profileMetricTags);
+    }
+
+    private void routeStreetProfiles(ProfilesStreetRouteRequest request, StreamObserver<StreetRouteReply> responseObserver,
+                                     String profileMetricTags) {
         long startTime = System.currentTimeMillis();
 
-        // For a given "base" profile requested (eg `car`), find all pre-loaded profiles associated
-        // with the base profile (eg `car_local`, `car_freeway`). Each such pre-loaded profile will get
-        // queried, and resulting paths will be combined in one response
-        List<String> profilesToQuery = graphHopper.getProfiles().stream()
-                .map(Profile::getName)
-                .filter(profile -> profile.startsWith(request.getProfile()))
-                .collect(Collectors.toList());
-
-        // Construct query object with settings shared across all profilesToQuery
-        GHRequest ghRequest = RouterConverters.toGHRequest(request);
-
-        GHPoint origin = ghRequest.getPoints().get(0);
-        GHPoint dest = ghRequest.getPoints().get(1);
+        Point origin = request.getPoints(0);
+        Point dest = request.getPoints(1);
 
         StreetRouteReply.Builder replyBuilder = StreetRouteReply.newBuilder();
         int pathsFound = 0;
         Set<Integer> pathHashesInReturnSet = Sets.newHashSet();
-        for (String profile : profilesToQuery) {
-            ghRequest.setProfile(profile);
+        for (GHRequest ghRequest : RouterConverters.toGHRequests(request)) {
             try {
                 GHResponse ghResponse = graphHopper.route(ghRequest);
                 // ghResponse.hasErrors() means that the router returned no results
@@ -86,17 +89,17 @@ public class StreetRouter {
 
                     // Add filtered set of paths to full response set
                     pathsToReturn.stream()
-                            .map(responsePath -> RouterConverters.toStreetPath(responsePath, profile, request.getReturnFullPathDetails()))
+                            .map(responsePath -> RouterConverters.toStreetPath(responsePath, ghRequest.getProfile(), request.getReturnFullPathDetails()))
                             .forEach(replyBuilder::addPaths);
                 }
             } catch (Exception e) {
                 String message = "GH internal error! Path could not be found between "
-                        + origin.lat + "," + origin.lon + " to " + dest.lat + "," + dest.lon +
-                        " using profile " + profile;
+                        + origin.getLat() + "," + origin.getLon() + " to " + dest.getLat() + "," + dest.getLon() +
+                        " using profile " + ghRequest.getProfile();
                 logger.error(message, e);
 
                 double durationSeconds = (System.currentTimeMillis() - startTime) / 1000.0;
-                String[] tags = {"mode:" + request.getProfile(), "api:grpc", "routes_found:error"};
+                String[] tags = {profileMetricTags, "api:grpc", "routes_found:error"};
                 tags = MetricUtils.applyCustomTags(tags, customTags);
                 MetricUtils.sendRoutingStats(statsDClient, tags, durationSeconds);
 
@@ -112,10 +115,10 @@ public class StreetRouter {
         // return the standard NOT_FOUND grpc error code
         if (pathsFound == 0) {
             String message = "Path could not be found between "
-                    + origin.lat + "," + origin.lon + " to " + dest.lat + "," + dest.lon;
+                    + origin.getLat() + "," + origin.getLon() + " to " + dest.getLat() + "," + dest.getLon();
 
             double durationSeconds = (System.currentTimeMillis() - startTime) / 1000.0;
-            String[] tags = {"mode:" + request.getProfile(), "api:grpc", "routes_found:false"};
+            String[] tags = {profileMetricTags, "api:grpc", "routes_found:false"};
             tags = MetricUtils.applyCustomTags(tags, customTags);
             MetricUtils.sendRoutingStats(statsDClient, tags, durationSeconds, 0);
 
@@ -126,7 +129,7 @@ public class StreetRouter {
             responseObserver.onError(StatusProto.toStatusRuntimeException(status));
         } else {
             double durationSeconds = (System.currentTimeMillis() - startTime) / 1000.0;
-            String[] tags = {"mode:" + request.getProfile(), "api:grpc", "routes_found:true"};
+            String[] tags = {profileMetricTags, "api:grpc", "routes_found:true"};
             tags = MetricUtils.applyCustomTags(tags, customTags);
             MetricUtils.sendRoutingStats(statsDClient, tags, durationSeconds, pathsFound);
 

--- a/grpc/src/main/java/com/replica/api/StreetRouter.java
+++ b/grpc/src/main/java/com/replica/api/StreetRouter.java
@@ -21,10 +21,7 @@ import router.RouterOuterClass.ProfilesStreetRouteRequest;
 import router.RouterOuterClass.StreetRouteReply;
 import router.RouterOuterClass.StreetRouteRequest;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class StreetRouter {
@@ -51,7 +48,10 @@ public class StreetRouter {
     }
 
     public void routeStreetProfiles(ProfilesStreetRouteRequest request, StreamObserver<StreetRouteReply> responseObserver) {
-        String profilesMetricTag = "profiles:" + request.getProfilesList();
+        List<String> orderedRequestedProfiles = new ArrayList<>(request.getProfilesList());
+        Collections.sort(orderedRequestedProfiles);
+        String profilesMetricTag = "profiles:" + orderedRequestedProfiles;
+
         routeStreetProfiles(request, responseObserver, profilesMetricTag);
     }
 

--- a/web/src/test/java/com/replica/RouterServerTest.java
+++ b/web/src/test/java/com/replica/RouterServerTest.java
@@ -182,6 +182,10 @@ public class RouterServerTest extends ReplicaGraphHopperTest {
         routerStub = router.RouterGrpc.newBlockingStub(channel);
     }
 
+    private static RouterOuterClass.Point createPoint(double[] latLon) {
+        return RouterOuterClass.Point.newBuilder().setLat(latLon[0]).setLon(latLon[1]).build();
+    }
+
     private static RouterOuterClass.StreetRouteRequest createStreetRequest(String mode, boolean alternatives,
                                                                            double[] from, double[] to) {
         return createStreetRequest(mode, alternatives, from, to, true, true);
@@ -192,14 +196,8 @@ public class RouterServerTest extends ReplicaGraphHopperTest {
                                                                            boolean returnFullPathDetails,
                                                                            boolean includeDuplicateRoutes) {
         return RouterOuterClass.StreetRouteRequest.newBuilder()
-                .addPoints(0, RouterOuterClass.Point.newBuilder()
-                        .setLat(from[0])
-                        .setLon(from[1])
-                        .build())
-                .addPoints(1, RouterOuterClass.Point.newBuilder()
-                        .setLat(to[0])
-                        .setLon(to[1])
-                        .build())
+                .addPoints(createPoint(from))
+                .addPoints(createPoint(to))
                 .setProfile(mode)
                 .setAlternateRouteMaxPaths(alternatives ? 5 : 0)
                 // below factors allow for long or very similar alternate routes for the sake of testing
@@ -785,5 +783,42 @@ public class RouterServerTest extends ReplicaGraphHopperTest {
         MultiPolygon reverseFlowInnerBucket = (MultiPolygon) wktReader.read(reverseFlowResponse.getBuckets(0).getGeometry());
         assertNotEquals(reverseFlowInnerBucket.getArea(), threeBucketInnerBucket.getArea());
         */
+    }
+
+    private static RouterOuterClass.ProfilesStreetRouteRequest createProfilesStreetRouteRequest(Set<String> profiles) {
+        return RouterOuterClass.ProfilesStreetRouteRequest.newBuilder()
+                .addPoints(createPoint(REQUEST_ORIGIN_1))
+                .addPoints(createPoint(REQUEST_DESTINATION_1))
+                .setIncludeDuplicateRoutes(true)
+                .addAllProfiles(profiles)
+                .build();
+    }
+
+    private static Set<String> getProfiles(RouterOuterClass.StreetRouteReply response) {
+        return response.getPathsList().stream()
+                .map(RouterOuterClass.StreetPath::getProfile)
+                .collect(Collectors.toSet());
+    }
+
+    @Test
+    public void testRouteStreetProfiles() {
+        Set<String> requestedProfiles = Sets.newHashSet("car", "foot");
+        RouterOuterClass.ProfilesStreetRouteRequest request = createProfilesStreetRouteRequest(requestedProfiles);
+        RouterOuterClass.StreetRouteReply response = routerStub.routeStreetProfiles(request);
+        assertEquals(getProfiles(response), requestedProfiles);
+
+        // multiple profiles within each mode
+        requestedProfiles = Sets.newHashSet("car", "car_freeway", "car_default", "foot", "foot_default");
+        request = createProfilesStreetRouteRequest(requestedProfiles);
+        response = routerStub.routeStreetProfiles(request);
+        assertEquals(getProfiles(response), requestedProfiles);
+
+        String nonexistentProfile = "nonexistent_profile";
+        requestedProfiles = Sets.newHashSet(nonexistentProfile, "car");
+        RouterOuterClass.ProfilesStreetRouteRequest invalidRequest = createProfilesStreetRouteRequest(requestedProfiles);
+        StatusRuntimeException exception =
+                assertThrows(StatusRuntimeException.class, () -> routerStub.routeStreetProfiles(invalidRequest));
+        assertEquals(exception.getStatus().getCode(), Status.Code.INVALID_ARGUMENT);
+        assertTrue(exception.getMessage().contains(nonexistentProfile));
     }
 }

--- a/web/src/test/java/com/replica/RouterServerTest.java
+++ b/web/src/test/java/com/replica/RouterServerTest.java
@@ -43,10 +43,7 @@ import router.RouterOuterClass;
 
 import java.io.File;
 import java.time.Instant;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -785,7 +782,7 @@ public class RouterServerTest extends ReplicaGraphHopperTest {
         */
     }
 
-    private static RouterOuterClass.ProfilesStreetRouteRequest createProfilesStreetRouteRequest(Set<String> profiles) {
+    private static RouterOuterClass.ProfilesStreetRouteRequest createProfilesStreetRouteRequest(Collection<String> profiles) {
         return RouterOuterClass.ProfilesStreetRouteRequest.newBuilder()
                 .addPoints(createPoint(REQUEST_ORIGIN_1))
                 .addPoints(createPoint(REQUEST_DESTINATION_1))
@@ -794,27 +791,27 @@ public class RouterServerTest extends ReplicaGraphHopperTest {
                 .build();
     }
 
-    private static Set<String> getProfiles(RouterOuterClass.StreetRouteReply response) {
+    private static List<String> getProfiles(RouterOuterClass.StreetRouteReply response) {
         return response.getPathsList().stream()
                 .map(RouterOuterClass.StreetPath::getProfile)
-                .collect(Collectors.toSet());
+                .collect(Collectors.toList());
     }
 
     @Test
     public void testRouteStreetProfiles() {
-        Set<String> requestedProfiles = Sets.newHashSet("car", "foot");
+        List<String> requestedProfiles = Lists.newArrayList("car", "foot");
         RouterOuterClass.ProfilesStreetRouteRequest request = createProfilesStreetRouteRequest(requestedProfiles);
         RouterOuterClass.StreetRouteReply response = routerStub.routeStreetProfiles(request);
         assertEquals(getProfiles(response), requestedProfiles);
 
         // multiple profiles within each mode
-        requestedProfiles = Sets.newHashSet("car", "car_freeway", "car_default", "foot", "foot_default");
+        requestedProfiles = Lists.newArrayList("car", "car_freeway", "car_default", "foot", "foot_default");
         request = createProfilesStreetRouteRequest(requestedProfiles);
         response = routerStub.routeStreetProfiles(request);
         assertEquals(getProfiles(response), requestedProfiles);
 
         String nonexistentProfile = "nonexistent_profile";
-        requestedProfiles = Sets.newHashSet(nonexistentProfile, "car");
+        requestedProfiles = Lists.newArrayList(nonexistentProfile, "car");
         RouterOuterClass.ProfilesStreetRouteRequest invalidRequest = createProfilesStreetRouteRequest(requestedProfiles);
         StatusRuntimeException exception =
                 assertThrows(StatusRuntimeException.class, () -> routerStub.routeStreetProfiles(invalidRequest));


### PR DESCRIPTION
https://replicahq.atlassian.net/browse/RAD-6652

Implements the RouteStreetProfiles endpoint introduced in https://github.com/replicahq/idls/pull/114. `StreetRouteRequest`s are now converted to the more general `ProfilesStreetRouteRequest `, allowing the `RouteStreetMode` and `RouteStreetProfiles` endpoints to share code.

Only sticky part was that `RouteStreetMode` previously used a metric tag of `"mode:" + request.getProfile()`. I kept that as-is for backcompat, but `ProfilesStreetRouteRequest`s aren't guaranteed to contain a single mode (and even if they do, they may not use all profiles which correspond to the mode). So I kept things explicit and included all the requested profiles in the metric tag for calls to `RouteStreetProfiles`. We should only see up to two different sets of profiles being requested for each mode in time of day road closures, and the metric tag uses the sorted requested profiles, so the cardinality should be manageable.

cc @rregue 