### PR TITLE
Support single-direction custom speeds

### DIFF
--- a/configs/test_gh_config.yaml
+++ b/configs/test_gh_config.yaml
@@ -45,6 +45,16 @@ graphhopper:
       weighting: fastest
       # sets a zero speed for a section of Baseline Road in Roseville (OSM way id 76254223)
       custom_speed_file: test-data/custom_speeds/baseline_road_zero_speed.csv # mvn tests run from the /web folder
+    - name: car_custom_no_bwd_column_closed_baseline_road
+      vehicle: car_custom_no_bwd_column_closed_baseline_road
+      weighting: fastest
+      # sets a zero speed for a section of Baseline Road in Roseville (OSM way id 76254223), without a bwd column included
+      custom_speed_file: test-data/custom_speeds/baseline_road_zero_speed_no_bwd_column.csv # mvn tests run from the /web folder
+    - name: car_custom_one_direction_closed_baseline_road
+      vehicle: car_custom_one_direction_closed_baseline_road
+      weighting: fastest
+      # sets a zero speed for one direction of a section of Baseline Road in Roseville (OSM way id 76254223)
+      custom_speed_file: test-data/custom_speeds/baseline_road_zero_speed_one_direction.csv # mvn tests run from the /web folder
     - name: bike_default  # _default suffix required for comparison against closed Baseline Road custom speeds profile
       vehicle: bike
       weighting: fastest
@@ -87,6 +97,8 @@ graphhopper:
     - profile: car_freeway
     - profile: car_custom_fast_thurton_drive
     - profile: car_custom_closed_baseline_road
+    - profile: car_custom_no_bwd_column_closed_baseline_road
+    - profile: car_custom_one_direction_closed_baseline_road
     - profile: bike_default
     - profile: bike_custom_closed_baseline_road
     - profile: foot

--- a/web-bundle/src/main/java/com/graphhopper/customspeeds/CustomSpeedsUtils.java
+++ b/web-bundle/src/main/java/com/graphhopper/customspeeds/CustomSpeedsUtils.java
@@ -4,6 +4,8 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.graphhopper.config.Profile;
 import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.BooleanEncodedValue;
+import com.graphhopper.routing.ev.EdgeIntAccess;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
@@ -39,13 +41,13 @@ public class CustomSpeedsUtils {
     public static ImmutableMap<String, CustomSpeedsVehicle> getCustomSpeedVehiclesByName(List<Profile> profiles) {
         Map<String, File> vehicleNameToCustomSpeedFile = getVehicleNameToCustomSpeedFile(profiles);
         // wrap transformValues result in a HashMap to turn the live, lazy view into a traditional map
-        Map<String, ImmutableMap<Pair<Long, Boolean>, Double>> vehicleNameToCustomSpeeds = new HashMap<>(
+        Map<String, Pair<ImmutableMap<Pair<Long, Boolean>, Double>, Boolean>> vehicleNameToCustomSpeeds = new HashMap<>(
                 Maps.transformValues(vehicleNameToCustomSpeedFile, CustomSpeedsUtils::parseOsmWayIdAndBwdToMaxSpeed));
 
         // validate all speeds before attempting to create CustomSpeedsVehicles so all invalid speeds will be logged
         // and users can address all errors instead of one-at-a-time
         Set<String> invalidSpeedVehicleNames = vehicleNameToCustomSpeeds.entrySet().stream()
-                .filter(entry -> !CustomSpeedsVehicle.validateCustomSpeeds(entry.getKey(), entry.getValue()))
+                .filter(entry -> !CustomSpeedsVehicle.validateCustomSpeeds(entry.getKey(), entry.getValue().getLeft()))
                 .map(Map.Entry::getKey)
                 .collect(Collectors.toSet());
         if (!invalidSpeedVehicleNames.isEmpty()) {
@@ -78,15 +80,25 @@ public class CustomSpeedsUtils {
                 .collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, entry -> entry.getValue().get()));
     }
 
-    private static ImmutableMap<Pair<Long, Boolean>, Double> parseOsmWayIdAndBwdToMaxSpeed(File customSpeedFile) {
+    /**
+     * Parses custom speeds from a single custom speeds file. Speeds are stored in a mapping from
+     * (OSM Way ID, `bwd`) -> speed, where `bwd` is a flag denoting that the speed should be stored for the
+     * backward direction of a Way. If no `bwd` column is present, speeds are stored for both True and False
+     * values of `bwd` (ie, the speed is applied for both directions, where applicable).
+     *
+     * @param customSpeedFile input custom speed file to be parsed
+     * @return Pair containing the mapping of (OSM Way Id, `bwd`) -> speed, and a boolean representing whether or not
+     * the `bwd` column was present in the input file
+     */
+    private static Pair<ImmutableMap<Pair<Long, Boolean>, Double>, Boolean> parseOsmWayIdAndBwdToMaxSpeed(File customSpeedFile) {
         ImmutableMap.Builder<Pair<Long, Boolean>, Double> osmWayIdAndBwdToMaxSpeed = ImmutableMap.builder();
-
+        boolean bwdColumnPresent;
         try {
             Reader in = new FileReader(customSpeedFile);
             // setHeader() with no args allows the column names to be automatically parsed from the first line of the
             // file
             CSVParser parser = CSVFormat.Builder.create().setHeader().build().parse(in);
-            boolean bwdColumnPresent = parser.getHeaderNames().contains(CUSTOM_SPEED_BWD_COL_NAME);
+            bwdColumnPresent = parser.getHeaderNames().contains(CUSTOM_SPEED_BWD_COL_NAME);
             for (CSVRecord record : parser) {
                 Long osmWayId = Long.parseLong(record.get(CUSTOM_SPEED_OSM_WAY_ID_COL_NAME));
                 Double maxSpeed = Double.parseDouble(record.get(CUSTOM_SPEED_MAX_SPEED_KPH_COL_NAME));
@@ -108,12 +120,22 @@ public class CustomSpeedsUtils {
                     + ". Please ensure file exists and is in the correct format!", e);
         }
 
-        return osmWayIdAndBwdToMaxSpeed.build();
+        return Pair.of(osmWayIdAndBwdToMaxSpeed.build(), bwdColumnPresent);
     }
 
     public static Optional<Double> getCustomMaxSpeed(ReaderWay way, ImmutableMap<Pair<Long, Boolean>, Double> osmWayIdAndBwdToCustomMaxSpeed, boolean bwd) {
         // n.b. CarAverageSpeedParser sets max speed to be 90% of the OSM's max speed for the way, but we don't apply the 90%
         // discount for the custom speeds we've been explicitly given
         return Optional.ofNullable(osmWayIdAndBwdToCustomMaxSpeed.get(Pair.of(way.getId(), bwd)));
+    }
+
+    public static void validateCustomSpeedDirection(ImmutableMap<Pair<Long, Boolean>, Double> osmWayIdAndBwdToMaxSpeed, boolean bwdColumnPresent,
+                                                    long wayId, BooleanEncodedValue accessEnc, int ghEdgeId, EdgeIntAccess edgeIntAccess) {
+        // If way ID -> custom speed mapping provided as input specifies a speed for the bwd direction of a road
+        // that doesn't allow travel in the bwd direction, throw an error
+        Pair<Long, Boolean> wayIdAndBwd = Pair.of(wayId, true);
+        if (osmWayIdAndBwdToMaxSpeed.containsKey(wayIdAndBwd) && bwdColumnPresent && !accessEnc.getBool(true, ghEdgeId, edgeIntAccess)) {
+            throw new RuntimeException("Input custom speeds specify a bwd speed for OSM Way " + wayId + ", but it doesn't allow travel in that direction!");
+        }
     }
 }

--- a/web-bundle/src/main/java/com/graphhopper/customspeeds/CustomSpeedsUtils.java
+++ b/web-bundle/src/main/java/com/graphhopper/customspeeds/CustomSpeedsUtils.java
@@ -1,6 +1,7 @@
 package com.graphhopper.customspeeds;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.graphhopper.config.Profile;
 import com.graphhopper.reader.ReaderWay;
@@ -131,11 +132,14 @@ public class CustomSpeedsUtils {
 
     public static void validateCustomSpeedDirection(ImmutableMap<Pair<Long, Boolean>, Double> osmWayIdAndBwdToMaxSpeed, boolean bwdColumnPresent,
                                                     long wayId, BooleanEncodedValue accessEnc, int ghEdgeId, EdgeIntAccess edgeIntAccess) {
-        // If way ID -> custom speed mapping provided as input specifies a speed for the bwd direction of a road
-        // that doesn't allow travel in the bwd direction, throw an error
-        Pair<Long, Boolean> wayIdAndBwd = Pair.of(wayId, true);
-        if (osmWayIdAndBwdToMaxSpeed.containsKey(wayIdAndBwd) && bwdColumnPresent && !accessEnc.getBool(true, ghEdgeId, edgeIntAccess)) {
-            throw new RuntimeException("Input custom speeds specify a bwd speed for OSM Way " + wayId + ", but it doesn't allow travel in that direction!");
+        // If way ID -> custom speed mapping provided as input specifies a speed for a direction of a road that doesn't allow travel in that
+        // direction, throw an error
+        for (Boolean bwd : Lists.newArrayList(true, false)){
+            Pair<Long, Boolean> wayIdAndBwd = Pair.of(wayId, bwd);
+            if (osmWayIdAndBwdToMaxSpeed.containsKey(wayIdAndBwd) && bwdColumnPresent && !accessEnc.getBool(bwd, ghEdgeId, edgeIntAccess)) {
+                String direction = bwd ? "backward" : "forward";
+                throw new RuntimeException("Input custom speeds specify a " + direction + " speed for OSM Way " + wayId + ", but it doesn't allow travel in that direction!");
+            }
         }
     }
 }

--- a/web-bundle/src/main/java/com/graphhopper/customspeeds/CustomSpeedsUtils.java
+++ b/web-bundle/src/main/java/com/graphhopper/customspeeds/CustomSpeedsUtils.java
@@ -132,8 +132,8 @@ public class CustomSpeedsUtils {
 
     public static void validateCustomSpeedDirection(ImmutableMap<Pair<Long, Boolean>, Double> osmWayIdAndBwdToMaxSpeed, boolean bwdColumnPresent,
                                                     long wayId, BooleanEncodedValue accessEnc, int ghEdgeId, EdgeIntAccess edgeIntAccess) {
-        // If way ID -> custom speed mapping provided as input specifies a speed for a direction of a road that doesn't allow travel in that
-        // direction, throw an error
+        // If way ID -> custom speed mapping provided as input specifies a speed for a direction of a road that
+        // doesn't allow travel in that direction, throw an error
         for (Boolean bwd : Lists.newArrayList(true, false)){
             Pair<Long, Boolean> wayIdAndBwd = Pair.of(wayId, bwd);
             if (osmWayIdAndBwdToMaxSpeed.containsKey(wayIdAndBwd) && bwdColumnPresent && !accessEnc.getBool(bwd, ghEdgeId, edgeIntAccess)) {

--- a/web-bundle/src/main/java/com/graphhopper/customspeeds/CustomSpeedsUtils.java
+++ b/web-bundle/src/main/java/com/graphhopper/customspeeds/CustomSpeedsUtils.java
@@ -89,7 +89,7 @@ public class CustomSpeedsUtils {
      *
      * @param customSpeedFile input custom speed file to be parsed
      * @return Pair containing the mapping of (OSM Way Id, `bwd`) -> speed, and a boolean representing whether or not
-     * the `bwd` column was present in the input file
+     * directional custom speeds were provided in the input file (ie the `bwd` column was present)
      */
     private static Pair<ImmutableMap<Pair<Long, Boolean>, Double>, Boolean> parseOsmWayIdAndBwdToMaxSpeed(File customSpeedFile) {
         ImmutableMap.Builder<Pair<Long, Boolean>, Double> osmWayIdAndBwdToMaxSpeed = ImmutableMap.builder();

--- a/web-bundle/src/main/java/com/graphhopper/customspeeds/CustomSpeedsVehicle.java
+++ b/web-bundle/src/main/java/com/graphhopper/customspeeds/CustomSpeedsVehicle.java
@@ -37,19 +37,21 @@ public class CustomSpeedsVehicle {
     public final VehicleType baseVehicleType;
     public final String customVehicleName;
     public final ImmutableMap<Pair<Long, Boolean>, Double> osmWayIdAndBwdToCustomSpeed;
+    public final boolean bwdColumnPresent;
 
-    private CustomSpeedsVehicle(String customVehicleName, VehicleType baseVehicleType, ImmutableMap<Pair<Long, Boolean>, Double> osmWayIdAndBwdToCustomSpeed) {
+    private CustomSpeedsVehicle(String customVehicleName, VehicleType baseVehicleType, ImmutableMap<Pair<Long, Boolean>, Double> osmWayIdAndBwdToCustomSpeed, boolean bwdColumnPresent) {
         this.customVehicleName = customVehicleName;
         this.baseVehicleType = baseVehicleType;
         this.osmWayIdAndBwdToCustomSpeed = osmWayIdAndBwdToCustomSpeed;
+        this.bwdColumnPresent = bwdColumnPresent;
     }
 
-    public static CustomSpeedsVehicle create(String customVehicleName, ImmutableMap<Pair<Long, Boolean>, Double> osmWayIdAndBwdToCustomSpeed) {
-        if (!validateCustomSpeeds(customVehicleName, osmWayIdAndBwdToCustomSpeed)) {
+    public static CustomSpeedsVehicle create(String customVehicleName, Pair<ImmutableMap<Pair<Long, Boolean>, Double>, Boolean> osmWayIdAndBwdToCustomSpeed) {
+        if (!validateCustomSpeeds(customVehicleName, osmWayIdAndBwdToCustomSpeed.getLeft())) {
             throw new IllegalArgumentException(String.format("Invalid speeds for vehicle %s. See logging for details", customVehicleName));
         }
 
-        return new CustomSpeedsVehicle(customVehicleName, CustomSpeedsVehicle.getBaseVehicleType(customVehicleName), osmWayIdAndBwdToCustomSpeed);
+        return new CustomSpeedsVehicle(customVehicleName, CustomSpeedsVehicle.getBaseVehicleType(customVehicleName), osmWayIdAndBwdToCustomSpeed.getLeft(), osmWayIdAndBwdToCustomSpeed.getRight());
     }
 
     public static boolean validateCustomSpeeds(String customVehicleName, ImmutableMap<Pair<Long, Boolean>, Double> osmWayIdAndBwdToCustomSpeed) {
@@ -63,7 +65,6 @@ public class CustomSpeedsVehicle {
                     customVehicleName, baseVehicleType, baseVehicleType.getMaxValidSpeed(), invalidSpeeds);
             return false;
         }
-
         return true;
     }
 

--- a/web-bundle/src/main/java/com/graphhopper/customspeeds/CustomSpeedsVehicle.java
+++ b/web-bundle/src/main/java/com/graphhopper/customspeeds/CustomSpeedsVehicle.java
@@ -7,6 +7,7 @@ import com.graphhopper.http.TruckAverageSpeedParser;
 import com.graphhopper.replica.ReplicaCustomSpeedsFootTagParser;
 import com.graphhopper.routing.util.parsers.BikeAverageSpeedParser;
 import com.graphhopper.routing.util.parsers.CarAverageSpeedParser;
+import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,27 +36,27 @@ public class CustomSpeedsVehicle {
 
     public final VehicleType baseVehicleType;
     public final String customVehicleName;
-    public final ImmutableMap<Long, Double> osmWayIdToCustomSpeed;
+    public final ImmutableMap<Pair<Long, Boolean>, Double> osmWayIdAndBwdToCustomSpeed;
 
-    private CustomSpeedsVehicle(String customVehicleName, VehicleType baseVehicleType, ImmutableMap<Long, Double> osmWayIdToCustomSpeed) {
+    private CustomSpeedsVehicle(String customVehicleName, VehicleType baseVehicleType, ImmutableMap<Pair<Long, Boolean>, Double> osmWayIdAndBwdToCustomSpeed) {
         this.customVehicleName = customVehicleName;
         this.baseVehicleType = baseVehicleType;
-        this.osmWayIdToCustomSpeed = osmWayIdToCustomSpeed;
+        this.osmWayIdAndBwdToCustomSpeed = osmWayIdAndBwdToCustomSpeed;
     }
 
-    public static CustomSpeedsVehicle create(String customVehicleName, ImmutableMap<Long, Double> osmWayIdToCustomSpeed) {
-        if (!validateCustomSpeeds(customVehicleName, osmWayIdToCustomSpeed)) {
+    public static CustomSpeedsVehicle create(String customVehicleName, ImmutableMap<Pair<Long, Boolean>, Double> osmWayIdAndBwdToCustomSpeed) {
+        if (!validateCustomSpeeds(customVehicleName, osmWayIdAndBwdToCustomSpeed)) {
             throw new IllegalArgumentException(String.format("Invalid speeds for vehicle %s. See logging for details", customVehicleName));
         }
 
-        return new CustomSpeedsVehicle(customVehicleName, CustomSpeedsVehicle.getBaseVehicleType(customVehicleName), osmWayIdToCustomSpeed);
+        return new CustomSpeedsVehicle(customVehicleName, CustomSpeedsVehicle.getBaseVehicleType(customVehicleName), osmWayIdAndBwdToCustomSpeed);
     }
 
-    public static boolean validateCustomSpeeds(String customVehicleName, ImmutableMap<Long, Double> osmWayIdToCustomSpeed) {
+    public static boolean validateCustomSpeeds(String customVehicleName, ImmutableMap<Pair<Long, Boolean>, Double> osmWayIdAndBwdToCustomSpeed) {
         VehicleType baseVehicleType = CustomSpeedsVehicle.getBaseVehicleType(customVehicleName);
 
         // wrap filterValues result in a HashMap to turn live, lazy view into a traditional map
-        Map<Long, Double> invalidSpeeds = new HashMap<>(Maps.filterValues(osmWayIdToCustomSpeed,
+        Map<Pair<Long, Boolean>, Double> invalidSpeeds = new HashMap<>(Maps.filterValues(osmWayIdAndBwdToCustomSpeed,
                 speed -> speed < 0 || speed > baseVehicleType.getMaxValidSpeed()));
         if (!invalidSpeeds.isEmpty()) {
             logger.error("Invalid speeds found for vehicle {}. Custom speeds for base vehicle {} must be between 0 and {}. Full mapping of invalid speeds: {}",
@@ -90,11 +91,11 @@ public class CustomSpeedsVehicle {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         CustomSpeedsVehicle that = (CustomSpeedsVehicle) o;
-        return baseVehicleType == that.baseVehicleType && customVehicleName.equals(that.customVehicleName) && osmWayIdToCustomSpeed.equals(that.osmWayIdToCustomSpeed);
+        return baseVehicleType == that.baseVehicleType && customVehicleName.equals(that.customVehicleName) && osmWayIdAndBwdToCustomSpeed.equals(that.osmWayIdAndBwdToCustomSpeed);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(baseVehicleType, customVehicleName, osmWayIdToCustomSpeed);
+        return Objects.hash(baseVehicleType, customVehicleName, osmWayIdAndBwdToCustomSpeed);
     }
 }

--- a/web-bundle/src/main/java/com/graphhopper/customspeeds/CustomSpeedsVehicle.java
+++ b/web-bundle/src/main/java/com/graphhopper/customspeeds/CustomSpeedsVehicle.java
@@ -37,13 +37,13 @@ public class CustomSpeedsVehicle {
     public final VehicleType baseVehicleType;
     public final String customVehicleName;
     public final ImmutableMap<Pair<Long, Boolean>, Double> osmWayIdAndBwdToCustomSpeed;
-    public final boolean bwdColumnPresent;
+    public final boolean directionalCustomSpeedsProvided;
 
-    private CustomSpeedsVehicle(String customVehicleName, VehicleType baseVehicleType, ImmutableMap<Pair<Long, Boolean>, Double> osmWayIdAndBwdToCustomSpeed, boolean bwdColumnPresent) {
+    private CustomSpeedsVehicle(String customVehicleName, VehicleType baseVehicleType, ImmutableMap<Pair<Long, Boolean>, Double> osmWayIdAndBwdToCustomSpeed, boolean directionalCustomSpeedsProvided) {
         this.customVehicleName = customVehicleName;
         this.baseVehicleType = baseVehicleType;
         this.osmWayIdAndBwdToCustomSpeed = osmWayIdAndBwdToCustomSpeed;
-        this.bwdColumnPresent = bwdColumnPresent;
+        this.directionalCustomSpeedsProvided = directionalCustomSpeedsProvided;
     }
 
     public static CustomSpeedsVehicle create(String customVehicleName, Pair<ImmutableMap<Pair<Long, Boolean>, Double>, Boolean> osmWayIdAndBwdToCustomSpeed) {

--- a/web-bundle/src/main/java/com/graphhopper/replica/ReplicaCustomSpeedsBikeAccessParser.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/ReplicaCustomSpeedsBikeAccessParser.java
@@ -1,0 +1,28 @@
+package com.graphhopper.replica;
+
+import com.google.common.collect.ImmutableMap;
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.EdgeIntAccess;
+import com.graphhopper.routing.ev.EncodedValueLookup;
+import com.graphhopper.routing.util.parsers.BikeAccessParser;
+import com.graphhopper.util.PMap;
+import org.apache.commons.lang3.tuple.Pair;
+
+import static com.graphhopper.customspeeds.CustomSpeedsUtils.validateCustomSpeedDirection;
+
+public class ReplicaCustomSpeedsBikeAccessParser extends BikeAccessParser {
+    private final ImmutableMap<Pair<Long, Boolean>, Double> osmWayIdAndBwdToMaxSpeed;
+    private final boolean bwdColumnPresent;
+
+    public ReplicaCustomSpeedsBikeAccessParser(EncodedValueLookup lookup, PMap properties, ImmutableMap<Pair<Long, Boolean>, Double> osmWayIdAndBwdToMaxSpeed, boolean bwdColumnPresent) {
+        super(lookup, properties);
+        this.osmWayIdAndBwdToMaxSpeed = osmWayIdAndBwdToMaxSpeed;
+        this.bwdColumnPresent = bwdColumnPresent;
+    }
+
+    @Override
+    public void handleWayTags(int edgeId, EdgeIntAccess edgeIntAccess, ReaderWay way) {
+        super.handleWayTags(edgeId, edgeIntAccess, way);
+        validateCustomSpeedDirection(osmWayIdAndBwdToMaxSpeed, bwdColumnPresent, way.getId(), accessEnc, edgeId, edgeIntAccess);
+    }
+}

--- a/web-bundle/src/main/java/com/graphhopper/replica/ReplicaCustomSpeedsBikeAccessParser.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/ReplicaCustomSpeedsBikeAccessParser.java
@@ -12,17 +12,17 @@ import static com.graphhopper.customspeeds.CustomSpeedsUtils.validateCustomSpeed
 
 public class ReplicaCustomSpeedsBikeAccessParser extends BikeAccessParser {
     private final ImmutableMap<Pair<Long, Boolean>, Double> osmWayIdAndBwdToMaxSpeed;
-    private final boolean bwdColumnPresent;
+    private final boolean directionalCustomSpeedsProvided;
 
-    public ReplicaCustomSpeedsBikeAccessParser(EncodedValueLookup lookup, PMap properties, ImmutableMap<Pair<Long, Boolean>, Double> osmWayIdAndBwdToMaxSpeed, boolean bwdColumnPresent) {
+    public ReplicaCustomSpeedsBikeAccessParser(EncodedValueLookup lookup, PMap properties, ImmutableMap<Pair<Long, Boolean>, Double> osmWayIdAndBwdToMaxSpeed, boolean directionalCustomSpeedsProvided) {
         super(lookup, properties);
         this.osmWayIdAndBwdToMaxSpeed = osmWayIdAndBwdToMaxSpeed;
-        this.bwdColumnPresent = bwdColumnPresent;
+        this.directionalCustomSpeedsProvided = directionalCustomSpeedsProvided;
     }
 
     @Override
     public void handleWayTags(int edgeId, EdgeIntAccess edgeIntAccess, ReaderWay way) {
         super.handleWayTags(edgeId, edgeIntAccess, way);
-        validateCustomSpeedDirection(osmWayIdAndBwdToMaxSpeed, bwdColumnPresent, way.getId(), accessEnc, edgeId, edgeIntAccess);
+        validateCustomSpeedDirection(osmWayIdAndBwdToMaxSpeed, directionalCustomSpeedsProvided, way.getId(), accessEnc, edgeId, edgeIntAccess);
     }
 }

--- a/web-bundle/src/main/java/com/graphhopper/replica/ReplicaCustomSpeedsBikeTagParser.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/ReplicaCustomSpeedsBikeTagParser.java
@@ -6,17 +6,18 @@ import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.EncodedValueLookup;
 import com.graphhopper.routing.util.parsers.BikeAverageSpeedParser;
 import com.graphhopper.util.PMap;
+import org.apache.commons.lang3.tuple.Pair;
 
 public class ReplicaCustomSpeedsBikeTagParser extends BikeAverageSpeedParser {
-    private final ImmutableMap<Long, Double> osmWayIdToMaxSpeed;
+    private final ImmutableMap<Pair<Long, Boolean>, Double> osmWayIdAndBwdToMaxSpeed;
 
-    public ReplicaCustomSpeedsBikeTagParser(EncodedValueLookup lookup, PMap configuration, ImmutableMap<Long, Double> osmWayIdToMaxSpeed) {
+    public ReplicaCustomSpeedsBikeTagParser(EncodedValueLookup lookup, PMap configuration, ImmutableMap<Pair<Long, Boolean>, Double> osmWayIdAndBwdToMaxSpeed) {
         super(lookup, configuration);
-        this.osmWayIdToMaxSpeed = osmWayIdToMaxSpeed;
+        this.osmWayIdAndBwdToMaxSpeed = osmWayIdAndBwdToMaxSpeed;
     }
 
     @Override
     public double applyMaxSpeed(ReaderWay way, double speed, boolean bwd) {
-        return CustomSpeedsUtils.getCustomMaxSpeed(way, osmWayIdToMaxSpeed).orElseGet(() -> super.applyMaxSpeed(way, speed, bwd));
+        return CustomSpeedsUtils.getCustomMaxSpeed(way, osmWayIdAndBwdToMaxSpeed, bwd).orElseGet(() -> super.applyMaxSpeed(way, speed, bwd));
     }
 }

--- a/web-bundle/src/main/java/com/graphhopper/replica/ReplicaCustomSpeedsCarAccessParser.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/ReplicaCustomSpeedsCarAccessParser.java
@@ -12,17 +12,17 @@ import static com.graphhopper.customspeeds.CustomSpeedsUtils.validateCustomSpeed
 
 public class ReplicaCustomSpeedsCarAccessParser extends CarAccessParser {
     private final ImmutableMap<Pair<Long, Boolean>, Double> osmWayIdAndBwdToMaxSpeed;
-    private final boolean bwdColumnPresent;
+    private final boolean directionalCustomSpeedsProvided;
 
-    public ReplicaCustomSpeedsCarAccessParser(EncodedValueLookup lookup, PMap properties, ImmutableMap<Pair<Long, Boolean>, Double> osmWayIdAndBwdToMaxSpeed, boolean bwdColumnPresent) {
+    public ReplicaCustomSpeedsCarAccessParser(EncodedValueLookup lookup, PMap properties, ImmutableMap<Pair<Long, Boolean>, Double> osmWayIdAndBwdToMaxSpeed, boolean directionalCustomSpeedsProvided) {
         super(lookup, properties);
         this.osmWayIdAndBwdToMaxSpeed = osmWayIdAndBwdToMaxSpeed;
-        this.bwdColumnPresent = bwdColumnPresent;
+        this.directionalCustomSpeedsProvided = directionalCustomSpeedsProvided;
     }
 
     @Override
     public void handleWayTags(int edgeId, EdgeIntAccess edgeIntAccess, ReaderWay way) {
         super.handleWayTags(edgeId, edgeIntAccess, way);
-        validateCustomSpeedDirection(osmWayIdAndBwdToMaxSpeed, bwdColumnPresent, way.getId(), accessEnc, edgeId, edgeIntAccess);
+        validateCustomSpeedDirection(osmWayIdAndBwdToMaxSpeed, directionalCustomSpeedsProvided, way.getId(), accessEnc, edgeId, edgeIntAccess);
     }
 }

--- a/web-bundle/src/main/java/com/graphhopper/replica/ReplicaCustomSpeedsCarAccessParser.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/ReplicaCustomSpeedsCarAccessParser.java
@@ -1,0 +1,28 @@
+package com.graphhopper.replica;
+
+import com.google.common.collect.ImmutableMap;
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.EdgeIntAccess;
+import com.graphhopper.routing.ev.EncodedValueLookup;
+import com.graphhopper.routing.util.parsers.CarAccessParser;
+import com.graphhopper.util.PMap;
+import org.apache.commons.lang3.tuple.Pair;
+
+import static com.graphhopper.customspeeds.CustomSpeedsUtils.validateCustomSpeedDirection;
+
+public class ReplicaCustomSpeedsCarAccessParser extends CarAccessParser {
+    private final ImmutableMap<Pair<Long, Boolean>, Double> osmWayIdAndBwdToMaxSpeed;
+    private final boolean bwdColumnPresent;
+
+    public ReplicaCustomSpeedsCarAccessParser(EncodedValueLookup lookup, PMap properties, ImmutableMap<Pair<Long, Boolean>, Double> osmWayIdAndBwdToMaxSpeed, boolean bwdColumnPresent) {
+        super(lookup, properties);
+        this.osmWayIdAndBwdToMaxSpeed = osmWayIdAndBwdToMaxSpeed;
+        this.bwdColumnPresent = bwdColumnPresent;
+    }
+
+    @Override
+    public void handleWayTags(int edgeId, EdgeIntAccess edgeIntAccess, ReaderWay way) {
+        super.handleWayTags(edgeId, edgeIntAccess, way);
+        validateCustomSpeedDirection(osmWayIdAndBwdToMaxSpeed, bwdColumnPresent, way.getId(), accessEnc, edgeId, edgeIntAccess);
+    }
+}

--- a/web-bundle/src/main/java/com/graphhopper/replica/ReplicaCustomSpeedsCarTagParser.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/ReplicaCustomSpeedsCarTagParser.java
@@ -6,22 +6,18 @@ import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.EncodedValueLookup;
 import com.graphhopper.routing.util.parsers.CarAverageSpeedParser;
 import com.graphhopper.util.PMap;
+import org.apache.commons.lang3.tuple.Pair;
 
 public class ReplicaCustomSpeedsCarTagParser extends CarAverageSpeedParser {
-    private final ImmutableMap<Long, Double> osmWayIdToMaxSpeed;
+    private final ImmutableMap<Pair<Long, Boolean>, Double> osmWayIdAndBwdToMaxSpeed;
 
-    public ReplicaCustomSpeedsCarTagParser(EncodedValueLookup lookup, PMap configuration, ImmutableMap<Long, Double> osmWayIdToMaxSpeed) {
+    public ReplicaCustomSpeedsCarTagParser(EncodedValueLookup lookup, PMap configuration, ImmutableMap<Pair<Long, Boolean>, Double> osmWayIdAndBwdToMaxSpeed) {
         super(lookup, configuration);
-        this.osmWayIdToMaxSpeed = osmWayIdToMaxSpeed;
+        this.osmWayIdAndBwdToMaxSpeed = osmWayIdAndBwdToMaxSpeed;
     }
 
     @Override
     protected double applyMaxSpeed(ReaderWay way, double speed, boolean bwd) {
-        return CustomSpeedsUtils.getCustomMaxSpeed(way, osmWayIdToMaxSpeed).orElseGet(() -> super.applyMaxSpeed(way, speed, bwd));
-    }
-
-    @Override
-    protected double applyBadSurfaceSpeed(ReaderWay way, double speed) {
-        return CustomSpeedsUtils.getCustomBadSurfaceSpeed(way, osmWayIdToMaxSpeed).orElseGet(() -> super.applyBadSurfaceSpeed(way, speed));
+        return CustomSpeedsUtils.getCustomMaxSpeed(way, osmWayIdAndBwdToMaxSpeed, bwd).orElseGet(() -> super.applyMaxSpeed(way, speed, bwd));
     }
 }

--- a/web-bundle/src/main/java/com/graphhopper/replica/ReplicaCustomSpeedsFootAccessParser.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/ReplicaCustomSpeedsFootAccessParser.java
@@ -12,17 +12,17 @@ import static com.graphhopper.customspeeds.CustomSpeedsUtils.validateCustomSpeed
 
 public class ReplicaCustomSpeedsFootAccessParser extends FootAccessParser {
     private final ImmutableMap<Pair<Long, Boolean>, Double> osmWayIdAndBwdToMaxSpeed;
-    private final boolean bwdColumnPresent;
+    private final boolean directionalCustomSpeedsProvided;
 
-    public ReplicaCustomSpeedsFootAccessParser(EncodedValueLookup lookup, PMap properties, ImmutableMap<Pair<Long, Boolean>, Double> osmWayIdAndBwdToMaxSpeed, boolean bwdColumnPresent) {
+    public ReplicaCustomSpeedsFootAccessParser(EncodedValueLookup lookup, PMap properties, ImmutableMap<Pair<Long, Boolean>, Double> osmWayIdAndBwdToMaxSpeed, boolean directionalCustomSpeedsProvided) {
         super(lookup, properties);
         this.osmWayIdAndBwdToMaxSpeed = osmWayIdAndBwdToMaxSpeed;
-        this.bwdColumnPresent = bwdColumnPresent;
+        this.directionalCustomSpeedsProvided = directionalCustomSpeedsProvided;
     }
 
     @Override
     public void handleWayTags(int edgeId, EdgeIntAccess edgeIntAccess, ReaderWay way) {
         super.handleWayTags(edgeId, edgeIntAccess, way);
-        validateCustomSpeedDirection(osmWayIdAndBwdToMaxSpeed, bwdColumnPresent, way.getId(), accessEnc, edgeId, edgeIntAccess);
+        validateCustomSpeedDirection(osmWayIdAndBwdToMaxSpeed, directionalCustomSpeedsProvided, way.getId(), accessEnc, edgeId, edgeIntAccess);
     }
 }

--- a/web-bundle/src/main/java/com/graphhopper/replica/ReplicaCustomSpeedsFootAccessParser.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/ReplicaCustomSpeedsFootAccessParser.java
@@ -1,0 +1,28 @@
+package com.graphhopper.replica;
+
+import com.google.common.collect.ImmutableMap;
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.EdgeIntAccess;
+import com.graphhopper.routing.ev.EncodedValueLookup;
+import com.graphhopper.routing.util.parsers.FootAccessParser;
+import com.graphhopper.util.PMap;
+import org.apache.commons.lang3.tuple.Pair;
+
+import static com.graphhopper.customspeeds.CustomSpeedsUtils.validateCustomSpeedDirection;
+
+public class ReplicaCustomSpeedsFootAccessParser extends FootAccessParser {
+    private final ImmutableMap<Pair<Long, Boolean>, Double> osmWayIdAndBwdToMaxSpeed;
+    private final boolean bwdColumnPresent;
+
+    public ReplicaCustomSpeedsFootAccessParser(EncodedValueLookup lookup, PMap properties, ImmutableMap<Pair<Long, Boolean>, Double> osmWayIdAndBwdToMaxSpeed, boolean bwdColumnPresent) {
+        super(lookup, properties);
+        this.osmWayIdAndBwdToMaxSpeed = osmWayIdAndBwdToMaxSpeed;
+        this.bwdColumnPresent = bwdColumnPresent;
+    }
+
+    @Override
+    public void handleWayTags(int edgeId, EdgeIntAccess edgeIntAccess, ReaderWay way) {
+        super.handleWayTags(edgeId, edgeIntAccess, way);
+        validateCustomSpeedDirection(osmWayIdAndBwdToMaxSpeed, bwdColumnPresent, way.getId(), accessEnc, edgeId, edgeIntAccess);
+    }
+}

--- a/web-bundle/src/main/java/com/graphhopper/replica/ReplicaCustomSpeedsFootTagParser.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/ReplicaCustomSpeedsFootTagParser.java
@@ -7,9 +7,10 @@ import com.graphhopper.routing.ev.EdgeIntAccess;
 import com.graphhopper.routing.ev.EncodedValueLookup;
 import com.graphhopper.routing.util.parsers.FootAverageSpeedParser;
 import com.graphhopper.util.PMap;
+import org.apache.commons.lang3.tuple.Pair;
 
 public class ReplicaCustomSpeedsFootTagParser extends FootAverageSpeedParser {
-    private final ImmutableMap<Long, Double> osmWayIdToMaxSpeed;
+    private final ImmutableMap<Pair<Long, Boolean>, Double> osmWayIdAndBwdToMaxSpeed;
 
     // Replica-specific limit for custom walking speeds
     public static final int FOOT_MAX_SPEED = 10;
@@ -18,9 +19,9 @@ public class ReplicaCustomSpeedsFootTagParser extends FootAverageSpeedParser {
     static final int SLOW_SPEED = 2;
     static final int MEAN_SPEED = 5;
 
-    public ReplicaCustomSpeedsFootTagParser(EncodedValueLookup lookup, PMap configuration, ImmutableMap<Long, Double> osmWayIdToMaxSpeed) {
+    public ReplicaCustomSpeedsFootTagParser(EncodedValueLookup lookup, PMap configuration, ImmutableMap<Pair<Long, Boolean>, Double> osmWayIdAndBwdToMaxSpeed) {
         super(lookup, configuration);
-        this.osmWayIdToMaxSpeed = osmWayIdToMaxSpeed;
+        this.osmWayIdAndBwdToMaxSpeed = osmWayIdAndBwdToMaxSpeed;
     }
 
     // Copied directly from FootAverageSpeedParser, edited to call edited setSpeed() function
@@ -46,7 +47,7 @@ public class ReplicaCustomSpeedsFootTagParser extends FootAverageSpeedParser {
 
     // Overrides speed with custom speed, if one exists
     void setSpeed(int edgeId, EdgeIntAccess edgeIntAccess, boolean fwd, boolean bwd, double speed, ReaderWay way) {
-         double speedToSet = CustomSpeedsUtils.getCustomMaxSpeed(way, osmWayIdToMaxSpeed).orElse(speed);
+         double speedToSet = CustomSpeedsUtils.getCustomMaxSpeed(way, osmWayIdAndBwdToMaxSpeed, bwd).orElse(speed);
          setSpeed(edgeId, edgeIntAccess, fwd, bwd, speedToSet);
     }
 

--- a/web-bundle/src/main/java/com/graphhopper/replica/ReplicaCustomSpeedsTruckAccessParser.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/ReplicaCustomSpeedsTruckAccessParser.java
@@ -12,17 +12,17 @@ import static com.graphhopper.customspeeds.CustomSpeedsUtils.validateCustomSpeed
 
 public class ReplicaCustomSpeedsTruckAccessParser extends TruckAccessParser {
     private final ImmutableMap<Pair<Long, Boolean>, Double> osmWayIdAndBwdToMaxSpeed;
-    private final boolean bwdColumnPresent;
+    private final boolean directionalCustomSpeedsProvided;
 
-    public ReplicaCustomSpeedsTruckAccessParser(EncodedValueLookup lookup, PMap properties, ImmutableMap<Pair<Long, Boolean>, Double> osmWayIdAndBwdToMaxSpeed, boolean bwdColumnPresent) {
+    public ReplicaCustomSpeedsTruckAccessParser(EncodedValueLookup lookup, PMap properties, ImmutableMap<Pair<Long, Boolean>, Double> osmWayIdAndBwdToMaxSpeed, boolean directionalCustomSpeedsProvided) {
         super(lookup, properties);
         this.osmWayIdAndBwdToMaxSpeed = osmWayIdAndBwdToMaxSpeed;
-        this.bwdColumnPresent = bwdColumnPresent;
+        this.directionalCustomSpeedsProvided = directionalCustomSpeedsProvided;
     }
 
     @Override
     public void handleWayTags(int edgeId, EdgeIntAccess edgeIntAccess, ReaderWay way) {
         super.handleWayTags(edgeId, edgeIntAccess, way);
-        validateCustomSpeedDirection(osmWayIdAndBwdToMaxSpeed, bwdColumnPresent, way.getId(), accessEnc, edgeId, edgeIntAccess);
+        validateCustomSpeedDirection(osmWayIdAndBwdToMaxSpeed, directionalCustomSpeedsProvided, way.getId(), accessEnc, edgeId, edgeIntAccess);
     }
 }

--- a/web-bundle/src/main/java/com/graphhopper/replica/ReplicaCustomSpeedsTruckAccessParser.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/ReplicaCustomSpeedsTruckAccessParser.java
@@ -1,0 +1,28 @@
+package com.graphhopper.replica;
+
+import com.google.common.collect.ImmutableMap;
+import com.graphhopper.http.TruckAccessParser;
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.EdgeIntAccess;
+import com.graphhopper.routing.ev.EncodedValueLookup;
+import com.graphhopper.util.PMap;
+import org.apache.commons.lang3.tuple.Pair;
+
+import static com.graphhopper.customspeeds.CustomSpeedsUtils.validateCustomSpeedDirection;
+
+public class ReplicaCustomSpeedsTruckAccessParser extends TruckAccessParser {
+    private final ImmutableMap<Pair<Long, Boolean>, Double> osmWayIdAndBwdToMaxSpeed;
+    private final boolean bwdColumnPresent;
+
+    public ReplicaCustomSpeedsTruckAccessParser(EncodedValueLookup lookup, PMap properties, ImmutableMap<Pair<Long, Boolean>, Double> osmWayIdAndBwdToMaxSpeed, boolean bwdColumnPresent) {
+        super(lookup, properties);
+        this.osmWayIdAndBwdToMaxSpeed = osmWayIdAndBwdToMaxSpeed;
+        this.bwdColumnPresent = bwdColumnPresent;
+    }
+
+    @Override
+    public void handleWayTags(int edgeId, EdgeIntAccess edgeIntAccess, ReaderWay way) {
+        super.handleWayTags(edgeId, edgeIntAccess, way);
+        validateCustomSpeedDirection(osmWayIdAndBwdToMaxSpeed, bwdColumnPresent, way.getId(), accessEnc, edgeId, edgeIntAccess);
+    }
+}

--- a/web-bundle/src/main/java/com/graphhopper/replica/ReplicaVehicleTagParserFactory.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/ReplicaVehicleTagParserFactory.java
@@ -21,7 +21,6 @@ package com.graphhopper.replica;
 import com.google.common.collect.ImmutableMap;
 import com.graphhopper.RouterConstants;
 import com.graphhopper.customspeeds.CustomSpeedsVehicle;
-import com.graphhopper.http.TruckAccessParser;
 import com.graphhopper.http.TruckAverageSpeedParser;
 import com.graphhopper.reader.osm.conditional.DateRangeParser;
 import com.graphhopper.routing.ev.EncodedValueLookup;
@@ -50,11 +49,13 @@ public class ReplicaVehicleTagParserFactory extends DefaultVehicleTagParserFacto
         // assume no custom speeds by default
         ImmutableMap<Pair<Long, Boolean>, Double> osmWayIdAndBwdToCustomSpeed = ImmutableMap.of();
         CustomSpeedsVehicle.VehicleType baseCustomSpeedsVehicleType = null;
+        boolean bwdColumnPresent = false;
 
         if (customSpeedsVehiclesByName.containsKey(vehicleName)) {
             CustomSpeedsVehicle customSpeedsVehicle = customSpeedsVehiclesByName.get(vehicleName);
             osmWayIdAndBwdToCustomSpeed = customSpeedsVehicle.osmWayIdAndBwdToCustomSpeed;
             baseCustomSpeedsVehicleType = customSpeedsVehicle.baseVehicleType;
+            bwdColumnPresent = customSpeedsVehicle.bwdColumnPresent;
             // vehicles with custom speeds use nonstandard vehicle names which must be added to the config for the GH
             // internals to tolerate it
             configuration.putObject("name", vehicleName);
@@ -62,19 +63,19 @@ public class ReplicaVehicleTagParserFactory extends DefaultVehicleTagParserFacto
 
         if (baseCustomSpeedsVehicleType == CustomSpeedsVehicle.VehicleType.CAR) {
             return new VehicleTagParsers(
-                    new CarAccessParser(lookup, configuration).init(configuration.getObject("date_range_parser", new DateRangeParser())),
+                    new ReplicaCustomSpeedsCarAccessParser(lookup, configuration, osmWayIdAndBwdToCustomSpeed, bwdColumnPresent).init(configuration.getObject("date_range_parser", new DateRangeParser())),
                     new ReplicaCustomSpeedsCarTagParser(lookup, configuration, osmWayIdAndBwdToCustomSpeed),
                     null
             );
         } else if (baseCustomSpeedsVehicleType == CustomSpeedsVehicle.VehicleType.BIKE) {
             return new VehicleTagParsers(
-                    new BikeAccessParser(lookup, configuration).init(configuration.getObject("date_range_parser", new DateRangeParser())),
+                    new ReplicaCustomSpeedsBikeAccessParser(lookup, configuration, osmWayIdAndBwdToCustomSpeed, bwdColumnPresent).init(configuration.getObject("date_range_parser", new DateRangeParser())),
                     new ReplicaCustomSpeedsBikeTagParser(lookup, configuration, osmWayIdAndBwdToCustomSpeed),
                     new BikePriorityParser(lookup, configuration)
             );
         } else if (baseCustomSpeedsVehicleType == CustomSpeedsVehicle.VehicleType.FOOT) {
             return new VehicleTagParsers(
-                    new FootAccessParser(lookup, configuration).init(configuration.getObject("date_range_parser", new DateRangeParser())),
+                    new ReplicaCustomSpeedsFootAccessParser(lookup, configuration, osmWayIdAndBwdToCustomSpeed, bwdColumnPresent).init(configuration.getObject("date_range_parser", new DateRangeParser())),
                     new ReplicaCustomSpeedsFootTagParser(lookup, configuration, osmWayIdAndBwdToCustomSpeed),
                     new FootPriorityParser(lookup, configuration)
             );
@@ -90,7 +91,7 @@ public class ReplicaVehicleTagParserFactory extends DefaultVehicleTagParserFacto
             if (!configuration.has("max_speed"))
                 configuration = new PMap(configuration).putObject("max_speed", EE_TRUCK_MAX_SPEED);
             return new VehicleTagParsers(
-                    new TruckAccessParser(lookup, configuration).
+                    new ReplicaCustomSpeedsTruckAccessParser(lookup, configuration, osmWayIdAndBwdToCustomSpeed, bwdColumnPresent).
                             setHeight(3.7).setWidth(2.6, 0.34).setLength(12).
                             setWeight(13.0 + 13.0).setAxes(3).setIsHGV(true).
                             initProperties().
@@ -107,7 +108,7 @@ public class ReplicaVehicleTagParserFactory extends DefaultVehicleTagParserFacto
             if (!configuration.has("max_speed"))
                 configuration = new PMap(configuration).putObject("max_speed", EE_SMALL_TRUCK_MAX_SPEED);
             return new VehicleTagParsers(
-                    new TruckAccessParser(lookup, configuration).
+                    new ReplicaCustomSpeedsTruckAccessParser(lookup, configuration, osmWayIdAndBwdToCustomSpeed, bwdColumnPresent).
                             setHeight(2.7).setWidth(2, 0.34).setLength(5.5).
                             setWeight(SMALL_TRUCK_WEIGHT).
                             initProperties().

--- a/web-bundle/src/main/java/com/graphhopper/replica/ReplicaVehicleTagParserFactory.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/ReplicaVehicleTagParserFactory.java
@@ -49,13 +49,13 @@ public class ReplicaVehicleTagParserFactory extends DefaultVehicleTagParserFacto
         // assume no custom speeds by default
         ImmutableMap<Pair<Long, Boolean>, Double> osmWayIdAndBwdToCustomSpeed = ImmutableMap.of();
         CustomSpeedsVehicle.VehicleType baseCustomSpeedsVehicleType = null;
-        boolean bwdColumnPresent = false;
+        boolean directionalCustomSpeedsProvided = false;
 
         if (customSpeedsVehiclesByName.containsKey(vehicleName)) {
             CustomSpeedsVehicle customSpeedsVehicle = customSpeedsVehiclesByName.get(vehicleName);
             osmWayIdAndBwdToCustomSpeed = customSpeedsVehicle.osmWayIdAndBwdToCustomSpeed;
             baseCustomSpeedsVehicleType = customSpeedsVehicle.baseVehicleType;
-            bwdColumnPresent = customSpeedsVehicle.bwdColumnPresent;
+            directionalCustomSpeedsProvided = customSpeedsVehicle.directionalCustomSpeedsProvided;
             // vehicles with custom speeds use nonstandard vehicle names which must be added to the config for the GH
             // internals to tolerate it
             configuration.putObject("name", vehicleName);
@@ -63,19 +63,19 @@ public class ReplicaVehicleTagParserFactory extends DefaultVehicleTagParserFacto
 
         if (baseCustomSpeedsVehicleType == CustomSpeedsVehicle.VehicleType.CAR) {
             return new VehicleTagParsers(
-                    new ReplicaCustomSpeedsCarAccessParser(lookup, configuration, osmWayIdAndBwdToCustomSpeed, bwdColumnPresent).init(configuration.getObject("date_range_parser", new DateRangeParser())),
+                    new ReplicaCustomSpeedsCarAccessParser(lookup, configuration, osmWayIdAndBwdToCustomSpeed, directionalCustomSpeedsProvided).init(configuration.getObject("date_range_parser", new DateRangeParser())),
                     new ReplicaCustomSpeedsCarTagParser(lookup, configuration, osmWayIdAndBwdToCustomSpeed),
                     null
             );
         } else if (baseCustomSpeedsVehicleType == CustomSpeedsVehicle.VehicleType.BIKE) {
             return new VehicleTagParsers(
-                    new ReplicaCustomSpeedsBikeAccessParser(lookup, configuration, osmWayIdAndBwdToCustomSpeed, bwdColumnPresent).init(configuration.getObject("date_range_parser", new DateRangeParser())),
+                    new ReplicaCustomSpeedsBikeAccessParser(lookup, configuration, osmWayIdAndBwdToCustomSpeed, directionalCustomSpeedsProvided).init(configuration.getObject("date_range_parser", new DateRangeParser())),
                     new ReplicaCustomSpeedsBikeTagParser(lookup, configuration, osmWayIdAndBwdToCustomSpeed),
                     new BikePriorityParser(lookup, configuration)
             );
         } else if (baseCustomSpeedsVehicleType == CustomSpeedsVehicle.VehicleType.FOOT) {
             return new VehicleTagParsers(
-                    new ReplicaCustomSpeedsFootAccessParser(lookup, configuration, osmWayIdAndBwdToCustomSpeed, bwdColumnPresent).init(configuration.getObject("date_range_parser", new DateRangeParser())),
+                    new ReplicaCustomSpeedsFootAccessParser(lookup, configuration, osmWayIdAndBwdToCustomSpeed, directionalCustomSpeedsProvided).init(configuration.getObject("date_range_parser", new DateRangeParser())),
                     new ReplicaCustomSpeedsFootTagParser(lookup, configuration, osmWayIdAndBwdToCustomSpeed),
                     new FootPriorityParser(lookup, configuration)
             );
@@ -91,7 +91,7 @@ public class ReplicaVehicleTagParserFactory extends DefaultVehicleTagParserFacto
             if (!configuration.has("max_speed"))
                 configuration = new PMap(configuration).putObject("max_speed", EE_TRUCK_MAX_SPEED);
             return new VehicleTagParsers(
-                    new ReplicaCustomSpeedsTruckAccessParser(lookup, configuration, osmWayIdAndBwdToCustomSpeed, bwdColumnPresent).
+                    new ReplicaCustomSpeedsTruckAccessParser(lookup, configuration, osmWayIdAndBwdToCustomSpeed, directionalCustomSpeedsProvided).
                             setHeight(3.7).setWidth(2.6, 0.34).setLength(12).
                             setWeight(13.0 + 13.0).setAxes(3).setIsHGV(true).
                             initProperties().
@@ -108,7 +108,7 @@ public class ReplicaVehicleTagParserFactory extends DefaultVehicleTagParserFacto
             if (!configuration.has("max_speed"))
                 configuration = new PMap(configuration).putObject("max_speed", EE_SMALL_TRUCK_MAX_SPEED);
             return new VehicleTagParsers(
-                    new ReplicaCustomSpeedsTruckAccessParser(lookup, configuration, osmWayIdAndBwdToCustomSpeed, bwdColumnPresent).
+                    new ReplicaCustomSpeedsTruckAccessParser(lookup, configuration, osmWayIdAndBwdToCustomSpeed, directionalCustomSpeedsProvided).
                             setHeight(2.7).setWidth(2, 0.34).setLength(5.5).
                             setWeight(SMALL_TRUCK_WEIGHT).
                             initProperties().

--- a/web-bundle/src/main/java/com/graphhopper/replica/ReplicaVehicleTagParserFactory.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/ReplicaVehicleTagParserFactory.java
@@ -29,6 +29,7 @@ import com.graphhopper.routing.util.DefaultVehicleTagParserFactory;
 import com.graphhopper.routing.util.VehicleTagParsers;
 import com.graphhopper.routing.util.parsers.*;
 import com.graphhopper.util.PMap;
+import org.apache.commons.lang3.tuple.Pair;
 
 import static com.graphhopper.http.TruckAverageSpeedParser.*;
 
@@ -47,12 +48,12 @@ public class ReplicaVehicleTagParserFactory extends DefaultVehicleTagParserFacto
     @Override
     public VehicleTagParsers createParsers(EncodedValueLookup lookup, String vehicleName, PMap configuration) {
         // assume no custom speeds by default
-        ImmutableMap<Long, Double> osmWayIdToCustomSpeed = ImmutableMap.of();
+        ImmutableMap<Pair<Long, Boolean>, Double> osmWayIdAndBwdToCustomSpeed = ImmutableMap.of();
         CustomSpeedsVehicle.VehicleType baseCustomSpeedsVehicleType = null;
 
         if (customSpeedsVehiclesByName.containsKey(vehicleName)) {
             CustomSpeedsVehicle customSpeedsVehicle = customSpeedsVehiclesByName.get(vehicleName);
-            osmWayIdToCustomSpeed = customSpeedsVehicle.osmWayIdToCustomSpeed;
+            osmWayIdAndBwdToCustomSpeed = customSpeedsVehicle.osmWayIdAndBwdToCustomSpeed;
             baseCustomSpeedsVehicleType = customSpeedsVehicle.baseVehicleType;
             // vehicles with custom speeds use nonstandard vehicle names which must be added to the config for the GH
             // internals to tolerate it
@@ -62,19 +63,19 @@ public class ReplicaVehicleTagParserFactory extends DefaultVehicleTagParserFacto
         if (baseCustomSpeedsVehicleType == CustomSpeedsVehicle.VehicleType.CAR) {
             return new VehicleTagParsers(
                     new CarAccessParser(lookup, configuration).init(configuration.getObject("date_range_parser", new DateRangeParser())),
-                    new ReplicaCustomSpeedsCarTagParser(lookup, configuration, osmWayIdToCustomSpeed),
+                    new ReplicaCustomSpeedsCarTagParser(lookup, configuration, osmWayIdAndBwdToCustomSpeed),
                     null
             );
         } else if (baseCustomSpeedsVehicleType == CustomSpeedsVehicle.VehicleType.BIKE) {
             return new VehicleTagParsers(
                     new BikeAccessParser(lookup, configuration).init(configuration.getObject("date_range_parser", new DateRangeParser())),
-                    new ReplicaCustomSpeedsBikeTagParser(lookup, configuration, osmWayIdToCustomSpeed),
+                    new ReplicaCustomSpeedsBikeTagParser(lookup, configuration, osmWayIdAndBwdToCustomSpeed),
                     new BikePriorityParser(lookup, configuration)
             );
         } else if (baseCustomSpeedsVehicleType == CustomSpeedsVehicle.VehicleType.FOOT) {
             return new VehicleTagParsers(
                     new FootAccessParser(lookup, configuration).init(configuration.getObject("date_range_parser", new DateRangeParser())),
-                    new ReplicaCustomSpeedsFootTagParser(lookup, configuration, osmWayIdToCustomSpeed),
+                    new ReplicaCustomSpeedsFootTagParser(lookup, configuration, osmWayIdAndBwdToCustomSpeed),
                     new FootPriorityParser(lookup, configuration)
             );
         } else if (vehicleName.equals(RouterConstants.CAR_VEHICLE_NAME)
@@ -94,7 +95,7 @@ public class ReplicaVehicleTagParserFactory extends DefaultVehicleTagParserFacto
                             setWeight(13.0 + 13.0).setAxes(3).setIsHGV(true).
                             initProperties().
                             init(configuration.getObject("date_range_parser", new DateRangeParser())),
-                    new TruckAverageSpeedParser(lookup, configuration, osmWayIdToCustomSpeed).
+                    new TruckAverageSpeedParser(lookup, configuration, osmWayIdAndBwdToCustomSpeed).
                             setHeight(3.7).setWidth(2.6, 0.34).setLength(12).
                             setWeight(13.0 + 13.0).setAxes(3).setIsHGV(true).
                             initProperties(),
@@ -111,7 +112,7 @@ public class ReplicaVehicleTagParserFactory extends DefaultVehicleTagParserFacto
                             setWeight(SMALL_TRUCK_WEIGHT).
                             initProperties().
                             init(configuration.getObject("date_range_parser", new DateRangeParser())),
-                    new TruckAverageSpeedParser(lookup, configuration, osmWayIdToCustomSpeed).
+                    new TruckAverageSpeedParser(lookup, configuration, osmWayIdAndBwdToCustomSpeed).
                             setHeight(2.7).setWidth(2, 0.34).setLength(5.5).
                             setWeight(SMALL_TRUCK_WEIGHT)
                             .initProperties(),

--- a/web-bundle/src/main/java/com/graphhopper/replica/StreetEdgeExporter.java
+++ b/web-bundle/src/main/java/com/graphhopper/replica/StreetEdgeExporter.java
@@ -28,7 +28,9 @@ public class StreetEdgeExporter {
     private static final Map<String, String> ACCESSIBILITY_MODE_MAP = Map.of(
             "car", "CAR",
             "bike", "BIKE",
-            "foot", "PEDESTRIAN"
+            "foot", "PEDESTRIAN",
+            "truck", "TRUCK",
+            "small_truck", "SMALL_TRUCK"
     );
     private static final List<String> HIGHWAY_FILTER_TAGS = Lists.newArrayList("bridleway", "steps");
     private static final List<String> INACCESSIBLE_MOTORWAY_TAGS = Lists.newArrayList("motorway", "motorway_link");

--- a/web-bundle/src/test/java/com/graphhopper/customspeeds/CustomSpeedsUtilsTest.java
+++ b/web-bundle/src/test/java/com/graphhopper/customspeeds/CustomSpeedsUtilsTest.java
@@ -14,10 +14,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 
 public class CustomSpeedsUtilsTest {
-    private static final ImmutableMap<Pair<Long, Boolean>, Double> TEST_CUSTOM_SPEEDS = ImmutableMap.of(Pair.of(1L, Boolean.TRUE), 2.0, Pair.of(3L, Boolean.FALSE), 4.0, Pair.of(123L, Boolean.TRUE), 45.6789);
-    private static final ImmutableMap<Pair<Long, Boolean>, Double> TEST_CUSTOM_SPEEDS_NO_BWD_COLUMN = ImmutableMap.of(Pair.of(10485465L, Boolean.TRUE), 90.0, Pair.of(10485465L, Boolean.FALSE), 90.0);
-    private static final ImmutableMap<Pair<Long, Boolean>, Double> FAST_THRUTON_DRIVE_SPEEDS = ImmutableMap.of(Pair.of(10485465L, Boolean.FALSE), 90.0, Pair.of(10485465L, Boolean.TRUE), 90.0);
-    private static final ImmutableMap<Pair<Long, Boolean>, Double> BASELINE_ROAD_CLOSURE_SPEEDS = ImmutableMap.of(Pair.of(76254223L, Boolean.FALSE), 0.0, Pair.of(76254223L, Boolean.TRUE), 0.0);
+    private static final Pair<ImmutableMap<Pair<Long, Boolean>, Double>, Boolean> TEST_CUSTOM_SPEEDS = Pair.of(ImmutableMap.of(Pair.of(1L, Boolean.TRUE), 2.0, Pair.of(3L, Boolean.FALSE), 4.0, Pair.of(123L, Boolean.TRUE), 45.6789), true);
+    private static final Pair<ImmutableMap<Pair<Long, Boolean>, Double>, Boolean> TEST_CUSTOM_SPEEDS_NO_BWD_COLUMN = Pair.of(ImmutableMap.of(Pair.of(10485465L, Boolean.TRUE), 90.0, Pair.of(10485465L, Boolean.FALSE), 90.0), false);
+    private static final Pair<ImmutableMap<Pair<Long, Boolean>, Double>, Boolean> FAST_THRUTON_DRIVE_SPEEDS = Pair.of(ImmutableMap.of(Pair.of(10485465L, Boolean.FALSE), 90.0, Pair.of(10485465L, Boolean.TRUE), 90.0), true);
+    private static final Pair<ImmutableMap<Pair<Long, Boolean>, Double>, Boolean> BASELINE_ROAD_CLOSURE_SPEEDS = Pair.of(ImmutableMap.of(Pair.of(76254223L, Boolean.FALSE), 0.0, Pair.of(76254223L, Boolean.TRUE), 0.0), false);
 
     @Test
     public void testGetCustomSpeedVehiclesByName() {

--- a/web-bundle/src/test/java/com/graphhopper/customspeeds/CustomSpeedsUtilsTest.java
+++ b/web-bundle/src/test/java/com/graphhopper/customspeeds/CustomSpeedsUtilsTest.java
@@ -3,6 +3,7 @@ package com.graphhopper.customspeeds;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.graphhopper.config.Profile;
+import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
@@ -13,9 +14,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 
 public class CustomSpeedsUtilsTest {
-    private static final ImmutableMap<Long, Double> TEST_CUSTOM_SPEEDS = ImmutableMap.of(1L, 2.0, 3L, 4.0, 123L, 45.6789);
-    private static final ImmutableMap<Long, Double> FAST_THRUTON_DRIVE_SPEEDS = ImmutableMap.of(10485465L, 90.0);
-    private static final ImmutableMap<Long, Double> BASELINE_ROAD_CLOSURE_SPEEDS = ImmutableMap.of(76254223L, 0.0);
+    private static final ImmutableMap<Pair<Long, Boolean>, Double> TEST_CUSTOM_SPEEDS = ImmutableMap.of(Pair.of(1L, Boolean.TRUE), 2.0, Pair.of(3L, Boolean.FALSE), 4.0, Pair.of(123L, Boolean.TRUE), 45.6789);
+    private static final ImmutableMap<Pair<Long, Boolean>, Double> TEST_CUSTOM_SPEEDS_NO_BWD_COLUMN = ImmutableMap.of(Pair.of(10485465L, Boolean.TRUE), 90.0, Pair.of(10485465L, Boolean.FALSE), 90.0);
+    private static final ImmutableMap<Pair<Long, Boolean>, Double> FAST_THRUTON_DRIVE_SPEEDS = ImmutableMap.of(Pair.of(10485465L, Boolean.FALSE), 90.0);
+    private static final ImmutableMap<Pair<Long, Boolean>, Double> BASELINE_ROAD_CLOSURE_SPEEDS = ImmutableMap.of(Pair.of(76254223L, Boolean.FALSE), 0.0);
 
     @Test
     public void testGetCustomSpeedVehiclesByName() {
@@ -23,16 +25,18 @@ public class CustomSpeedsUtilsTest {
                 createProfile("prof1", "car", null),
                 createProfile("prof2", "car_custom", "../web/test-data/custom_speeds/test_custom_speeds.csv"),
                 createProfile("prof3", "car_custom_2", "../web/test-data/custom_speeds/custom_fast_thurton_drive_speed.csv"),
-                createProfile("prof4", "truck", "../web/test-data/custom_speeds/custom_fast_thurton_drive_speed.csv"),
-                createProfile("prof5", "small_truck", "../web/test-data/custom_speeds/test_custom_speeds.csv"),
-                createProfile("prof6", "foot", "../web/test-data/custom_speeds/baseline_road_zero_speed.csv"),
-                createProfile("prof7", "bike", "../web/test-data/custom_speeds/baseline_road_zero_speed.csv")
+                createProfile("prof4", "car_custom_3", "../web/test-data/custom_speeds/test_custom_speeds_no_bwd_column.csv"),
+                createProfile("prof5", "truck", "../web/test-data/custom_speeds/custom_fast_thurton_drive_speed.csv"),
+                createProfile("prof6", "small_truck", "../web/test-data/custom_speeds/test_custom_speeds.csv"),
+                createProfile("prof7", "foot", "../web/test-data/custom_speeds/baseline_road_zero_speed.csv"),
+                createProfile("prof8", "bike", "../web/test-data/custom_speeds/baseline_road_zero_speed.csv")
         );
         ImmutableMap<String, CustomSpeedsVehicle> customSpeedVehiclesByName =
                 CustomSpeedsUtils.getCustomSpeedVehiclesByName(profiles);
         ImmutableMap<String, CustomSpeedsVehicle> expectedCustomSpeedVehiclesByName = ImmutableMap.of(
                 "car_custom", CustomSpeedsVehicle.create("car_custom", TEST_CUSTOM_SPEEDS),
                 "car_custom_2", CustomSpeedsVehicle.create("car_custom_2", FAST_THRUTON_DRIVE_SPEEDS),
+                "car_custom_3", CustomSpeedsVehicle.create("car_custom_3", TEST_CUSTOM_SPEEDS_NO_BWD_COLUMN),
                 "truck", CustomSpeedsVehicle.create("truck", FAST_THRUTON_DRIVE_SPEEDS),
                 "small_truck", CustomSpeedsVehicle.create("small_truck", TEST_CUSTOM_SPEEDS),
                 "foot", CustomSpeedsVehicle.create("foot", BASELINE_ROAD_CLOSURE_SPEEDS),

--- a/web-bundle/src/test/java/com/graphhopper/customspeeds/CustomSpeedsUtilsTest.java
+++ b/web-bundle/src/test/java/com/graphhopper/customspeeds/CustomSpeedsUtilsTest.java
@@ -14,10 +14,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 
 public class CustomSpeedsUtilsTest {
-    private static final Pair<ImmutableMap<Pair<Long, Boolean>, Double>, Boolean> TEST_CUSTOM_SPEEDS = Pair.of(ImmutableMap.of(Pair.of(1L, Boolean.TRUE), 2.0, Pair.of(3L, Boolean.FALSE), 4.0, Pair.of(123L, Boolean.TRUE), 45.6789), true);
-    private static final Pair<ImmutableMap<Pair<Long, Boolean>, Double>, Boolean> TEST_CUSTOM_SPEEDS_NO_BWD_COLUMN = Pair.of(ImmutableMap.of(Pair.of(10485465L, Boolean.TRUE), 90.0, Pair.of(10485465L, Boolean.FALSE), 90.0), false);
-    private static final Pair<ImmutableMap<Pair<Long, Boolean>, Double>, Boolean> FAST_THRUTON_DRIVE_SPEEDS = Pair.of(ImmutableMap.of(Pair.of(10485465L, Boolean.FALSE), 90.0, Pair.of(10485465L, Boolean.TRUE), 90.0), true);
-    private static final Pair<ImmutableMap<Pair<Long, Boolean>, Double>, Boolean> BASELINE_ROAD_CLOSURE_SPEEDS = Pair.of(ImmutableMap.of(Pair.of(76254223L, Boolean.FALSE), 0.0, Pair.of(76254223L, Boolean.TRUE), 0.0), false);
+    private static final Pair<ImmutableMap<Pair<Long, Boolean>, Double>, Boolean> TEST_CUSTOM_SPEEDS = Pair.of(ImmutableMap.of(Pair.of(1L, Boolean.TRUE), 2.0, Pair.of(3L, Boolean.FALSE), 4.0, Pair.of(123L, Boolean.TRUE), 45.6789), Boolean.TRUE);
+    private static final Pair<ImmutableMap<Pair<Long, Boolean>, Double>, Boolean> TEST_CUSTOM_SPEEDS_NO_BWD_COLUMN = Pair.of(ImmutableMap.of(Pair.of(10485465L, Boolean.TRUE), 90.0, Pair.of(10485465L, Boolean.FALSE), 90.0), Boolean.FALSE);
+    private static final Pair<ImmutableMap<Pair<Long, Boolean>, Double>, Boolean> FAST_THRUTON_DRIVE_SPEEDS = Pair.of(ImmutableMap.of(Pair.of(10485465L, Boolean.FALSE), 90.0, Pair.of(10485465L, Boolean.TRUE), 90.0), Boolean.TRUE);
+    private static final Pair<ImmutableMap<Pair<Long, Boolean>, Double>, Boolean> BASELINE_ROAD_CLOSURE_SPEEDS = Pair.of(ImmutableMap.of(Pair.of(76254223L, Boolean.FALSE), 0.0, Pair.of(76254223L, Boolean.TRUE), 0.0), Boolean.TRUE);
 
     @Test
     public void testGetCustomSpeedVehiclesByName() {

--- a/web-bundle/src/test/java/com/graphhopper/customspeeds/CustomSpeedsUtilsTest.java
+++ b/web-bundle/src/test/java/com/graphhopper/customspeeds/CustomSpeedsUtilsTest.java
@@ -16,8 +16,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class CustomSpeedsUtilsTest {
     private static final ImmutableMap<Pair<Long, Boolean>, Double> TEST_CUSTOM_SPEEDS = ImmutableMap.of(Pair.of(1L, Boolean.TRUE), 2.0, Pair.of(3L, Boolean.FALSE), 4.0, Pair.of(123L, Boolean.TRUE), 45.6789);
     private static final ImmutableMap<Pair<Long, Boolean>, Double> TEST_CUSTOM_SPEEDS_NO_BWD_COLUMN = ImmutableMap.of(Pair.of(10485465L, Boolean.TRUE), 90.0, Pair.of(10485465L, Boolean.FALSE), 90.0);
-    private static final ImmutableMap<Pair<Long, Boolean>, Double> FAST_THRUTON_DRIVE_SPEEDS = ImmutableMap.of(Pair.of(10485465L, Boolean.FALSE), 90.0);
-    private static final ImmutableMap<Pair<Long, Boolean>, Double> BASELINE_ROAD_CLOSURE_SPEEDS = ImmutableMap.of(Pair.of(76254223L, Boolean.FALSE), 0.0);
+    private static final ImmutableMap<Pair<Long, Boolean>, Double> FAST_THRUTON_DRIVE_SPEEDS = ImmutableMap.of(Pair.of(10485465L, Boolean.FALSE), 90.0, Pair.of(10485465L, Boolean.TRUE), 90.0);
+    private static final ImmutableMap<Pair<Long, Boolean>, Double> BASELINE_ROAD_CLOSURE_SPEEDS = ImmutableMap.of(Pair.of(76254223L, Boolean.FALSE), 0.0, Pair.of(76254223L, Boolean.TRUE), 0.0);
 
     @Test
     public void testGetCustomSpeedVehiclesByName() {

--- a/web-bundle/src/test/java/com/graphhopper/customspeeds/CustomSpeedsVehicleTest.java
+++ b/web-bundle/src/test/java/com/graphhopper/customspeeds/CustomSpeedsVehicleTest.java
@@ -30,6 +30,6 @@ public class CustomSpeedsVehicleTest {
         assertTrue(CustomSpeedsVehicle.validateCustomSpeeds("car_valid", validCarCustomSpeeds));
 
         // creating a CustomSpeedsVehicle with invalid speeds should be disallowed
-        assertThrows(IllegalArgumentException.class, () -> CustomSpeedsVehicle.create("car_invalid", invalidCarCustomSpeeds));
+        assertThrows(IllegalArgumentException.class, () -> CustomSpeedsVehicle.create("car_invalid", Pair.of(invalidCarCustomSpeeds, true)));
     }
 }

--- a/web-bundle/src/test/java/com/graphhopper/customspeeds/CustomSpeedsVehicleTest.java
+++ b/web-bundle/src/test/java/com/graphhopper/customspeeds/CustomSpeedsVehicleTest.java
@@ -1,6 +1,7 @@
 package com.graphhopper.customspeeds;
 
 import com.google.common.collect.ImmutableMap;
+import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -9,23 +10,23 @@ public class CustomSpeedsVehicleTest {
 
     @Test
     public void testInvalidSpeeds() {
-        ImmutableMap<Long, Double> invalidCarCustomSpeeds = ImmutableMap.of(1L, 200.0, 2L, 2.0);
+        ImmutableMap<Pair<Long, Boolean>, Double> invalidCarCustomSpeeds = ImmutableMap.of(Pair.of(1L, Boolean.TRUE), 200.0, Pair.of(2L, Boolean.FALSE), 2.0);
         assertFalse(CustomSpeedsVehicle.validateCustomSpeeds("car_invalid", invalidCarCustomSpeeds));
 
-        ImmutableMap<Long, Double> invalidSmallTruckCustomSpeeds = ImmutableMap.of(1L, 150.0, 2L, -1.0);
+        ImmutableMap<Pair<Long, Boolean>, Double> invalidSmallTruckCustomSpeeds = ImmutableMap.of(Pair.of(1L, Boolean.TRUE), 150.0, Pair.of(2L, Boolean.FALSE), -1.0);
         assertFalse(CustomSpeedsVehicle.validateCustomSpeeds("small_truck_invalid", invalidSmallTruckCustomSpeeds));
 
-        ImmutableMap<Long, Double> invalidTruckCustomSpeeds = ImmutableMap.of(1L, 100.0, 2L, 0.0);
+        ImmutableMap<Pair<Long, Boolean>, Double> invalidTruckCustomSpeeds = ImmutableMap.of(Pair.of(1L, Boolean.TRUE), 100.0, Pair.of(2L, Boolean.FALSE), 0.0);
         assertFalse(CustomSpeedsVehicle.validateCustomSpeeds("truck_invalid", invalidTruckCustomSpeeds));
 
-        ImmutableMap<Long, Double> invalidBikeCustomSpeeds = ImmutableMap.of(1L, 35.0, 2L, 0.0);
+        ImmutableMap<Pair<Long, Boolean>, Double> invalidBikeCustomSpeeds = ImmutableMap.of(Pair.of(1L, Boolean.TRUE), 35.0, Pair.of(2L, Boolean.FALSE), 0.0);
         assertFalse(CustomSpeedsVehicle.validateCustomSpeeds("bike_invalid", invalidBikeCustomSpeeds));
 
-        ImmutableMap<Long, Double> invalidFootCustomSpeeds = ImmutableMap.of(1L, 15.0, 2L, 0.0);
+        ImmutableMap<Pair<Long, Boolean>, Double> invalidFootCustomSpeeds = ImmutableMap.of(Pair.of(1L, Boolean.TRUE), 15.0, Pair.of(2L, Boolean.FALSE), 0.0);
         assertFalse(CustomSpeedsVehicle.validateCustomSpeeds("foot_invalid", invalidFootCustomSpeeds));
 
         // validation should be vehicle-specific. speed is too high for trucks, but valid for cars
-        ImmutableMap<Long, Double> validCarCustomSpeeds = invalidTruckCustomSpeeds;
+        ImmutableMap<Pair<Long, Boolean>, Double> validCarCustomSpeeds = invalidTruckCustomSpeeds;
         assertTrue(CustomSpeedsVehicle.validateCustomSpeeds("car_valid", validCarCustomSpeeds));
 
         // creating a CustomSpeedsVehicle with invalid speeds should be disallowed

--- a/web/test-data/custom_speeds/baseline_road_zero_speed.csv
+++ b/web/test-data/custom_speeds/baseline_road_zero_speed.csv
@@ -1,2 +1,2 @@
-osm_way_id,max_speed_kph
-76254223,0
+osm_way_id,max_speed_kph,bwd
+76254223,0,False

--- a/web/test-data/custom_speeds/baseline_road_zero_speed.csv
+++ b/web/test-data/custom_speeds/baseline_road_zero_speed.csv
@@ -1,2 +1,3 @@
 osm_way_id,max_speed_kph,bwd
 76254223,0,False
+76254223,0,True

--- a/web/test-data/custom_speeds/baseline_road_zero_speed_no_bwd_column.csv
+++ b/web/test-data/custom_speeds/baseline_road_zero_speed_no_bwd_column.csv
@@ -1,0 +1,2 @@
+osm_way_id,max_speed_kph
+76254223,0

--- a/web/test-data/custom_speeds/baseline_road_zero_speed_one_direction.csv
+++ b/web/test-data/custom_speeds/baseline_road_zero_speed_one_direction.csv
@@ -1,0 +1,2 @@
+osm_way_id,max_speed_kph,bwd
+76254223,0,False

--- a/web/test-data/custom_speeds/custom_fast_thurton_drive_speed.csv
+++ b/web/test-data/custom_speeds/custom_fast_thurton_drive_speed.csv
@@ -1,2 +1,3 @@
 osm_way_id,max_speed_kph,bwd
 10485465,90,False
+10485465,90,True

--- a/web/test-data/custom_speeds/custom_fast_thurton_drive_speed.csv
+++ b/web/test-data/custom_speeds/custom_fast_thurton_drive_speed.csv
@@ -1,2 +1,2 @@
-osm_way_id,max_speed_kph
-10485465,90
+osm_way_id,max_speed_kph,bwd
+10485465,90,False

--- a/web/test-data/custom_speeds/test_custom_speeds.csv
+++ b/web/test-data/custom_speeds/test_custom_speeds.csv
@@ -1,4 +1,4 @@
-osm_way_id,max_speed_kph
-1,2
-3,4
-123,45.6789
+osm_way_id,max_speed_kph,bwd
+1,2,True
+3,4,False
+123,45.6789,True

--- a/web/test-data/custom_speeds/test_custom_speeds_empty_bwd_column.csv
+++ b/web/test-data/custom_speeds/test_custom_speeds_empty_bwd_column.csv
@@ -1,0 +1,2 @@
+osm_way_id,max_speed_kph,bwd
+10485465,90

--- a/web/test-data/custom_speeds/test_custom_speeds_no_bwd_column.csv
+++ b/web/test-data/custom_speeds/test_custom_speeds_no_bwd_column.csv
@@ -1,0 +1,2 @@
+osm_way_id,max_speed_kph
+10485465,90


### PR DESCRIPTION
## Background

https://replicahq.atlassian.net/browse/RAD-6267

Updates the router's custom speed processing to optionally allow for directional custom speeds to be declared for OSM Ways. 

The proposed approach allows for custom speed input files (containing mappings from OSM Way ID -> speed) to include a `bwd` column of booleans, that specifies whether or not the speed should be applied in the reverse direction for that OSM Way or not. If no `bwd` column is present, the old behavior is used - the speed is applied for both directions of the OSM Way.

## Details 
This change is implemented by storing a direction along with each (Way ID -> speed) pairing, denoting the direction for which that speed should be applied to the Way. In the case where now `bwd ` column is provided, we simply store directional speeds for both directions of the Way.

The concept of a Way's "direction" is a bit murky; there's no universal OSM tag/definition of which direction of a Way is considered "forward" vs "backward". GraphHopper has solved the direction issue fairly well via its access parser classes, that look at a wide range of mode-specific OSM tags to determine, for each mode, which direction each Way is accessible in. This notion of access is what we use to populate the `flags` column in our street export tables.

Leveraging these^ access parser classes, a validation was added (`validateCustomSpeedDirection()`) that checks that every directional custom speed provided for a (mode, OSM Way) is in a direction that's accessible for that mode on that Way. Note that when directional custom speeds are not provided - ie no `bwd` column is included in the input custom speeds file - this check is not applied.

---

A validation was also added that checks that if the `bwd` column is present in an input custom speed file, a boolean value is provided in that column for every row.

---

One other implication of the need to ensure directional speeds for Ways are declared only in directions where the affected mode(s) are actually accessible on those Ways is that we'll likely want to implement similar checks in scenario inputs processing (and eventually in the Scenario GUI itself). To accomplish this, I think we'll need to create a mapping between (OSM Way ID, mode, direction) -> (boolean representing accessibility) that we can check against to determine the validity of a directional speed change.

This mapping is easy to generate using our existing network link tables, specifically the `flags` column that lists mode-based accessibility for each stable edge ID. The only change I made in this PR related to this is to add `truck` and `small_truck` to the modes we include in the `flags` column, as these are modes that we allow applying custom speeds for.

Note: Creating the mapping I mentioned above from our network link tables makes the assumption that for all network links we create from a given OSM Way, the mode-based accessibility (flags) for those network links are all identical. I _think_ this is the case, as the accessibility comes directly from OSM Way tags as far as I can tell, but we'll need to check this before implementing this validation in inputs processing.

## Testing
Created new unit tests that cover the new validations added and the basic new behavior (both in the new case where directional speeds are provided, and in the old case where no `bwd` column is provided to check for backwards compatibility). 

I also spun up a small test router with a few of the new test profiles I added to `test_gh_config.yaml` to ensure that each case (no `bwd` column provided, `bwd` column provided but only one direction's speed edited, `bwd` provided but both directions' speeds edited) functioned as-expected

## cc
@rregue @rslassman 